### PR TITLE
test(hsc): add multiline secret detection tests

### DIFF
--- a/tests/test_hardcoded_secret.py
+++ b/tests/test_hardcoded_secret.py
@@ -295,3 +295,96 @@ class TestHSCEdgeCases:
         signal = HardcodedSecretSignal(repo_path=tmp_path)
         findings = signal.analyze([_make_pr()], {}, DriftConfig())
         assert len(findings) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Multi-line secrets
+# ---------------------------------------------------------------------------
+
+
+class TestMultilineSecrets:
+    def test_pem_private_key_detected(self, tmp_path: Path) -> None:
+        # Triple-quoted PEM key — common in config files and CI scripts
+        _write_source(
+            tmp_path, "config.py",
+            '''\
+            private_key = """-----BEGIN RSA PRIVATE KEY-----
+            MIIEowIBAAKCAQEA2a2rwplBQLzHPZe5RJaItBWFkMVaVEFVCpkJuGZCqqDSX/s6
+            bMECBEmzKFBMFZGQfJ7sM3N4zGAVDGRMkHVFHfCkBjIRzLv0bKTjQ8IkK1l2mPFN
+            y3qXCPZGhJqJVJuZiKxjM5TbLBLpC1J4JFHxlXJzKVZiT6ygGdLK5oaVZdPxLvWm
+            -----END RSA PRIVATE KEY-----"""
+            ''',
+        )
+        signal = HardcodedSecretSignal(repo_path=tmp_path)
+        findings = signal.analyze([_make_pr()], {}, DriftConfig())
+        assert len(findings) >= 1
+        assert findings[0].signal_type == SignalType.HARDCODED_SECRET
+        assert "private_key" in findings[0].title
+
+    def test_base64_token_block_detected(self, tmp_path: Path) -> None:
+        # Multi-line triple-quoted base64 token — high entropy, long string
+        _write_source(
+            tmp_path, "config.py",
+            '''\
+            api_key = """
+            dGhpcyBpcyBhIHZlcnkgbG9uZyBiYXNlNjQgZW5jb2RlZCB0b2tlbiB0aGF0
+            c2hvdWxkIGJlIGRldGVjdGVkIGJ5IHRoZSBoYXJkY29kZWQgc2VjcmV0IHNpZ25hbA==
+            """
+            ''',
+        )
+        signal = HardcodedSecretSignal(repo_path=tmp_path)
+        findings = signal.analyze([_make_pr()], {}, DriftConfig())
+        assert len(findings) >= 1
+        assert "api_key" in findings[0].title
+
+    def test_multiline_connection_string_with_password_detected(
+        self, tmp_path: Path
+    ) -> None:
+        # Implicit string concatenation — joined into one constant by Python
+        _write_source(
+            tmp_path, "config.py",
+            '''\
+            db_password = (
+                "postgresql://admin:S3cr3tP@ssw0rd123!"
+                "@prod-db.internal:5432/appdb"
+            )
+            ''',
+        )
+        signal = HardcodedSecretSignal(repo_path=tmp_path)
+        findings = signal.analyze([_make_pr()], {}, DriftConfig())
+        assert len(findings) >= 1
+        assert "db_password" in findings[0].title
+
+    def test_multiline_sql_query_not_flagged(self, tmp_path: Path) -> None:
+        # Non-secret variable name — should never trigger regardless of length
+        _write_source(
+            tmp_path, "queries.py",
+            '''\
+            sql_query = """
+                SELECT id, name, email
+                FROM users
+                WHERE active = true
+                AND created_at > '2024-01-01'
+            """
+            ''',
+        )
+        signal = HardcodedSecretSignal(repo_path=tmp_path)
+        findings = signal.analyze([_make_pr("queries.py")], {}, DriftConfig())
+        assert len(findings) == 0
+
+    def test_multiline_help_text_not_flagged(self, tmp_path: Path) -> None:
+        # Long descriptive string mentioning "secret" only as a word, not a var name
+        _write_source(
+            tmp_path, "config.py",
+            '''\
+            HELP_TEXT = """
+                This application requires the following environment variables:
+                - SECRET_KEY: set this to a random value before deploying
+                - DATABASE_URL: connection string for the primary database
+                - REDIS_URL: connection string for the cache layer
+            """
+            ''',
+        )
+        signal = HardcodedSecretSignal(repo_path=tmp_path)
+        findings = signal.analyze([_make_pr()], {}, DriftConfig())
+        assert len(findings) == 0


### PR DESCRIPTION
#Summary

HSC had 21 tests covering single-line secrets but no coverage for
  multi-line patterns common in real codebases. Added a new
  `TestMultilineSecrets` class in `tests/test_hardcoded_secret.py` with
  5 tests:

  **True positives (should detect):**
  - Triple-quoted RSA PEM private key assigned to `private_key`
  - Triple-quoted base64 token block assigned to `api_key`
  - Implicit string concatenation (`"part1" "part2"`) — Python joins these
    into a single `ast.Constant` at parse time, so the signal sees one
    long string

  **True negatives (should not detect):**
  - Multi-line SQL query — variable name `sql_query` does not match
    `_SECRET_VAR_RE`
  - Multi-line help text — the word "SECRET_KEY" appears inside the string
    value, not as the variable name

  ## Related issue

  Fixes #22 

  ## Policy criterion served

  - [x] Signal precision (fewer false positives/negatives)

  ## Type of change

  - [x] Test-only change

  ## Validation

  - [x] `pytest tests/test_hardcoded_secret.py -v --tb=short` — 29 passed
  - [x] `ruff check src/ tests/` passes locally
  - [x] `mypy src/drift` passes locally
  - [x] No source code changes — pure test addition

  ## Empirical evidence (required for new features)

  - [x] This PR introduces no new feature (skip section)

  ## Checklist

  - [x] PR is focused on one concern
  - [x] Public docs updated if needed — N/A
  - [x] Changelog entry added if user-visible — N/A (test-only)
  - [x] No unrelated files included

  ## Notes for reviewers

  No signal logic was changed. Multi-line strings are already handled
  correctly — triple-quoted strings are just `ast.Constant` nodes with
  `\n` in the value. These tests document and lock in that behaviour.