### PR TITLE
test: add resilience test for JSON extraction from noisy CLI output

### DIFF
--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -361,6 +361,41 @@ def test_findings_to_sarif_message_text_with_fix_and_recommendation() -> None:
     assert "FIX:" in result_text
 
 
+def test_json_report_extractable_from_noisy_cli_output() -> None:
+    """Resilience: JSON report can be extracted when surrounded by non-JSON progress text.
+
+    CI integrations and agent workflows may receive CLI output that mixes
+    progress updates or status lines with the final JSON report.  This test
+    verifies that the JSON object produced by analysis_to_json can still be
+    recovered from such noisy output and that its key contract fields remain
+    intact after extraction.
+    """
+    analysis = _sample_analysis()
+    clean_json = analysis_to_json(analysis)
+
+    # Simulate the kind of noisy output a real CLI run might produce:
+    # progress banners before the JSON and a status line after it.
+    noisy_output = (
+        "Scanning repository…\n"
+        "Discovering files: 12 found\n"
+        "Running signal checks…\n"
+        + clean_json
+        + "\nAnalysis complete. Exit 0.\n"
+    )
+
+    # Extraction strategy: locate the outermost JSON object by finding the
+    # first '{' and the last '}', then parse the substring.
+    start = noisy_output.index("{")
+    end = noisy_output.rindex("}") + 1
+    extracted = noisy_output[start:end]
+
+    payload = json.loads(extracted)
+
+    assert payload["drift_score"] == 0.73
+    assert payload["analysis_status"]["status"] == "complete"
+    assert payload["summary"]["total_files"] == 12
+
+
 def test_findings_to_sarif_rule_help_for_known_signal() -> None:
     """ADR-052: SARIF rule 'help' field is populated for signals with a recommender."""
     finding = Finding(


### PR DESCRIPTION
## Summary
Adds one narrow resilience test to `tests/test_json_output.py` that verifies the final JSON report can be correctly extracted and parsed when extra non-JSON text (progress updates, status lines) appears around it in CLI output.

## What was changed
- `tests/test_json_output.py` — added `test_json_report_extractable_from_noisy_cli_output`

## What was NOT changed
- All 14 existing JSON and SARIF contract tests are preserved unchanged
- No changes to `json_output.py` or any production code
- No JSON Schema file added
- No CLI integration test / subprocess invocation

## How the test works
1. Generates a clean JSON report via `analysis_to_json`
2. Wraps it with realistic noisy CLI text (progress banners before, status line after)
3. Extracts the JSON using the `first { … last }` strategy that CI consumers use in practice
4. Asserts key contract fields (`drift_score`, `analysis_status.status`, `summary.total_files`) are intact

## Test results
pytest tests/test_json_output.py -q
15 passed in 0.77s


## Related
Closes #198 