### PR TITLE
docs: position Copilot Chat before MCP, remove deprecated task tools from MCP surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,11 @@ Every finding includes a human-readable `reason` and a concrete `next_action`. F
 
 ## 🔌 Works with
 
-| AI Tools (MCP) | Copilot Chat | CI/CD | Git Hooks | Install |
+| Copilot Chat | CI/CD | Git Hooks | Install | MCP (advanced) |
 |:---:|:---:|:---:|:---:|:---:|
-| Cursor · Claude Code · Copilot | `/drift-fix-plan` · `/drift-export-report` · `/drift-auto-fix-loop` | GitHub Actions · SARIF | pre-commit · pre-push | pip · pipx · uvx · Homebrew · Docker |
+| `/drift-fix-plan` · `/drift-export-report` · `/drift-auto-fix-loop` | GitHub Actions · SARIF | pre-commit · pre-push | pip · pipx · uvx · Homebrew · Docker | Cursor · Claude Code · Copilot |
 
-`Bootstrap:` `drift init --mcp --ci --hooks` scaffolds all integrations at once. Copilot Chat: `drift kit init` (once per repo → `/drift-fix-plan`). Language support: Python (full) · TypeScript/TSX 17/24 via `pip install 'drift-analyzer[typescript]'` · [language matrix](docs/language-support-matrix.md)
+`Start here (no MCP needed):` `drift kit init` → `/drift-fix-plan` in VS Code Copilot Chat. `Full CI + MCP:` `drift init --mcp --ci --hooks`. Language support: Python (full) · TypeScript/TSX 17/24 via `pip install 'drift-analyzer[typescript]'` · [language matrix](docs/language-support-matrix.md)
 
 ### GitHub Actions
 
@@ -182,7 +182,50 @@ jobs:
 
 **Outputs available** for downstream steps: `drift-score`, `grade`, `severity`, `finding-count`, `badge-svg`
 
-### MCP / AI Tools
+### VS Code Copilot Chat — no MCP needed
+
+`drift kit init` (once per repo) scaffolds prompt files for VS Code Copilot Chat. After `drift analyze`, drift writes `.vscode/drift-session.json` and shows a **Copilot Chat Handoff** panel in the terminal. Open VS Code Copilot Chat and call:
+
+| Slash command | What it does |
+|---|---|
+| `/drift-fix-plan` | Prioritized repair tasks from the latest findings |
+| `/drift-export-report` | Self-contained findings report as Markdown |
+| `/drift-auto-fix-loop` | Step through findings one-at-a-time with confirm/skip gates |
+
+**One-time setup — one command:**
+```bash
+drift kit init   # scaffolds prompt files + VS Code settings — run once per repo
+```
+
+No extension install needed. `drift kit init` creates `.github/prompts/` with all three prompt files and merges `chat.promptFilesLocations` into `.vscode/settings.json` without touching your existing keys. Idempotent — safe to re-run.
+
+📖 [VS Code Copilot Chat Workflow guide →](https://mick-gsk.github.io/drift/guides/vscode-copilot-workflow/)
+
+### VS Code Extension
+
+The `vscode-drift` extension shows findings as inline **CodeLens** annotations — no terminal needed.
+
+```
+auth/handler.py             [Drift · C · score 0.71 · 3 findings (1 high, 2 medium)]
+  def authenticate(...):    [Drift · PFS · co-change coupling to auth/service.py · high]
+```
+
+**Install from VSIX:**
+```bash
+pip install drift-analyzer          # drift must be on PATH
+code --install-extension vscode-drift-0.1.0.vsix
+```
+
+Download the VSIX from the [Releases](https://github.com/mick-gsk/drift/releases) page, or build from source:
+```bash
+cd extensions/vscode-drift && npm install && npm run compile
+```
+
+📖 [Extension README →](extensions/vscode-drift/README.md)
+
+### MCP / AI Tools — advanced execution layer
+
+> **This is the advanced path.** MCP is valuable for active agent loops with deterministic tool contracts — but it adds setup friction and consumes model context budget. Start with the Copilot Chat path above if you haven't already.
 
 Cursor, Claude Code, and Copilot call drift directly via MCP server — the agent runs a full session loop:
 
@@ -192,6 +235,8 @@ Cursor, Claude Code, and Copilot call drift directly via MCP server — the agen
 | **Code** | `drift_nudge` | Real-time `safe_to_commit` check after each edit |
 | **Verify** | `drift_diff` | Full before/after comparison before push |
 | **Learn** | `drift_feedback` | Mark findings as TP/FP — calibrates signal weights |
+
+The execution core (`brief`, `nudge`, `diff`, `fix-plan`, `feedback`) covers most agent loops. The full tool surface is documented in [integrations →](https://mick-gsk.github.io/drift/integrations/).
 
 #### Copy-paste MCP config
 
@@ -252,48 +297,6 @@ repos:
 ```
 
 📖 [Full integration guide →](https://mick-gsk.github.io/drift/integrations/) · [drift-pre-commit repo →](https://github.com/mick-gsk/drift-pre-commit)
-
-### VS Code Extension
-
-The `vscode-drift` extension shows findings as inline **CodeLens** annotations — no terminal needed.
-
-```
-auth/handler.py             [Drift · C · score 0.71 · 3 findings (1 high, 2 medium)]
-  def authenticate(...):    [Drift · PFS · co-change coupling to auth/service.py · high]
-```
-
-**Install from VSIX:**
-```bash
-pip install drift-analyzer          # drift must be on PATH
-code --install-extension vscode-drift-0.1.0.vsix
-```
-
-Download the VSIX from the [Releases](https://github.com/mick-gsk/drift/releases) page, or build from source:
-```bash
-cd extensions/vscode-drift && npm install && npm run compile
-```
-
-📖 [Extension README →](extensions/vscode-drift/README.md)
-
-### VS Code Copilot Chat — slash commands after `drift analyze`
-
-After `drift analyze`, drift writes `.vscode/drift-session.json` and shows a
-**Copilot Chat Handoff** panel in the terminal. Open VS Code Copilot Chat and call:
-
-| Slash command | What it does |
-|---|---|
-| `/drift-fix-plan` | Prioritized repair tasks from the latest findings |
-| `/drift-export-report` | Self-contained findings report as Markdown |
-| `/drift-auto-fix-loop` | Step through findings one-at-a-time with confirm/skip gates |
-
-**One-time setup — one command:**
-```bash
-drift kit init   # scaffolds prompt files + VS Code settings — run once per repo
-```
-
-No extension install needed. `drift kit init` creates `.github/prompts/` with all three prompt files and merges `chat.promptFilesLocations` into `.vscode/settings.json` without touching your existing keys. Idempotent — safe to re-run.
-
-📖 [VS Code Copilot Chat Workflow guide →](https://mick-gsk.github.io/drift/guides/vscode-copilot-workflow/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ jobs:
 drift kit init   # scaffolds prompt files + VS Code settings — run once per repo
 ```
 
-No extension install needed. `drift kit init` creates `.github/prompts/` with all three prompt files and merges `chat.promptFilesLocations` into `.vscode/settings.json` without touching your existing keys. Idempotent — safe to re-run.
+No additional Drift-specific extension install is needed for this workflow; you still need VS Code with GitHub Copilot Chat installed/enabled. `drift kit init` creates `.github/prompts/` with the three user-facing slash-command prompt files shown above, plus `drift-feature-guardrails.prompt.md`, and merges `chat.promptFilesLocations` into `.vscode/settings.json` without touching your existing keys. Idempotent — safe to re-run.
 
 📖 [VS Code Copilot Chat Workflow guide →](https://mick-gsk.github.io/drift/guides/vscode-copilot-workflow/)
 

--- a/src/drift/mcp_server.py
+++ b/src/drift/mcp_server.py
@@ -1043,7 +1043,7 @@ async def drift_session_end(
 
 
 # ---------------------------------------------------------------------------
-# MCP Tools — Task-queue leasing (multi-agent coordination)
+# Legacy task-queue functions (unregistered; backward compatibility)
 # DEPRECATED: These tools will be removed in v3.0.
 # Removed from @mcp.tool() registration to reduce default MCP surface (Issue #545).
 # The underlying functions remain callable for backward compatibility.

--- a/src/drift/mcp_server.py
+++ b/src/drift/mcp_server.py
@@ -32,11 +32,11 @@ Tool surface (v3 — sessions):
     drift_capture_intent  — Extract and persist a structured intent from user input
     drift_verify_intent   — Verify a build artifact against a captured intent
     drift_feedback_for_agent — Prioritised action list from verify state
-    drift_task_claim      — (deprecated) Claim a task from the fix-plan queue
-    drift_task_renew      — (deprecated) Extend an active task lease
-    drift_task_release    — (deprecated) Release a claimed task
-    drift_task_complete   — (deprecated) Mark a claimed task as completed
-    drift_task_status     — (deprecated) Show full task queue status
+    drift_task_claim      — (deprecated, unregistered) Claim a task from the fix-plan queue
+    drift_task_renew      — (deprecated, unregistered) Extend an active task lease
+    drift_task_release    — (deprecated, unregistered) Release a claimed task
+    drift_task_complete   — (deprecated, unregistered) Mark a claimed task as completed
+    drift_task_status     — (deprecated, unregistered) Show full task queue status
 
 Decision: ADR-022
 Refactored: Issue #378 — business logic extracted to router modules
@@ -1045,10 +1045,11 @@ async def drift_session_end(
 # ---------------------------------------------------------------------------
 # MCP Tools — Task-queue leasing (multi-agent coordination)
 # DEPRECATED: These tools will be removed in v3.0.
+# Removed from @mcp.tool() registration to reduce default MCP surface (Issue #545).
+# The underlying functions remain callable for backward compatibility.
 # ---------------------------------------------------------------------------
 
 
-@mcp.tool()  # drift:ignore[DCA]
 async def drift_task_claim(
     session_id: Annotated[
         str, Field(description="The active session ID from drift_session_start.")
@@ -1081,7 +1082,6 @@ async def drift_task_claim(
     )
 
 
-@mcp.tool()  # drift:ignore[DCA]
 async def drift_task_renew(
     session_id: Annotated[
         str, Field(description="The active session ID from drift_session_start.")
@@ -1108,7 +1108,6 @@ async def drift_task_renew(
     )
 
 
-@mcp.tool()  # drift:ignore[DCA]
 async def drift_task_release(
     session_id: Annotated[
         str, Field(description="The active session ID from drift_session_start.")
@@ -1135,7 +1134,6 @@ async def drift_task_release(
     )
 
 
-@mcp.tool()  # drift:ignore[DCA]
 async def drift_task_complete(
     session_id: Annotated[
         str, Field(description="The active session ID from drift_session_start.")
@@ -1167,7 +1165,6 @@ async def drift_task_complete(
     )
 
 
-@mcp.tool()  # drift:ignore[DCA]
 async def drift_task_status(
     session_id: Annotated[
         str, Field(description="The active session ID from drift_session_start.")
@@ -1974,11 +1971,9 @@ _EXPORTED_MCP_TOOLS = (
     drift_session_status,
     drift_session_update,
     drift_session_end,
-    drift_task_claim,
-    drift_task_renew,
-    drift_task_release,
-    drift_task_complete,
-    drift_task_status,
+    # drift_task_claim, drift_task_renew, drift_task_release, drift_task_complete,
+    # drift_task_status removed from MCP surface (Issue #545). Functions remain
+    # callable for backward compatibility; will be deleted in v3.0.
     drift_session_trace,
     drift_map,
     drift_guard_contract,


### PR DESCRIPTION
Closes #545

## Summary

This PR implements the scope described in the Issue #545 maintainer comment: **subtraction and surface curation**, not a new feature.

### Changes

**README.md**
- Promoted `### VS Code Copilot Chat` section above `### MCP / AI Tools` so the lightweight `drift kit init` path is the first AI integration a user encounters
- Reordered the "Works with" summary table: Copilot Chat first, MCP listed last as advanced
- Renamed the MCP section to `### MCP / AI Tools — advanced execution layer` with an explicit callout to start with the Copilot Chat path
- Surfaced the execution core (`brief`, `nudge`, `diff`, `fix-plan`, `feedback`) as the relevant MCP subset rather than implying the full 35-tool catalog
- Updated the bootstrap note to lead with `drift kit init` (no MCP needed) before the full `drift init --mcp --ci --hooks`

**src/drift/mcp_server.py**
- Removed `@mcp.tool()` registration from the 5 deprecated task-leasing tools (`drift_task_claim`, `drift_task_renew`, `drift_task_release`, `drift_task_complete`, `drift_task_status`)
- Removed them from `_EXPORTED_MCP_TOOLS` — they no longer appear in the MCP tool catalog
- Wrapper functions remain callable for backward compatibility; planned for deletion in v3.0 (as already documented in `mcp_legacy.py`)

### What this does NOT do
- Does not remove MCP
- Does not add a new feature surface
- Does not break any existing tests (all task tool tests pass; functions remain callable from Python)

### Tests
`test_mcp_server_task_tools_boost.py`, `test_tool_metadata.py`, `test_advisory_semantic.py` all pass.