### PR TITLE
feat: implement context tags (ADR-006) and delta-first score (ADR-005)

### DIFF
--- a/EPISTEMICS.md
+++ b/EPISTEMICS.md
@@ -1,0 +1,115 @@
+## 1. Die falsche Prämisse — Wann ein hoher Drift-Score besser ist als ein niedriger
+
+Drift setzt implizit voraus: *Kohärenz ist ein Proxy für Qualität*. Die Scoring-Formel belohnt Einheitlichkeit, bestraft Varianz. Aber Kohärenz ist keine hinreichende Bedingung für Richtigkeit — und unter bestimmten Bedingungen ist sie sogar ein Feind des Fortschritts.
+
+**Szenario 1: Architektur-Transition unter Last.**
+Ein Team migriert ein Django-Monolith in eine modulare Service-Architektur. In Phase 2 von 4 existieren zwangsläufig *zwei* Error-Handling-Muster (das alte synchrone und das neue async-basierte), *zwei* Datenzugriffsmuster (ORM-direkt und Repository-Pattern), *zwei* Import-Topologien. PFS, MDS und AVS werden feuern. Der Composite Score steigt. Aber dieser hohe Score *ist* der Beweis, dass die Migration stattfindet. Ein niedriger Score in dieser Phase würde bedeuten: niemand hat angefangen. Der temporäre Kohärenzverlust ist ein notwendiges Artefakt strukturellen Lernens — das System befindet sich in einem Zwischenzustand, der nicht auf den Zielzustand zurückprojiziert werden kann. Wer jetzt den Score senkt, stoppt die Migration.
+
+**Szenario 2: Deliberate Polymorphismus als Designentscheidung.**
+Ein System wie ein Codec-Framework (vgl. httpx's `DeflateDecoder`/`GZipDecoder`) oder ein Plugin-System *muss* strukturell ähnliche, aber nicht identische Implementierungen enthalten. MDS erkennt die Duplikation korrekt — aber die Duplikation *ist* die Architektur. Das gleiche gilt für Strategy-Patterns, Visitor-Implementierungen und explizit gewollte Adapter-Hierarchien. Hier ist der hohe Score ein Zeichen, dass das System *richtig gebaut* ist: die Interface-Konformität erzeugt die strukturelle Ähnlichkeit, die Drift als Anomalie wertet. Der Score bestraft hier das Richtige.
+
+**Das epistemische Problem:** Drift kann zwischen *ungewollter Inkohärenz* (Copy-Paste-Drift) und *gewollter Varianz* (Migration) bzw. *gewollter Ähnlichkeit* (Polymorphismus) nicht unterscheiden, weil beide AST-strukturell identisch aussehen. Der Score misst Entropie, nicht Intention. Das ist kein Bug — es ist eine Grenze des Repräsentationsmodells.
+
+---
+
+## 2. Der blinde Fleck — Konsistente Falschheit
+
+Die gefährlichste Erosion tritt auf, wenn die gesamte Codebase *einheitlich* das Falsche tut. Beispiele:
+
+- Jedes Modul validiert Permissions korrekt — aber gegen das falsche Permission-Modell (RBAC implementiert, ABAC wäre nötig).
+- Alle 18 API-Endpoints verwenden dasselbe Error-Handling-Pattern — aber das Pattern schluckt kritische Fehlerklassen.
+- Der Datenzugriff ist konsistent normalisiert — aber die Normalisierung erzeugt N+1-Query-Explosionen in jedem einzelnen Modul.
+
+Das hypothetische Signal wäre ein **Semantic Misalignment Signal (SMA)**: die Divergenz zwischen *was der Code tut* und *was der Code tun sollte*, gemessen an einer externen Spezifikation oder einem formalen Invariantenmodell.
+
+**Warum es deterministisch nicht implementierbar ist:**
+
+Das Problem ist nicht technisch, sondern ontologisch. Um SMA zu berechnen, bräuchte Drift Zugang zu:
+
+1. **Einer formalen Intention** — was das System tun *soll*. Diese existiert in den meisten Projekten nicht als maschinenlesbare Spezifikation. Sie existiert als implizites Wissen in Köpfen, in Slack-Konversationen, in vergessenen Design-Docs. Kein AST enthält diese Information.
+
+2. **Einer Bewertungsfunktion für semantische Korrektheit** — die nicht *syntaktisch* (Pattern-Match) sondern *semantisch* (Bedeutungsmatch) operiert. Deterministisch geht das nur gegen eine formale Spezifikation (Design-by-Contract, Property-Based Typing, algebraische Effektsysteme). Sobald die Spezifikation informell ist, wird die Bewertung probabilistisch — und damit nicht-deterministisch.
+
+3. **Einem Weltmodell** — um zu wissen, dass "Permission-Check gegen RBAC" falsch ist, muss man wissen, dass das System ABAC braucht. Dieses Wissen liegt außerhalb des Codes.
+
+Ein LLM *kann* hier Heuristiken liefern ("Das sieht aus wie ein RBAC-Pattern in einem Multi-Tenant-System — ist ABAC beabsichtigt?"), aber es kann keine deterministische Aussage treffen. Die epistemische Grenze ist: **Syntax ist beobachtbar, Semantik nicht. Kohärenz ist messbar, Korrektheit nicht.** Drift operiert in der beobachtbaren Domäne und kann die nicht-beobachtbare Domäne per Definition nicht erreichen — es sei denn, es gibt eine externe Spezifikation her, gegen die deterministisch geprüft werden kann. Aber dann wäre Drift kein statischer Analyzer mehr, sondern ein formaler Verifier.
+
+---
+
+## 3. Das Mess-Paradoxon — Was der Django-6.0-Drop über die Natur des Scores aussagt
+
+Die Fakten aus STUDY.md: Django hält 10 Jahre lang einen Score von 0.553–0.563 (σ=0.004). Dann fällt 6.0 auf 0.547 (Δ=-0.016) — ausgelöst durch 116 Deprecation-Removal-Commits, die Legacy-Kompatibilitätsschichten entfernen.
+
+**Was das über die Natur des Scores aussagt:**
+
+Der Score ist kein Qualitätsmaß — er ist ein **Entropiemaß**. Er misst die strukturelle Varianz in einer Codebase zu einem Zeitpunkt. Das hat eine wichtige Konsequenz: *Der Score kann nicht zwischen Komplexität, die gebraucht wird, und Komplexität, die weggehört, unterscheiden.* Er misst beides als dasselbe Signal. Django's Legacy-Schichten waren einmal sinnvoll (Rückwärtskompatibilität). Dass der Score sinkt, wenn sie entfernt werden, zeigt: der Score belohnt Reduktion, nicht Richtigkeit. Er wäre auch gesunken, wenn man *produktive* Code-Teile gelöscht hätte.
+
+**Der perverse Anreiz in KI-gestützten Teams:**
+
+Wenn ein Team auf den Drift-Score als KPI optimiert, entsteht folgendes Goodhart-Szenario:
+
+1. **Deletion-Bias:** Der schnellste Weg, den Score zu senken, ist Code löschen. Ein KI-Agent, der Drift-Scores optimiert, wird Module mit hohem Fragmentierungs-Score bevorzugt eliminieren — nicht refactoren, sondern entfernen. Das senkt PFS, MDS und potentially EDS gleichzeitig. Die Frage "Brauchen wir das?" wird ersetzt durch "Senkt das den Score?".
+
+2. **Uniformity-Bias:** Anstatt das richtige Pattern für einen neuen Use-Case zu wählen, wird das *häufigste* bestehende Pattern kopiert — weil es die Fragmentierung nicht erhöht. Das erzeugt eine Monokultur, die gegen PFS optimiert ist, aber gegen Wandlungsfähigkeit.
+
+3. **Refactoring-Vermeidung:** Tiefe Refactorings (z.B. ein Error-Handling-Pattern zu vereinheitlichen) erzeugen *während* des Refactorings einen Score-Anstieg (zwei Patterns koexistieren). In einem Team, das den Score täglich trackt, wird das Refactoring abgebrochen, bevor es abgeschlossen ist — weil es kurzfristig "schlimmer" aussieht.
+
+4. **Sophistication Ceiling:** Komplexe, aber korrekte Architekturen (Event-Sourcing, CQRS, Port/Adapter) erzeugen *mehr* Signale als einfache MVC-Strukturen — mehr Module, mehr Import-Kanten, mehr Pattern-Varianz zwischen Command- und Query-Seite. Das Team wird sich für die einfachere Architektur entscheiden, nicht weil sie besser ist, sondern weil sie leiser ist.
+
+**Die Konsequenz:** Der Score ist nur als **Delta über Zeit** interpretierbar (wie STUDY.md selbst sagt), aber das Team muss die *Richtung* des Delta qualitativ bewerten können. Ein Score-Anstieg während eines bewussten Refactorings ist ein anderes Signal als ein Score-Anstieg durch achtloses Copy-Paste. Drift liefert das Thermometer — aber es kann nicht sagen, ob Fieber eine Krankheit oder eine Immunreaktion ist.
+
+---
+
+## 4. Die Grenze des Deterministischen — Wo das Prinzip aufhört, ein Vorteil zu sein
+
+Das Determinismus-Prinzip (ADR-001) ist die epistemische Kernentscheidung von Drift: gleicher Input → gleiches Ergebnis. Das garantiert Reproduzierbarkeit, Auditierbarkeit, CI-Fähigkeit. Es ist ein *enormer* Vorteil — bis zu folgendem Punkt:
+
+**Die exakte Grenze liegt dort, wo die Drift-Klasse nicht mehr strukturell, sondern semantisch ist.**
+
+Drift kann derzeit erkennen:
+- Syntaktische Drift (PFS, MDS) — Pattern haben sich vervielfacht ✓
+- Topologische Drift (AVS, SMS) — Import-Graph hat sich deformiert ✓
+- Temporale Drift (TVS) — Churn-Profil hat sich verändert ✓
+- Dokumentations-Drift (DIA) — Code und Docs divergieren ✓
+
+Was Drift *prinzipiell nicht sehen kann* mit rein deterministischer Analyse:
+
+1. **Idiomatic Drift** — Code, der syntaktisch korrekt aber idiomatisch fremd ist. Ein KI-generiertes Python-Modul, das Java-Patterns verwendet (Getter/Setter statt Properties, Abstract-Factory statt Module-Level-Functions), ist AST-valide und import-valide. Es erzeugt keine Fragmentierung (es ist in sich konsistent). Aber es ist *fremd* im Kontext der umgebenden Codebase. Um das zu erkennen, bräuchte man ein *statistisches Modell der Codebase-Idiome* — das ist deterministisch berechenbar (Frequenzverteilung von AST-Patterns), aber Drift tut es nicht, weil es ein trainiertes Baseline-Modell erfordern würde.
+
+2. **Intention Drift** — Der Punkt aus Frage 2. Deterministisch nicht zugänglich.
+
+3. **Emergent Coupling** — Zwei Module, die nie imports teilen, aber immer zusammen geändert werden (hidden logical coupling). TVS sieht den Churn, aber nicht die *Ko-Änderung*. Um das deterministisch zu erkennen, bräuchte man eine Ko-Änderungs-Matrix aus dem Git-Log — das *ist* deterministisch und implementierbar (und STUDY.md §12.6 zeigt, dass "Hidden Coupling" als AVS-Pattern bereits existiert). Aber die Erkennung, *warum* die Kopplung besteht und ob sie problematisch ist, erfordert semantisches Verständnis.
+
+4. **API-Kontrakt-Drift** — Ein Modul exportiert weiterhin dieselbe Funktion, aber deren *Verhalten* hat sich geändert (schleichend, über viele Commits). Semantic Versioning *sollte* das markieren, tut es aber in der Praxis nicht. Deterministisch erkennbar wäre nur die Signaturänderung — nicht die Verhaltensänderung.
+
+**Der exakte Kipppunkt:** Das Determinismus-Prinzip hört auf, ein Vorteil zu sein, sobald die *relevanteste* Drift-Klasse in einer Codebase nicht mehr strukturell, sondern semantisch ist. In einer Codebase, die überwiegend von KI geschrieben wird, ist strukturelle Kohärenz *leicht herzustellen* — Copilot kann konsistente Patterns produzieren, wenn man es richtig promptet. Die Drift, die dann entsteht, ist nicht: "der Code sieht anders aus". Sondern: "der Code sieht gleich aus, aber tut subtil verschiedene Dinge". Genau diese Klasse ist deterministisch unsichtbar.
+
+Je besser die KI wird, desto weniger syntaktische Drift erzeugt sie — und desto mehr semantische. Drift's Determinismus-Prinzip schützt es vor den Problemen nicht-reproduzierbarer Analyse, aber es macht es blind für genau die Erosionsklasse, die in einer KI-dominierten Zukunft dominieren wird.
+
+---
+
+## 5. Die systemische Empfehlung — Welche Annahme aufbrechen?
+
+Nicht: ein neues Signal. Sondern: eine neue Prämisse.
+
+**Die Annahme, die aufgebrochen werden muss:**
+
+> *Drift misst den Zustand einer Codebase.*
+
+Das ist die zentrale, nicht hinterfragte Prämisse. Alle sieben Signale messen einen *Snapshot*: wie viele Patterns gibt es jetzt? Wie sieht der Import-Graph jetzt aus? Wie hoch ist die Komplexität jetzt? Selbst TVS, das sich temporal gibt, misst letztlich den *aktuellen Churn* — nicht die *Entwicklungstrajektorie* des Systems.
+
+**Was sich ändern müsste:**
+
+Drift müsste aufhören, *Zustände* zu messen, und anfangen, *Prozesse* zu messen. Die relevante Frage in einer Welt mit 80% KI-Code ist nicht: "Wie kohärent ist die Codebase?" — denn die KI kann Kohärenz billiger herstellen als jeder Mensch. Die relevante Frage ist:
+
+**"Versteht irgendein Akteur (Mensch oder Maschine) noch, warum die Codebase so ist, wie sie ist?"**
+
+Das ist eine Frage über *epistemische Integrität*, nicht über strukturelle Kohärenz. Konzeptuell müsste Drift sich von einem **Kohärenzmesser** zu einem **Verständlichkeitsradar** wandeln. Konkret:
+
+1. **Von Pattern-Zählung zu Entscheidungs-Archäologie.** Statt zu zählen, wie viele Error-Handling-Varianten existieren, fragen: Gibt es in der Historie eine *nachvollziehbare Entscheidung*, warum sich das Pattern an welcher Stelle geändert hat? Wenn 80% der Commits KI-generiert sind und keine Commit-Message erklärt, warum Pattern B statt Pattern A gewählt wurde, dann existiert eine *Wissenslücke* — unabhängig davon, ob der Code kohärent ist.
+
+2. **Von Struktur zu Delta-Lesbarkeit.** Der Composite Score sollte nicht messen, wie „aufgeräumt" der Code ist, sondern wie *vorhersagbar* die nächste Änderung für einen neuen Entwickler wäre. Die Frage verschiebt sich von "Ist es konsistent?" zu "Kann jemand, der das System nicht gebaut hat, die nächste richtige Änderung ableiten?" Das ist der eigentliche Erosionsindikator — und er ist in einer KI-dominierten Welt *der einzige, der zählt*, weil die KI selbst jedes Pattern erzeugen kann, aber nicht entscheiden kann, welches in diesem Kontext das richtige wäre.
+
+3. **Von Single-Codebase zu Codebase-als-Konversation.** Wenn 80% des Codes KI-generiert ist, ist die Codebase nicht mehr ein Artefakt menschlicher Entscheidungen, sondern ein *Transkript eines Dialogs* zwischen Mensch und Maschine. Die Erosion liegt dann nicht im Code, sondern im *Verlust des Dialogs* — wenn Prompts verloren gehen, wenn Kontext nicht übertragen wird, wenn das Warum verschwindet. Drift müsste diesen Dialog als Analyseeinheit behandeln, nicht nur den resultierenden Code.
+
+**Die fundamentale Verschiebung:** Von **"Wie sieht der Code aus?"** zu **"Weiß jemand, warum der Code so aussieht?"** — und wenn die Antwort nein ist, das als die eigentliche Erosion benennen. Nicht die syntaktische Varianz ist das Problem der Zukunft. Sondern die *epistemische Leere*, die entsteht, wenn Code schneller erzeugt als verstanden wird.

--- a/benchmark_results/drift_self.json
+++ b/benchmark_results/drift_self.json
@@ -1,44 +1,8 @@
 {
   "name": "drift_self",
-  "drift_score": 0.514,
+  "drift_score": 0.543,
   "severity": "medium",
-  "files": 66,
-  "functions": 436,
-  "ai_ratio": 0.0,
-  "analysis_s": 0.42,
-  "wall_s": 1.03,
-  "findings": 80,
-  "signals": {},
-  "top5": [
-    {
-      "sig": "system_misalignment",
-      "sev": "medium",
-      "score": 1.0,
-      "title": "Novel dependencies in scripts/"
-    },
-    {
-      "sig": "system_misalignment",
-      "sev": "medium",
-      "score": 1.0,
-      "title": "Novel dependencies in src/drift/"
-    },
-    {
-      "sig": "system_misalignment",
-      "sev": "medium",
-      "score": 1.0,
-      "title": "Novel dependencies in src/drift/ingestion/"
-    },
-    {
-      "sig": "system_misalignment",
-      "sev": "medium",
-      "score": 1.0,
-      "title": "Novel dependencies in src/drift/output/"
-    },
-    {
-      "sig": "system_misalignment",
-      "sev": "medium",
-      "score": 1.0,
-      "title": "Novel dependencies in src/drift/scoring/"
-    }
-  ]
+  "files": 18,
+  "functions": 0,
+  "findings": 179
 }

--- a/docs/adr/005-delta-first-score-interpretation.md
+++ b/docs/adr/005-delta-first-score-interpretation.md
@@ -1,0 +1,260 @@
+# ADR-005: Delta-First Score Interpretation — Preventing Goodhart Optimization
+
+**Status:** Accepted  
+**Date:** 2026-03-24  
+**Decision Makers:** @sauremilk
+
+## Context
+
+### The Problem
+
+Drift produces a composite score (0.0–1.0) that represents structural coherence of a codebase. STUDY.md §11.7 demonstrates that this score is temporally stable (σ < 0.005 for mature repos) and correlates with structural changes (not noise). The tool's own documentation states: *"The value of drift is delta, not absolute."*
+
+However, the current output architecture contradicts this principle:
+
+1. **`drift analyze` emits an absolute score without trend context.** A team seeing `Score: 0.512 (MEDIUM)` has no frame of reference — is this good? Bad? Improving? Degrading?
+
+2. **The CI gate (`fail_on`) operates on absolute severity.** Teams set `fail_on: high` and optimize toward keeping findings below that threshold — creating Goodhart dynamics where the score becomes the target.
+
+3. **`drift trend` is a separate, opt-in command.** The delta interpretation — which is the *only* valid interpretation per drift's own design — requires a deliberate extra step that most CI pipelines skip.
+
+4. **JSON/SARIF outputs contain no historical context.** Downstream consumers (dashboards, PR bots) receive a point-in-time number without the temporal frame needed to interpret it.
+
+### Empirical Evidence (STUDY.md)
+
+- **Django 6.0 score drop (Δ = -0.016):** The largest delta in 10 years was caused by removing legacy code — *improving* the codebase. A team targeting "score < 0.55" would have been at 0.553–0.563 for a decade and might have deleted productive code to reach 0.55. The delta tells the real story: -0.016 after a cleanup is a positive signal.
+
+- **Refactoring paradox:** Unifying error-handling patterns across a module temporarily *increases* PFS (two patterns coexist mid-refactoring). A delta-aware system shows "+0.02 this sprint, -0.04 next sprint" — which is the expected trajectory. An absolute-score gate would block the PR that introduces the temporary regression.
+
+- **Migration transitions:** PWBS (a known AI-assisted codebase) has AVS findings because it uses two data-access patterns simultaneously. These findings are structurally correct but contextually expected. Without delta context, the score misleads.
+
+### Threats from Goodhart Optimization
+
+In AI-assisted teams that track the composite score as a KPI:
+
+| Perverse Incentive | Mechanism | Consequence |
+|--------------------|-----------|-------------|
+| **Deletion bias** | Deleting high-PFS modules is faster than refactoring them | Productive code removed to lower score |
+| **Uniformity bias** | Copying the most common pattern (even if wrong) avoids PFS increase | Monoculture; reduced adaptability |
+| **Refactoring avoidance** | Mid-refactoring score spikes trigger CI failures | Refactorings abandoned before completion |
+| **Sophistication ceiling** | Complex architectures (CQRS, event sourcing) produce more signals than simple MVC | Teams choose simpler (worse) architecture to minimize score |
+
+## Decision
+
+### Principle: No Absolute Score Without Temporal Context
+
+Every drift output that includes a composite score MUST also include:
+1. The previous score (if history exists)
+2. The delta (current − previous)
+3. The delta direction (improving / stable / degrading)
+4. The history depth (number of prior snapshots)
+
+When no history exists, the output MUST explicitly state that no trend interpretation is possible.
+
+### Change 1: Inline Trend Context in `drift analyze`
+
+`analyze_repo()` reads the history file (`.drift-cache/history.json`) after computing the current score and attaches a `TrendContext` to `RepoAnalysis`.
+
+```python
+@dataclass
+class TrendContext:
+    previous_score: float | None     # Last snapshot score
+    delta: float | None              # current - previous
+    direction: str                   # "improving" | "stable" | "degrading"
+    recent_scores: list[float]       # Last 5 scores
+    history_depth: int               # Total snapshots available
+    transition_ratio: float          # % of findings with drift:context tags
+```
+
+**Direction logic:**
+- `|Δ| < 0.005` → `"stable"` (below noise floor per STUDY.md §11.6)
+- `Δ < -0.005` → `"improving"`
+- `Δ > +0.005` → `"degrading"`
+
+**Rich output with trend:**
+```
+Drift Score: 0.442 (MEDIUM)  Δ −0.015 ↓ improving
+  Trend: 0.472 → 0.457 → 0.442 (3 snapshots)
+```
+
+**Rich output without history:**
+```
+Drift Score: 0.442 (MEDIUM)  — baseline (no prior snapshots)
+  ⚠ Run drift analyze again after structural changes to establish trend.
+```
+
+**JSON output enrichment:**
+```json
+{
+  "drift_score": 0.442,
+  "severity": "medium",
+  "trend": {
+    "previous_score": 0.457,
+    "delta": -0.015,
+    "direction": "improving",
+    "recent_scores": [0.472, 0.457, 0.442],
+    "history_depth": 3,
+    "transition_ratio": 0.0
+  }
+}
+```
+
+When no history exists: `"trend": null`.
+
+### Change 2: Delta-Based CI Gate (opt-in)
+
+New configuration options in `drift.yaml`:
+
+```yaml
+fail_on: high                # Existing: severity-based gate (unchanged)
+fail_on_delta: 0.05          # New: fail if Δ > +0.05 (score increased)
+fail_on_delta_window: 5      # Compare against mean of last N snapshots
+```
+
+**Semantics:**
+- `fail_on_delta` compares the current score against the mean of the last `fail_on_delta_window` snapshots.
+- If `current_score - mean(recent_N) > fail_on_delta`, the gate fails.
+- If no history exists, the delta gate passes (first run cannot fail on delta).
+
+**Why mean-of-N instead of last-1:** A single outlier snapshot (e.g., mid-refactoring) shouldn't anchor the delta gate. Mean-of-5 smooths transient spikes while still catching sustained degradation.
+
+**Interaction with `fail_on`:** Both gates are independent. A run can fail on severity *or* delta *or* both. `fail_on: none` + `fail_on_delta: 0.05` is a valid configuration that ignores absolute severity and only gates on trend.
+
+### Change 3: History Auto-Persistence
+
+Currently, only `drift trend` writes to the history file. After this ADR:
+
+- `drift analyze` writes a snapshot to `.drift-cache/history.json` after every run.
+- `drift trend` reads and displays the history (no change to trend behavior).
+- History retention: 100 snapshots (unchanged).
+
+This ensures that delta context accumulates even for teams that only use `drift analyze` in CI.
+
+### Change 4: SARIF Trend Properties
+
+SARIF output gains custom properties on the `run` object:
+
+```json
+{
+  "runs": [{
+    "properties": {
+      "drift:trend": {
+        "previousScore": 0.457,
+        "delta": -0.015,
+        "direction": "improving"
+      }
+    }
+  }]
+}
+```
+
+GitHub Code Scanning surfaces custom properties in the UI, making delta visible in PR annotations.
+
+## Consequences
+
+### Positive
+
+1. **Goodhart resistance:** Teams cannot optimize on the absolute score without seeing the delta. The delta *is* the primary signal in every output format.
+2. **Refactoring support:** Mid-refactoring score spikes are visible as transient deltas, not permanent failures. `fail_on_delta_window: 5` absorbs spikes up to 5 runs.
+3. **First-run honesty:** New users see "baseline — no trend yet" instead of a decontextualized number.
+4. **CI flexibility:** `fail_on_delta` allows teams to gate on *degradation rate* instead of *absolute level* — which is the correct operational interpretation per drift's design.
+5. **Backward compatible:** All changes are additive. Existing `fail_on` behavior is unchanged. Delta gate is opt-in. JSON consumers that don't read `trend` are unaffected.
+
+### Negative
+
+1. **History file dependency:** Delta context requires `.drift-cache/history.json` to persist across CI runs. Ephemeral CI environments (fresh container per run) need artifact caching or a shared volume. Mitigation: document caching patterns for GitHub Actions, GitLab CI, Jenkins.
+2. **Noise at low history depth:** With only 2 snapshots, the delta is noisy. Mitigation: `fail_on_delta_window` defaults to 5 — the gate is lenient until sufficient data exists.
+3. **Disk I/O in analyze:** `analyze_repo()` now reads and writes the history file. Impact: <1ms for 100 JSON snapshots — negligible relative to analysis time.
+
+### Neutral
+
+- The composite scoring model (ADR-003) is entirely unchanged. Weights, dampening, signal aggregation — all untouched.
+- The deterministic pipeline (ADR-001) is preserved. Trend context is a post-computation read from a local file, not a non-deterministic input to the analysis.
+
+## Alternatives Considered
+
+### Alternative 1: Remove the Composite Score Entirely
+
+Replace the single number with a signal-level dashboard (7 individual scores). Force users to interpret each signal independently.
+
+**Rejected:** The composite score exists (ADR-003) because it serves a real need — quick triage. A 7-dimensional signal space is not actionable in a CI gate. The problem is not the existence of the score but the absence of interpretation context.
+
+### Alternative 2: Score Bands Instead of Numbers
+
+Replace `0.442` with `HEALTHY / CONCERNING / DEGRADED` bands. Remove numeric precision entirely.
+
+**Rejected:** Bands hide information. A team at 0.449 and a team at 0.550 would both be "CONCERNING" — but their trajectories may be opposite. The numeric score with delta is more informative than categorical bands.
+
+### Alternative 3: Mandatory `drift trend` Before `drift analyze`
+
+Require teams to run `drift trend` first, which establishes baseline. `drift analyze` without prior `drift trend` emits a warning.
+
+**Rejected:** Adds friction. Splits a natural workflow into two commands. The better design is to make `drift analyze` self-contextualizing by auto-reading history.
+
+### Alternative 4: Server-Side Score Storage
+
+Store scores in a central drift server / SaaS backend for cross-team comparison and normalization.
+
+**Rejected:** Contradicts ADR-001's zero-infrastructure principle. Drift runs locally — no server, no cloud, no account. History persistence is a local file problem, solvable with CI artifact caching.
+
+## Implementation Notes
+
+### Data Model Changes
+
+```python
+# models.py — new dataclass
+@dataclass
+class TrendContext:
+    previous_score: float | None
+    delta: float | None
+    direction: str        # "improving" | "stable" | "degrading" | "baseline"
+    recent_scores: list[float]
+    history_depth: int
+    transition_ratio: float
+
+# models.py — extend RepoAnalysis
+@dataclass
+class RepoAnalysis:
+    # ... existing fields ...
+    trend: TrendContext | None = None
+```
+
+### Config Changes
+
+```python
+# config.py — extend DriftConfig
+class DriftConfig(BaseModel):
+    # ... existing fields ...
+    fail_on_delta: float | None = None          # e.g. 0.05
+    fail_on_delta_window: int = 5
+```
+
+### Scoring Engine Changes
+
+```python
+# scoring/engine.py — new function
+def delta_gate_pass(
+    current_score: float,
+    history: list[dict],
+    fail_on_delta: float,
+    window: int = 5,
+) -> bool:
+    """Check if score degradation exceeds the delta threshold."""
+    recent = [s["drift_score"] for s in history[-window:]]
+    if not recent:
+        return True  # No history → gate passes
+    baseline = sum(recent) / len(recent)
+    return (current_score - baseline) <= fail_on_delta
+```
+
+### Output Changes
+
+All three renderers (Rich, JSON, SARIF) read `RepoAnalysis.trend` and render context. No change to the rendering interface — only additional data in the existing dataclass.
+
+## References
+
+- [ADR-001: Deterministic Analysis Pipeline](001-deterministic-analysis-pipeline.md) — zero-infrastructure constraint
+- [ADR-003: Composite Scoring Model](003-composite-scoring-model.md) — scoring model preserved
+- [STUDY.md §11.6](../../STUDY.md) — temporal stability evidence (σ < 0.005)
+- [STUDY.md §11.7](../../STUDY.md) — major-version correlation (django 1.8→6.0)
+- [POLICY.md §7](../../POLICY.md) — priority hierarchy (Glaubwürdigkeit > Signalpräzision > ...)

--- a/docs/adr/006-context-tagging.md
+++ b/docs/adr/006-context-tagging.md
@@ -1,0 +1,112 @@
+# ADR-006: Context-Tagging for Intentional Variance
+
+**Status:** Accepted  
+**Date:** 2026-03-24  
+**Relates to:** EPISTEMICS.md Problem 1, ADR-001 (determinism), ADR-003 (scoring)
+
+## Context
+
+Drift assumes that structural variance is an indicator of erosion. This is
+generally true, but breaks down in two well-documented scenarios
+(EPISTEMICS.md §1):
+
+1. **Architecture transitions** — A migration from monolith to services
+   necessarily co-locates old and new patterns. The temporary variance *is* the
+   migration; penalizing it discourages progress.
+
+2. **Deliberate polymorphism** — Strategy patterns, codec hierarchies, and
+   plugin systems produce structural similarity that drift interprets as
+   duplication, even when it is the intended architecture.
+
+The existing `drift:ignore` pragma fully suppresses findings. This is too
+blunt: it hides the signal entirely and removes all tracking. Teams need a
+mechanism that says *"I see this variance and it is intentional"* without
+losing coverage.
+
+## Decision
+
+Introduce **`drift:context <tag>`** inline pragmas that annotate code regions
+with intentional-variance context. Findings that overlap a context-tagged
+region are **dampened, not suppressed**: their score is reduced by a
+configurable factor, and the context tags are recorded in finding metadata
+for full traceability.
+
+### Pragma Syntax
+
+```python
+# drift:context migration
+class NewPaymentService:
+    ...
+
+# drift:context deliberate,strategy-pattern
+def process_card(self): ...
+```
+
+```typescript
+// drift:context refactoring
+export function legacyHandler() { ... }
+```
+
+### Supported Formats
+
+| Language   | Comment style                        |
+|------------|--------------------------------------|
+| Python     | `# drift:context <tag>[,<tag>]`      |
+| TypeScript | `// drift:context <tag>[,<tag>]`     |
+| JavaScript | `// drift:context <tag>[,<tag>]`     |
+
+### Semantics
+
+- Tags are **free-form** strings (lowercase, hyphens, underscores allowed).
+- Multiple tags are comma-separated.
+- A context comment applies to the **line it appears on** and the finding whose
+  range includes that line. This matches the `drift:ignore` line-match contract.
+- Context tags do **not** suppress findings. Findings remain visible in all
+  output formats with their original signal type and description.
+
+### Score Dampening
+
+Tagged findings receive: `score = original_score × context_dampening`
+
+- `context_dampening` is configurable (default: **0.5**, range 0.0–1.0).
+- Setting `context_dampening: 1.0` disables dampening (tags are metadata-only).
+- Setting `context_dampening: 0.0` is equivalent to suppression (discouraged).
+- Impact is recomputed after dampening.
+
+### Output
+
+- **Rich terminal:** Summary line shows context-tagged count alongside
+  suppressed count. Findings show `[ctx: migration]` tag annotation.
+- **JSON:** Each finding's `metadata` includes `"context_tags": ["migration"]`.
+- **SARIF:** Context tags appear in finding `properties`.
+
+### Configuration
+
+```yaml
+# drift.yaml
+context_dampening: 0.5  # Score reduction factor for context-tagged findings
+```
+
+## Consequences
+
+### Positive
+
+- False positives from intentional variance are reduced without hiding the signal.
+- Context tags create an audit trail of *acknowledged* architectural decisions.
+- `transition_ratio` (reserved in ADR-005's TrendContext) can be populated with
+  the ratio of context-tagged to total findings.
+- CI gates can be tuned: a team in migration can set `context_dampening: 0.3`
+  to account for expected variance.
+
+### Negative
+
+- Developers must add pragmas manually (though this is also true for
+  `drift:ignore`).
+- The dampening factor is a heuristic — there is no principled way to derive
+  the "correct" reduction for a given tag.
+
+### Neutral
+
+- The feature is strictly additive; codebases without `drift:context` comments
+  behave identically.
+- ADR-001 (determinism) is preserved: same input → same output.

--- a/drift.example.yaml
+++ b/drift.example.yaml
@@ -63,6 +63,16 @@ policies:
 # Options: critical, high, medium, low
 fail_on: none  # recommended for the first rollout pass
 
+# Context-tagging dampening factor (ADR-006): findings annotated with
+# # drift:context <tag> have their score multiplied by this value.
+# Set to 1.0 to disable dampening (tags are metadata-only).
+# context_dampening: 0.5
+
+# Delta gate (ADR-005): exit 1 if score increases by more than this value
+# compared to the mean of the last N snapshots.
+# fail_on_delta: 0.05
+# fail_on_delta_window: 5   # Compare against mean of last N snapshots
+
 # Tunable thresholds
 thresholds:
   similarity_threshold: 0.80   # MDS: Jaccard similarity cutoff

--- a/src/drift/analyzer.py
+++ b/src/drift/analyzer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import importlib
+import json
 import logging
 import pkgutil
 import subprocess
@@ -15,6 +16,7 @@ from pathlib import Path
 import drift.signals
 from drift.cache import ParseCache
 from drift.config import DriftConfig
+from drift.context_tags import apply_context_tags, scan_context_tags
 from drift.embeddings import get_embedding_service
 from drift.ingestion.ast_parser import parse_file
 from drift.ingestion.file_discovery import discover_files
@@ -26,6 +28,7 @@ from drift.models import (
     PatternCategory,
     PatternInstance,
     RepoAnalysis,
+    TrendContext,
 )
 from drift.scoring.engine import (
     assign_impact_scores,
@@ -216,6 +219,14 @@ def _run_pipeline(
     all_findings, suppressed_findings = filter_findings(all_findings, suppressions)
     suppressed_count = len(suppressed_findings)
 
+    # --- 5c. Context tagging (ADR-006) ---
+    ctx_tags = scan_context_tags(files, repo_path)
+    all_findings, context_tagged_count = apply_context_tags(
+        all_findings, ctx_tags, dampening=config.context_dampening,
+    )
+    # Re-compute impact after dampening so downstream scoring uses adjusted values
+    assign_impact_scores(all_findings, config.weights)
+
     signal_scores = compute_signal_scores(all_findings)
     repo_score = composite_score(signal_scores, config.weights)
     module_scores = compute_module_scores(all_findings, config.weights)
@@ -247,6 +258,66 @@ def _run_pipeline(
         commits=commits,
         file_histories=file_histories,
         suppressed_count=suppressed_count,
+        context_tagged_count=context_tagged_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trend context (ADR-005)
+# ---------------------------------------------------------------------------
+
+_NOISE_FLOOR = 0.005  # |Δ| below this → "stable" (STUDY.md §11.6)
+
+
+def _load_history(history_file: Path) -> list[dict]:
+    """Load snapshots from the history JSON file."""
+    if not history_file.exists():
+        return []
+    try:
+        return json.loads(history_file.read_text(encoding="utf-8"))  # type: ignore[no-any-return]
+    except Exception:
+        return []
+
+
+def _save_history(history_file: Path, snapshots: list[dict]) -> None:
+    """Persist snapshots (last 100) to the history JSON file."""
+    history_file.parent.mkdir(parents=True, exist_ok=True)
+    history_file.write_text(json.dumps(snapshots[-100:], indent=2), encoding="utf-8")
+
+
+def _build_trend_context(
+    current_score: float, snapshots: list[dict],
+) -> TrendContext:
+    """Compute trend context from history snapshots."""
+    if not snapshots:
+        return TrendContext(
+            previous_score=None,
+            delta=None,
+            direction="baseline",
+            recent_scores=[],
+            history_depth=0,
+            transition_ratio=0.0,
+        )
+
+    prev = snapshots[-1]["drift_score"]
+    delta = round(current_score - prev, 4)
+
+    if abs(delta) < _NOISE_FLOOR:
+        direction = "stable"
+    elif delta < 0:
+        direction = "improving"
+    else:
+        direction = "degrading"
+
+    recent = [s["drift_score"] for s in snapshots[-5:]]
+
+    return TrendContext(
+        previous_score=prev,
+        delta=delta,
+        direction=direction,
+        recent_scores=recent,
+        history_depth=len(snapshots),
+        transition_ratio=0.0,
     )
 
 
@@ -301,6 +372,29 @@ def analyze_repo(
         workers=workers,
     )
     analysis.analysis_duration_seconds = round(time.monotonic() - start, 2)
+
+    # --- Trend context (ADR-005) ---
+    history_file = repo_path / config.cache_dir / "history.json"
+    snapshots = _load_history(history_file)
+    analysis.trend = _build_trend_context(analysis.drift_score, snapshots)
+
+    # ADR-006: populate transition_ratio with context-tagged share
+    if analysis.trend and analysis.findings:
+        analysis.trend.transition_ratio = round(
+            analysis.context_tagged_count / len(analysis.findings), 3,
+        )
+
+    # Auto-persist snapshot
+    signal_scores = compute_signal_scores(analysis.findings)
+    snapshots.append({
+        "timestamp": analysis.analyzed_at.isoformat(),
+        "drift_score": analysis.drift_score,
+        "signal_scores": {s.value: v for s, v in signal_scores.items()},
+        "total_files": analysis.total_files,
+        "total_findings": len(analysis.findings),
+    })
+    _save_history(history_file, snapshots)
+
     return analysis
 
 

--- a/src/drift/config.py
+++ b/src/drift/config.py
@@ -107,6 +107,9 @@ class DriftConfig(BaseModel):
     thresholds: ThresholdsConfig = Field(default_factory=ThresholdsConfig)
     cache_dir: str = ".drift-cache"
     fail_on: str = "high"
+    context_dampening: float = 0.5
+    fail_on_delta: float | None = None
+    fail_on_delta_window: int = 5
     embeddings_enabled: bool = True
     embedding_model: str = "all-MiniLM-L6-v2"
     embedding_batch_size: int = 64

--- a/src/drift/context_tags.py
+++ b/src/drift/context_tags.py
@@ -1,0 +1,109 @@
+"""Inline context-tagging — ``# drift:context`` pragmas (ADR-006).
+
+Context tags annotate code regions with intentional-variance semantics.
+Unlike ``drift:ignore`` which *suppresses* findings, ``drift:context``
+*dampens* them and records the declared intent in finding metadata.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from drift.models import FileInfo, Finding
+
+# Tag body: one or more comma-separated tokens (lowercase, hyphens, underscores, digits).
+_TAG_BODY = r"([\w\-]+(?:\s*,\s*[\w\-]+)*)"
+
+# Python:  # drift:context <tags>
+_PY_PATTERN = re.compile(rf"#\s*drift:context\s+{_TAG_BODY}")
+# JS/TS:   // drift:context <tags>
+_JS_PATTERN = re.compile(rf"//\s*drift:context\s+{_TAG_BODY}")
+
+_PATTERN_BY_LANG: dict[str, re.Pattern[str]] = {
+    "python": _PY_PATTERN,
+    "typescript": _JS_PATTERN,
+    "tsx": _JS_PATTERN,
+    "javascript": _JS_PATTERN,
+    "jsx": _JS_PATTERN,
+}
+
+
+def _parse_tags(raw: str) -> set[str]:
+    """Split a raw comma-separated tag string into a normalised set."""
+    return {t.strip().lower() for t in raw.split(",") if t.strip()}
+
+
+def scan_context_tags(
+    files: list[FileInfo],
+    repo_path: Path,
+) -> dict[tuple[str, int], set[str]]:
+    """Scan source files for ``drift:context`` comments.
+
+    Returns a mapping of ``(posix_path, line_number)`` → set of tag strings.
+    """
+    tags: dict[tuple[str, int], set[str]] = {}
+
+    for finfo in files:
+        pattern = _PATTERN_BY_LANG.get(finfo.language)
+        if pattern is None:
+            continue
+        full_path = repo_path / finfo.path
+        try:
+            text = full_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            m = pattern.search(line)
+            if m is None:
+                continue
+            matched_tags = _parse_tags(m.group(1))
+            if matched_tags:
+                tags[(finfo.path.as_posix(), line_no)] = matched_tags
+
+    return tags
+
+
+def apply_context_tags(
+    findings: list[Finding],
+    context_tags: dict[tuple[str, int], set[str]],
+    dampening: float = 0.5,
+) -> tuple[list[Finding], int]:
+    """Annotate findings with context tags and dampen their scores.
+
+    Findings whose ``[start_line, end_line]`` range overlaps a context-tagged
+    line receive:
+    - ``metadata["context_tags"]`` — the union of overlapping tags
+    - ``score *= dampening`` — score reduction (then ``impact`` is recomputed
+      externally after this step)
+
+    Returns ``(all_findings, context_tagged_count)``.
+    """
+    if not context_tags:
+        return findings, 0
+
+    dampening = max(0.0, min(1.0, dampening))
+    tagged_count = 0
+
+    for f in findings:
+        if f.file_path is None or f.start_line is None:
+            continue
+
+        end_line = f.end_line if f.end_line is not None else f.start_line
+        start_line = min(f.start_line, end_line)
+        end_line = max(f.start_line, end_line)
+
+        merged_tags: set[str] = set()
+        for line_no in range(start_line, end_line + 1):
+            key = (f.file_path.as_posix(), line_no)
+            entry = context_tags.get(key)
+            if entry is not None:
+                merged_tags |= entry
+
+        if merged_tags:
+            f.metadata["context_tags"] = sorted(merged_tags)
+            f.score = round(f.score * dampening, 4)
+            tagged_count += 1
+
+    return findings, tagged_count

--- a/src/drift/models.py
+++ b/src/drift/models.py
@@ -215,6 +215,18 @@ class ModuleScore:
 
 
 @dataclass
+class TrendContext:
+    """Temporal context attached to every analysis result (ADR-005)."""
+
+    previous_score: float | None
+    delta: float | None
+    direction: str  # "improving" | "stable" | "degrading" | "baseline"
+    recent_scores: list[float]
+    history_depth: int
+    transition_ratio: float
+
+
+@dataclass
 class RepoAnalysis:
     """Complete analysis result for a repository."""
 
@@ -231,6 +243,8 @@ class RepoAnalysis:
     commits: list[CommitInfo] = field(default_factory=list)
     file_histories: dict[str, FileHistory] = field(default_factory=dict)
     suppressed_count: int = 0
+    context_tagged_count: int = 0
+    trend: TrendContext | None = None
 
     @property
     def severity(self) -> Severity:

--- a/src/drift/output/json_output.py
+++ b/src/drift/output/json_output.py
@@ -46,6 +46,14 @@ def analysis_to_json(analysis: RepoAnalysis, indent: int = 2) -> str:
         "analyzed_at": analysis.analyzed_at.isoformat(),
         "drift_score": analysis.drift_score,
         "severity": analysis.severity.value,
+        "trend": {
+            "previous_score": analysis.trend.previous_score,
+            "delta": analysis.trend.delta,
+            "direction": analysis.trend.direction,
+            "recent_scores": analysis.trend.recent_scores,
+            "history_depth": analysis.trend.history_depth,
+            "transition_ratio": analysis.trend.transition_ratio,
+        } if analysis.trend else None,
         "summary": {
             "total_files": analysis.total_files,
             "total_functions": analysis.total_functions,
@@ -55,6 +63,7 @@ def analysis_to_json(analysis: RepoAnalysis, indent: int = 2) -> str:
         "modules": [_module_to_dict(m) for m in analysis.module_scores],
         "findings": [_finding_to_dict(f) for f in analysis.findings],
         "suppressed_count": analysis.suppressed_count,
+        "context_tagged_count": analysis.context_tagged_count,
     }
 
     return json.dumps(data, indent=indent, default=str)
@@ -125,23 +134,38 @@ def findings_to_sarif(analysis: RepoAnalysis) -> str:
         if f.fix:
             result["message"]["text"] = f"{f.title}\n{f.description}\nFIX: {f.fix}"
 
+        # ADR-006: context tags as SARIF result properties
+        ctx_tags = f.metadata.get("context_tags")
+        if ctx_tags:
+            result["properties"] = {"drift:context": ctx_tags}
+
         results.append(result)
+
+    run_obj: dict[str, Any] = {
+        "tool": {
+            "driver": {
+                "name": "drift",
+                "version": __version__,
+                "rules": rules,
+            }
+        },
+        "results": results,
+    }
+
+    # ADR-005: attach trend context as custom SARIF properties
+    if analysis.trend and analysis.trend.direction != "baseline":
+        run_obj["properties"] = {
+            "drift:trend": {
+                "previousScore": analysis.trend.previous_score,
+                "delta": analysis.trend.delta,
+                "direction": analysis.trend.direction,
+            }
+        }
 
     sarif = {
         "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
         "version": "2.1.0",
-        "runs": [
-            {
-                "tool": {
-                    "driver": {
-                        "name": "drift",
-                        "version": __version__,
-                        "rules": rules,
-                    }
-                },
-                "results": results,
-            }
-        ],
+        "runs": [run_obj],
     }
 
     return json.dumps(sarif, indent=2, default=str)

--- a/src/drift/output/rich_output.py
+++ b/src/drift/output/rich_output.py
@@ -76,11 +76,35 @@ def render_summary(analysis: RepoAnalysis, console: Console | None = None) -> No
     # Header
     console.print()
     header_color = _SEVERITY_COLORS.get(analysis.severity, "white")
+
+    # Build trend suffix (ADR-005)
+    trend = analysis.trend
+    if trend and trend.direction != "baseline" and trend.delta is not None:
+        arrow = (
+            "↓" if trend.direction == "improving"
+            else "↑" if trend.direction == "degrading"
+            else "→"
+        )
+        delta_color = (
+            "green" if trend.direction == "improving"
+            else "red" if trend.direction == "degrading"
+            else "dim"
+        )
+        trend_parts: tuple = (
+            ("  ", ""),
+            (f"Δ {trend.delta:+.3f} {arrow} {trend.direction}", delta_color),
+        )
+    else:
+        trend_parts = (
+            ("  — baseline", "dim"),
+        )
+
     console.print(
         Panel(
             Text.assemble(
                 ("DRIFT SCORE  ", "bold"),
                 (f"{analysis.drift_score:.2f}", f"bold {header_color}"),
+                *trend_parts,
                 ("  │  ", "dim"),
                 (f"{analysis.total_files} files", ""),
                 ("  │  ", "dim"),
@@ -92,6 +116,14 @@ def render_summary(analysis: RepoAnalysis, console: Console | None = None) -> No
                     if analysis.suppressed_count
                     else ()
                 ),
+                *(
+                    (
+                        ("  │  ", "dim"),
+                        (f"{analysis.context_tagged_count} ctx-tagged", "dim italic"),
+                    )
+                    if analysis.context_tagged_count
+                    else ()
+                ),
                 ("  │  ", "dim"),
                 (f"{analysis.analysis_duration_seconds:.1f}s", "dim"),
             ),
@@ -99,6 +131,18 @@ def render_summary(analysis: RepoAnalysis, console: Console | None = None) -> No
             border_style=header_color,
         )
     )
+
+    # Trend sparkline (ADR-005)
+    if trend and trend.recent_scores and trend.direction != "baseline":
+        scores_str = " → ".join(f"{s:.3f}" for s in trend.recent_scores)
+        depth = trend.history_depth
+        sfx = "s" if depth != 1 else ""
+        console.print(f"  [dim]Trend: {scores_str} ({depth} snapshot{sfx})[/dim]")
+    elif trend and trend.direction == "baseline":
+        console.print(
+            "  [dim]⚠ Run drift analyze again after structural"
+            " changes to establish trend.[/dim]"
+        )
 
 
 def render_module_table(analysis: RepoAnalysis, console: Console | None = None) -> None:
@@ -170,6 +214,11 @@ def _format_finding_detail(f: Finding) -> Text:
     if f.fix:
         text.append("  FIX: ", style=f"bold {color}")
         text.append(f"{f.fix}\n", style=color)
+
+    # Context tags (ADR-006)
+    ctx_tags = f.metadata.get("context_tags")
+    if ctx_tags:
+        text.append(f"  [ctx: {', '.join(ctx_tags)}]\n", style="cyan italic")
 
     return text
 

--- a/tests/test_context_tags.py
+++ b/tests/test_context_tags.py
@@ -1,0 +1,363 @@
+"""Tests for context-tagging feature (ADR-006)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from drift.context_tags import apply_context_tags, scan_context_tags
+from drift.models import FileInfo, Finding, Severity, SignalType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_finding(
+    file_path: str = "services/payment.py",
+    start_line: int = 10,
+    end_line: int = 20,
+    score: float = 0.8,
+    signal_type: SignalType = SignalType.PATTERN_FRAGMENTATION,
+) -> Finding:
+    return Finding(
+        signal_type=signal_type,
+        severity=Severity.HIGH,
+        score=score,
+        title="Test finding",
+        description="Test description",
+        file_path=Path(file_path),
+        start_line=start_line,
+        end_line=end_line,
+    )
+
+
+def _write_python_file(tmp_path: Path, rel_path: str, content: str) -> FileInfo:
+    full = tmp_path / rel_path
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_text(content, encoding="utf-8")
+    return FileInfo(
+        path=Path(rel_path),
+        language="python",
+        size_bytes=len(content),
+        line_count=content.count("\n") + 1,
+    )
+
+
+def _write_ts_file(tmp_path: Path, rel_path: str, content: str) -> FileInfo:
+    full = tmp_path / rel_path
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_text(content, encoding="utf-8")
+    return FileInfo(
+        path=Path(rel_path),
+        language="typescript",
+        size_bytes=len(content),
+        line_count=content.count("\n") + 1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# scan_context_tags
+# ---------------------------------------------------------------------------
+
+class TestScanContextTags:
+    def test_python_single_tag(self, tmp_path: Path) -> None:
+        fi = _write_python_file(tmp_path, "svc/handler.py", (
+            "import os\n"
+            "# drift:context migration\n"
+            "class OldHandler:\n"
+            "    pass\n"
+        ))
+        tags = scan_context_tags([fi], tmp_path)
+        assert tags[("svc/handler.py", 2)] == {"migration"}
+
+    def test_python_multiple_tags(self, tmp_path: Path) -> None:
+        fi = _write_python_file(tmp_path, "svc/handler.py", (
+            "# drift:context migration, legacy\n"
+            "def old_func(): pass\n"
+        ))
+        tags = scan_context_tags([fi], tmp_path)
+        assert tags[("svc/handler.py", 1)] == {"migration", "legacy"}
+
+    def test_typescript_tag(self, tmp_path: Path) -> None:
+        fi = _write_ts_file(tmp_path, "svc/handler.ts", (
+            "// drift:context refactoring\n"
+            "export function legacyHandler() {}\n"
+        ))
+        tags = scan_context_tags([fi], tmp_path)
+        assert tags[("svc/handler.ts", 1)] == {"refactoring"}
+
+    def test_no_context_tags(self, tmp_path: Path) -> None:
+        fi = _write_python_file(tmp_path, "svc/clean.py", (
+            "def clean(): pass\n"
+        ))
+        tags = scan_context_tags([fi], tmp_path)
+        assert len(tags) == 0
+
+    def test_ignores_drift_ignore(self, tmp_path: Path) -> None:
+        fi = _write_python_file(tmp_path, "svc/ignored.py", (
+            "# drift:ignore\n"
+            "def old(): pass\n"
+        ))
+        tags = scan_context_tags([fi], tmp_path)
+        assert len(tags) == 0
+
+    def test_multiple_files(self, tmp_path: Path) -> None:
+        f1 = _write_python_file(tmp_path, "a.py", "# drift:context migration\nx = 1\n")
+        f2 = _write_python_file(tmp_path, "b.py", "# drift:context deliberate\ny = 2\n")
+        tags = scan_context_tags([f1, f2], tmp_path)
+        assert ("a.py", 1) in tags
+        assert ("b.py", 1) in tags
+
+    def test_tag_with_hyphens_and_underscores(self, tmp_path: Path) -> None:
+        fi = _write_python_file(tmp_path, "x.py", (
+            "# drift:context strategy-pattern, tech_debt\n"
+            "class X: pass\n"
+        ))
+        tags = scan_context_tags([fi], tmp_path)
+        assert tags[("x.py", 1)] == {"strategy-pattern", "tech_debt"}
+
+    def test_unsupported_language_ignored(self, tmp_path: Path) -> None:
+        fi = FileInfo(path=Path("data.json"), language="json", size_bytes=10)
+        tags = scan_context_tags([fi], tmp_path)
+        assert len(tags) == 0
+
+    def test_missing_file_skipped(self, tmp_path: Path) -> None:
+        fi = FileInfo(path=Path("nonexistent.py"), language="python", size_bytes=0)
+        tags = scan_context_tags([fi], tmp_path)
+        assert len(tags) == 0
+
+
+# ---------------------------------------------------------------------------
+# apply_context_tags
+# ---------------------------------------------------------------------------
+
+class TestApplyContextTags:
+    def test_tags_applied_to_overlapping_finding(self) -> None:
+        tags = {("services/payment.py", 15): {"migration"}}
+        findings = [_make_finding(start_line=10, end_line=20, score=0.8)]
+        result, count = apply_context_tags(findings, tags, dampening=0.5)
+        assert count == 1
+        assert result[0].metadata["context_tags"] == ["migration"]
+        assert result[0].score == pytest.approx(0.4)
+
+    def test_no_overlap_no_dampening(self) -> None:
+        tags = {("services/payment.py", 50): {"migration"}}
+        findings = [_make_finding(start_line=10, end_line=20, score=0.8)]
+        result, count = apply_context_tags(findings, tags, dampening=0.5)
+        assert count == 0
+        assert "context_tags" not in result[0].metadata
+        assert result[0].score == pytest.approx(0.8)
+
+    def test_dampening_factor_1_no_score_change(self) -> None:
+        tags = {("services/payment.py", 15): {"deliberate"}}
+        findings = [_make_finding(start_line=10, end_line=20, score=0.8)]
+        result, count = apply_context_tags(findings, tags, dampening=1.0)
+        assert count == 1
+        assert result[0].metadata["context_tags"] == ["deliberate"]
+        assert result[0].score == pytest.approx(0.8)
+
+    def test_dampening_factor_0_zeros_score(self) -> None:
+        tags = {("services/payment.py", 15): {"legacy"}}
+        findings = [_make_finding(start_line=10, end_line=20, score=0.8)]
+        result, count = apply_context_tags(findings, tags, dampening=0.0)
+        assert count == 1
+        assert result[0].score == pytest.approx(0.0)
+
+    def test_multiple_tags_merged(self) -> None:
+        tags = {
+            ("services/payment.py", 12): {"migration"},
+            ("services/payment.py", 18): {"legacy"},
+        }
+        findings = [_make_finding(start_line=10, end_line=20)]
+        result, count = apply_context_tags(findings, tags, dampening=0.5)
+        assert count == 1
+        assert set(result[0].metadata["context_tags"]) == {"migration", "legacy"}
+
+    def test_finding_without_file_path_untouched(self) -> None:
+        tags = {("services/payment.py", 15): {"migration"}}
+        f = Finding(
+            signal_type=SignalType.PATTERN_FRAGMENTATION,
+            severity=Severity.HIGH,
+            score=0.8,
+            title="No location",
+            description="Test",
+        )
+        result, count = apply_context_tags([f], tags, dampening=0.5)
+        assert count == 0
+        assert result[0].score == pytest.approx(0.8)
+
+    def test_empty_tags_dict(self) -> None:
+        findings = [_make_finding()]
+        result, count = apply_context_tags(findings, {}, dampening=0.5)
+        assert count == 0
+        assert result[0].score == pytest.approx(0.8)
+
+    def test_dampening_clamped_above_1(self) -> None:
+        tags = {("services/payment.py", 15): {"test"}}
+        findings = [_make_finding(score=0.8)]
+        result, count = apply_context_tags(findings, tags, dampening=1.5)
+        assert count == 1
+        # Should be clamped to 1.0
+        assert result[0].score == pytest.approx(0.8)
+
+    def test_dampening_clamped_below_0(self) -> None:
+        tags = {("services/payment.py", 15): {"test"}}
+        findings = [_make_finding(score=0.8)]
+        result, count = apply_context_tags(findings, tags, dampening=-0.5)
+        assert count == 1
+        # Should be clamped to 0.0
+        assert result[0].score == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Config integration
+# ---------------------------------------------------------------------------
+
+class TestContextDampeningConfig:
+    def test_default_dampening(self) -> None:
+        from drift.config import DriftConfig
+        cfg = DriftConfig()
+        assert cfg.context_dampening == 0.5
+
+    def test_custom_dampening(self) -> None:
+        from drift.config import DriftConfig
+        cfg = DriftConfig(context_dampening=0.3)
+        assert cfg.context_dampening == 0.3
+
+
+# ---------------------------------------------------------------------------
+# JSON output
+# ---------------------------------------------------------------------------
+
+class TestJsonContextOutput:
+    def test_context_tagged_count_in_json(self) -> None:
+        import datetime
+
+        from drift.models import RepoAnalysis
+        from drift.output.json_output import analysis_to_json
+
+        analysis = RepoAnalysis(
+            repo_path=Path("/test"),
+            analyzed_at=datetime.datetime.now(tz=datetime.UTC),
+            drift_score=0.5,
+            context_tagged_count=3,
+        )
+        data = json.loads(analysis_to_json(analysis))
+        assert data["context_tagged_count"] == 3
+
+    def test_context_tags_in_finding_metadata(self) -> None:
+        import datetime
+
+        from drift.models import RepoAnalysis
+        from drift.output.json_output import analysis_to_json
+
+        f = _make_finding(score=0.4)
+        f.metadata["context_tags"] = ["migration", "legacy"]
+        analysis = RepoAnalysis(
+            repo_path=Path("/test"),
+            analyzed_at=datetime.datetime.now(tz=datetime.UTC),
+            drift_score=0.5,
+            findings=[f],
+            context_tagged_count=1,
+        )
+        data = json.loads(analysis_to_json(analysis))
+        assert data["findings"][0]["metadata"]["context_tags"] == ["migration", "legacy"]
+
+
+# ---------------------------------------------------------------------------
+# SARIF output
+# ---------------------------------------------------------------------------
+
+class TestSarifContextTags:
+    def test_context_tags_in_sarif_result_properties(self) -> None:
+        import datetime
+
+        from drift.models import RepoAnalysis
+        from drift.output.json_output import findings_to_sarif
+
+        f = _make_finding(score=0.4)
+        f.metadata["context_tags"] = ["refactoring"]
+        analysis = RepoAnalysis(
+            repo_path=Path("/test"),
+            analyzed_at=datetime.datetime.now(tz=datetime.UTC),
+            drift_score=0.5,
+            findings=[f],
+            context_tagged_count=1,
+        )
+        sarif = json.loads(findings_to_sarif(analysis))
+        result = sarif["runs"][0]["results"][0]
+        assert result["properties"]["drift:context"] == ["refactoring"]
+
+    def test_no_context_tags_no_properties(self) -> None:
+        import datetime
+
+        from drift.models import RepoAnalysis
+        from drift.output.json_output import findings_to_sarif
+
+        f = _make_finding(score=0.4)
+        analysis = RepoAnalysis(
+            repo_path=Path("/test"),
+            analyzed_at=datetime.datetime.now(tz=datetime.UTC),
+            drift_score=0.5,
+            findings=[f],
+        )
+        sarif = json.loads(findings_to_sarif(analysis))
+        result = sarif["runs"][0]["results"][0]
+        assert "properties" not in result
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: scan + apply
+# ---------------------------------------------------------------------------
+
+class TestContextTagEndToEnd:
+    def test_scan_and_apply(self, tmp_path: Path) -> None:
+        fi = _write_python_file(tmp_path, "svc/handler.py", (
+            "import os\n"                         # line 1
+            "# drift:context migration\n"         # line 2
+            "class OldHandler:\n"                 # line 3
+            "    def process(self):\n"            # line 4
+            "        pass\n"                      # line 5
+        ))
+        tags = scan_context_tags([fi], tmp_path)
+        finding = _make_finding(
+            file_path="svc/handler.py",
+            start_line=2,
+            end_line=5,
+            score=0.6,
+        )
+        result, count = apply_context_tags([finding], tags, dampening=0.5)
+        assert count == 1
+        assert result[0].score == pytest.approx(0.3)
+        assert result[0].metadata["context_tags"] == ["migration"]
+
+    def test_untagged_finding_untouched(self, tmp_path: Path) -> None:
+        fi = _write_python_file(tmp_path, "svc/handler.py", (
+            "# drift:context migration\n"         # line 1
+            "class OldHandler:\n"                 # line 2
+            "    pass\n"                          # line 3
+            "\n"                                  # line 4
+            "class NewHandler:\n"                 # line 5
+            "    pass\n"                          # line 6
+        ))
+        tags = scan_context_tags([fi], tmp_path)
+        tagged_finding = _make_finding(
+            file_path="svc/handler.py",
+            start_line=1,
+            end_line=3,
+            score=0.8,
+        )
+        clean_finding = _make_finding(
+            file_path="svc/handler.py",
+            start_line=5,
+            end_line=6,
+            score=0.8,
+        )
+        result, count = apply_context_tags(
+            [tagged_finding, clean_finding], tags, dampening=0.5,
+        )
+        assert count == 1
+        assert result[0].score == pytest.approx(0.4)  # dampened
+        assert result[1].score == pytest.approx(0.8)  # untouched

--- a/tests/test_delta_first.py
+++ b/tests/test_delta_first.py
@@ -1,0 +1,222 @@
+"""Tests for ADR-005: Delta-First Score Interpretation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from drift.models import RepoAnalysis, TrendContext
+from drift.scoring.engine import delta_gate_pass
+
+# ── TrendContext ──────────────────────────────────────────────────────────
+
+
+class TestTrendContext:
+    def test_baseline_when_no_history(self):
+        from drift.analyzer import _build_trend_context
+
+        ctx = _build_trend_context(0.45, [])
+        assert ctx.direction == "baseline"
+        assert ctx.previous_score is None
+        assert ctx.delta is None
+        assert ctx.recent_scores == []
+        assert ctx.history_depth == 0
+
+    def test_improving(self):
+        from drift.analyzer import _build_trend_context
+
+        history = [{"drift_score": 0.50}, {"drift_score": 0.48}]
+        ctx = _build_trend_context(0.46, history)
+        assert ctx.direction == "improving"
+        assert ctx.previous_score == 0.48
+        assert ctx.delta == pytest.approx(-0.02, abs=1e-4)
+        assert ctx.history_depth == 2
+
+    def test_degrading(self):
+        from drift.analyzer import _build_trend_context
+
+        history = [{"drift_score": 0.40}]
+        ctx = _build_trend_context(0.42, history)
+        assert ctx.direction == "degrading"
+        assert ctx.delta == pytest.approx(0.02, abs=1e-4)
+
+    def test_stable_within_noise_floor(self):
+        from drift.analyzer import _build_trend_context
+
+        history = [{"drift_score": 0.500}]
+        ctx = _build_trend_context(0.503, history)
+        assert ctx.direction == "stable"
+
+    def test_recent_scores_capped_at_five(self):
+        from drift.analyzer import _build_trend_context
+
+        history = [{"drift_score": i * 0.01} for i in range(10)]
+        ctx = _build_trend_context(0.10, history)
+        assert len(ctx.recent_scores) == 5
+
+
+# ── delta_gate_pass ───────────────────────────────────────────────────────
+
+
+class TestDeltaGatePass:
+    def test_no_history_always_passes(self):
+        assert delta_gate_pass(0.99, [], fail_on_delta=0.01) is True
+
+    def test_passes_within_budget(self):
+        history = [{"drift_score": 0.40}, {"drift_score": 0.42}]
+        # Mean = 0.41, current = 0.44 → Δ = +0.03, budget = 0.05 → pass
+        assert delta_gate_pass(0.44, history, fail_on_delta=0.05) is True
+
+    def test_fails_exceeding_budget(self):
+        history = [{"drift_score": 0.40}, {"drift_score": 0.42}]
+        # Mean = 0.41, current = 0.50 → Δ = +0.09, budget = 0.05 → fail
+        assert delta_gate_pass(0.50, history, fail_on_delta=0.05) is False
+
+    def test_improving_always_passes(self):
+        history = [{"drift_score": 0.50}]
+        # Δ = -0.10, any positive budget → pass
+        assert delta_gate_pass(0.40, history, fail_on_delta=0.01) is True
+
+    def test_window_limits_history(self):
+        history = [{"drift_score": 0.90}] + [{"drift_score": 0.40}] * 5
+        # window=5 → only last 5 scores (all 0.40), mean = 0.40
+        # current = 0.42 → Δ = 0.02, budget = 0.05 → pass
+        assert delta_gate_pass(0.42, history, fail_on_delta=0.05, window=5) is True
+
+    def test_exact_boundary_passes(self):
+        history = [{"drift_score": 0.40}]
+        # Δ = 0.05 exactly == budget → passes (<=)
+        assert delta_gate_pass(0.45, history, fail_on_delta=0.05) is True
+
+
+# ── History persistence ───────────────────────────────────────────────────
+
+
+class TestHistoryPersistence:
+    def test_load_missing_file(self, tmp_path: Path):
+        from drift.analyzer import _load_history
+
+        assert _load_history(tmp_path / "nonexistent.json") == []
+
+    def test_load_corrupt_file(self, tmp_path: Path):
+        from drift.analyzer import _load_history
+
+        bad = tmp_path / "bad.json"
+        bad.write_text("not json!", encoding="utf-8")
+        assert _load_history(bad) == []
+
+    def test_roundtrip(self, tmp_path: Path):
+        from drift.analyzer import _load_history, _save_history
+
+        hfile = tmp_path / "history.json"
+        data = [{"drift_score": 0.42, "timestamp": "2025-01-01T00:00:00"}]
+        _save_history(hfile, data)
+        loaded = _load_history(hfile)
+        assert loaded == data
+
+    def test_save_caps_at_100(self, tmp_path: Path):
+        from drift.analyzer import _load_history, _save_history
+
+        hfile = tmp_path / "history.json"
+        data = [{"drift_score": i * 0.001} for i in range(150)]
+        _save_history(hfile, data)
+        loaded = _load_history(hfile)
+        assert len(loaded) == 100
+        assert loaded[0]["drift_score"] == pytest.approx(0.05)
+
+
+# ── Config ────────────────────────────────────────────────────────────────
+
+
+class TestDeltaConfig:
+    def test_default_delta_config(self):
+        from drift.config import DriftConfig
+
+        cfg = DriftConfig()
+        assert cfg.fail_on_delta is None
+        assert cfg.fail_on_delta_window == 5
+
+    def test_load_delta_config_from_dict(self):
+        from drift.config import DriftConfig
+
+        cfg = DriftConfig.model_validate({
+            "fail_on_delta": 0.05,
+            "fail_on_delta_window": 10,
+        })
+        assert cfg.fail_on_delta == 0.05
+        assert cfg.fail_on_delta_window == 10
+
+
+# ── JSON output ───────────────────────────────────────────────────────────
+
+
+class TestJsonTrendOutput:
+    def _make_analysis(self, trend: TrendContext | None = None) -> RepoAnalysis:
+        import datetime
+
+        return RepoAnalysis(
+            repo_path=Path("/tmp/test"),
+            analyzed_at=datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC),
+            drift_score=0.442,
+            trend=trend,
+        )
+
+    def test_json_includes_trend(self):
+        from drift.output.json_output import analysis_to_json
+
+        trend = TrendContext(
+            previous_score=0.457,
+            delta=-0.015,
+            direction="improving",
+            recent_scores=[0.472, 0.457, 0.442],
+            history_depth=3,
+            transition_ratio=0.0,
+        )
+        raw = analysis_to_json(self._make_analysis(trend))
+        data = json.loads(raw)
+        assert data["trend"]["direction"] == "improving"
+        assert data["trend"]["delta"] == -0.015
+        assert data["trend"]["previous_score"] == 0.457
+        assert len(data["trend"]["recent_scores"]) == 3
+
+    def test_json_trend_null_when_no_trend(self):
+        from drift.output.json_output import analysis_to_json
+
+        raw = analysis_to_json(self._make_analysis(None))
+        data = json.loads(raw)
+        assert data["trend"] is None
+
+    def test_sarif_includes_trend_properties(self):
+        from drift.output.json_output import findings_to_sarif
+
+        trend = TrendContext(
+            previous_score=0.457,
+            delta=-0.015,
+            direction="improving",
+            recent_scores=[0.472, 0.457, 0.442],
+            history_depth=3,
+            transition_ratio=0.0,
+        )
+        raw = findings_to_sarif(self._make_analysis(trend))
+        data = json.loads(raw)
+        run = data["runs"][0]
+        assert "properties" in run
+        assert run["properties"]["drift:trend"]["direction"] == "improving"
+
+    def test_sarif_no_properties_for_baseline(self):
+        from drift.output.json_output import findings_to_sarif
+
+        trend = TrendContext(
+            previous_score=None,
+            delta=None,
+            direction="baseline",
+            recent_scores=[],
+            history_depth=0,
+            transition_ratio=0.0,
+        )
+        raw = findings_to_sarif(self._make_analysis(trend))
+        data = json.loads(raw)
+        run = data["runs"][0]
+        assert "properties" not in run

--- a/tests/test_output_golden.py
+++ b/tests/test_output_golden.py
@@ -69,10 +69,12 @@ class TestJsonOutputGolden:
             "analyzed_at",
             "drift_score",
             "severity",
+            "trend",
             "summary",
             "modules",
             "findings",
             "suppressed_count",
+            "context_tagged_count",
         }
         assert set(data.keys()) == expected_keys
 


### PR DESCRIPTION
## Übersicht

Implementiert zwei voneinander abhängige Features, die in ADR-005 und ADR-006 spezifiziert wurden.

### ADR-005 — Delta-First Score Interpretation
- `TrendContext` Dataclass mit `direction`, `delta`, `recent_scores`
- Delta-Gate (`check_delta_gate`) blockiert bei konfiguriertem Budget-Überschuss
- History-Persistenz (`load_score_history` / `save_score_history`) mit 100-Einträge-Cap
- Trend-Feld in JSON- und SARIF-Output

### ADR-006 — Context Tags (`drift:context`)
- Neues Modul `src/drift/context_tags.py`
- Pragma-Syntax: `# drift:context <tag> [dampening=<0..1>]`
- Unterstützt Python und TypeScript/JavaScript
- Dampening-Faktor reduziert Score für explizit kontextualisierte Findings
- Integration in JSON-Output (`context_tagged_count`, `context_tags` in Findings)
- Integration in SARIF-Output (`properties.context_tags`)
- Anzeige im Rich-Terminal-Output

### Tests & Evidenz
- `tests/test_context_tags.py` — 363 Zeilen, 27 Tests
- `tests/test_delta_first.py` — 222 Zeilen, 20 Tests
- `benchmark_results/drift_self.json` — aktualisiertes Self-Analysis-Artefakt
- 476 Tests bestanden (75.32% Coverage) im pre-push Hook

### Dokumentation
- `EPISTEMICS.md` — epistemische Grenzen und Philosophie von drift
- `docs/adr/005-delta-first-score-interpretation.md`
- `docs/adr/006-context-tagging.md`