### PR TITLE
test: cover edge-case bootstrap repos

### DIFF
--- a/src/drift/signals/doc_impl_drift.py
+++ b/src/drift/signals/doc_impl_drift.py
@@ -302,6 +302,10 @@ class DocImplDriftSignal(BaseSignal):
         # Locate README
         readme_path = self._find_readme()
         if readme_path is None:
+            # Tiny bootstrap repos do not have enough structure for a missing
+            # README to be actionable architectural drift.
+            if len(parse_results) <= 1:
+                return findings
             findings.append(
                 Finding(
                     signal_type=self.signal_type,

--- a/tests/test_analysis_edge_cases.py
+++ b/tests/test_analysis_edge_cases.py
@@ -1,0 +1,42 @@
+"""Edge-case repository shape tests for public scan API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from drift.api import scan
+
+
+def test_scan_empty_repo_returns_informational_empty_result(tmp_path: Path) -> None:
+    result = scan(path=tmp_path)
+
+    assert isinstance(result["drift_score"], float)
+    assert result["drift_score"] == 0.0
+    assert result["severity"] == "info"
+    assert result["finding_count"] == 0
+    assert result["findings"] == []
+
+
+def test_scan_single_file_repo_returns_valid_analysis(tmp_path: Path) -> None:
+    (tmp_path / "main.py").write_text("def hello() -> int:\n    return 1\n")
+
+    result = scan(path=tmp_path)
+
+    assert isinstance(result["drift_score"], float)
+    assert result["severity"] == "info"
+    assert result["total_files"] == 1
+    assert result["finding_count"] == 0
+
+
+def test_scan_init_only_repo_returns_valid_analysis(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+
+    result = scan(path=tmp_path)
+
+    assert isinstance(result["drift_score"], float)
+    assert result["severity"] == "info"
+    assert result["total_files"] == 1
+    assert result["total_functions"] == 0
+    assert result["finding_count"] == 0


### PR DESCRIPTION
## Summary
- add scan API coverage for empty, single-file, and __init__-only repositories
- suppress the README-missing DIA finding for tiny bootstrap repositories where architectural drift is not actionable
- keep existing DIA README/ADR checks intact for repositories with meaningful structure

## Verification
- .venv/bin/pytest tests/test_analysis_edge_cases.py tests/test_dia_enhanced.py -q
- .venv/bin/ruff check src/drift/signals/doc_impl_drift.py tests/test_analysis_edge_cases.py