### PR TITLE
fix(eds): skip __init__ methods from EDS false-positive calculation

### DIFF
--- a/src/drift/signals/explainability_deficit.py
+++ b/src/drift/signals/explainability_deficit.py
@@ -152,8 +152,12 @@ class ExplainabilityDeficitSignal(BaseSignal):
             if func.loc < min_func_loc:
                 continue
 
-            # Check if there's a corresponding test
+            # Skip __init__ methods – the class docstring covers their intent
             base_name = func.name.split(".")[-1] if "." in func.name else func.name
+            if base_name == "__init__":
+                continue
+
+            # Check if there's a corresponding test
             has_test = base_name in test_targets
 
             explanation = _explanation_score(func, has_test)

--- a/tests/fixtures/ground_truth.py
+++ b/tests/fixtures/ground_truth.py
@@ -1019,6 +1019,41 @@ EDS_NESTED_LOOPS_TP = GroundTruthFixture(
     ],
 )
 
+EDS_INIT_TN = GroundTruthFixture(
+    name="eds_init_tn",
+    description="Complex __init__ without docstring → should NOT fire EDS",
+    files={
+        "models/__init__.py": "",
+        "models/pipeline.py": """\
+            class Pipeline:
+                def __init__(self, config, steps, hooks, timeout=30, retries=3):
+                    self.config = config
+                    self.steps = steps
+                    self.hooks = hooks
+                    self.timeout = timeout
+                    self.retries = retries
+                    if config.get("strict"):
+                        for step in steps:
+                            if not step.get("name"):
+                                raise ValueError("Each step must have a name")
+                            if step.get("timeout", 0) > timeout:
+                                raise ValueError("Step timeout exceeds pipeline timeout")
+                    for hook in hooks:
+                        if hook.get("on") not in ("start", "end", "error"):
+                            raise ValueError(f"Unknown hook event: {hook.get('on')}")
+                    self._state = "ready"
+        """,
+    },
+    expected=[
+        ExpectedFinding(
+            signal_type=SignalType.EXPLAINABILITY_DEFICIT,
+            file_path="models/pipeline.py",
+            should_detect=False,
+            description="Complex __init__ without docstring → EDS must not fire",
+        ),
+    ],
+)
+
 
 # ── Additional AVS fixtures ──────────────────────────────────────────────
 
@@ -2072,6 +2107,7 @@ ALL_FIXTURES: list[GroundTruthFixture] = [
     EDS_TRUE_NEGATIVE,
     EDS_STATE_MACHINE_TP,
     EDS_NESTED_LOOPS_TP,
+    EDS_INIT_TN,
     TVS_TRUE_POSITIVE,
     TVS_TRUE_NEGATIVE,
     SMS_TRUE_POSITIVE,


### PR DESCRIPTION
__init__ methods are structurally understood via the class docstring and should
  not be flagged for lacking a standalone docstring. Adds EDS_INIT_TN ground-truth
  fixture to prevent regression.

  ## Summary

  EDS was flagging `__init__` methods as underdocumented when they had high cyclomatic
  complexity but no standalone docstring. In practice, `__init__` intent is covered by
  the class-level docstring — a separate docstring on `__init__` is not idiomatic Python.
  This was causing noisy false positives on real-world repos (pydantic, paramiko).

  Fixed by checking `base_name == "__init__"` early in the findings loop and skipping
  before a finding is appended. The check handles both `__init__` and `ClassName.__init__`
  since the parser emits both forms.

  ## Related issue

  Fixes #15 

  ## Policy criterion served

  - [x] Signal precision (fewer false positives/negatives)

  ## First contribution?

  - [x] This is my first contribution to drift

  ## Type of change

  - [x] Bug fix

  ## Validation

  - [x] `pytest` passes locally
  - [x] `ruff check src/ tests/` passes locally
  - [x] `mypy src/drift` passes locally
  - [x] `drift self` delta checked — score 0.56, Δ -0.022 (improving)
  - [x] Added/updated tests for behavioral changes

  ## Empirical evidence (required for new features)

  - [x] This PR introduces no new feature (skip section)

  ## Checklist

  - [x] PR is focused on one concern
  - [x] Public docs updated (README/docs-site) if needed — N/A
  - [x] Changelog entry added if user-visible — not added (patch fix, maintainer discretion)
  - [x] No unrelated files included

  ## Notes for reviewers

  `mutation_benchmark.py` has a pre-existing parse failure on master unrelated to this
  change — verified by running it against the unmodified codebase and reproducing the
  same error.

  Note: developed with AI assistance (Claude Code).