### PR TITLE
docs: split specs and evidence updates

### DIFF
--- a/.github/skills/karpathy-guidelines/SKILL.md
+++ b/.github/skills/karpathy-guidelines/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: karpathy-guidelines
+description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
+license: MIT
+---
+
+# Karpathy Guidelines
+
+Behavioral guidelines to reduce common LLM coding mistakes, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 ## [2.50.0] - 2026-05-02
 
+<<<<<<< HEAD
 Short version: split cockpit ui and backend package
+=======
+Short version: merge main into feat/adr100-phase7a-cleanup (resolve README badge conflict)
+
+### Changed
+- merge main into feat/adr100-phase7a-cleanup (resolve README badge conflict)
+- add script categories to catalog.py + agent-facing scripts/README.md
+- snapshot all current workspace changes
+
+### Fixed
+- install workspace packages before root in all CI workflows (ADR-100 monorepo)
+- ruff imports, shellcheck backticks, secrets baseline, smoke-pr deps (CI cleanup)
+- ruff I001 in packages/, shellcheck YAML syntax in workflows, fix end-of-files
+- remove UTF-8 BOM and ensure end-of-file newlines in packages/
+- add explicit mypy re-exports to ADR-100 sys.modules stubs
+- unblock CI gates for PR checks
+- install workspace packages in drift-agent-gate workflow
+- resolve failing CI checks for PR 576
+>>>>>>> 18ee6ada0 (chore: snapshot all current workspace changes)
 
 ### Added
 - split cockpit ui and backend package

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,102 @@
+# Drift
+
+A static-analysis tool that measures architectural erosion in Python (and
+TypeScript) codebases via a set of Signals, aggregates them into a Composite
+Score, and emits actionable Findings for humans and agents.
+
+## Language
+
+**Signal**:
+A single measurable indicator of architectural erosion. Each signal has a
+unique ID (e.g. `PFS`, `AVS`, `MDS`), a scope (`file_local` or
+`cross_file`), and emits zero or more Findings.
+_Avoid_: metric, check, rule, detector.
+
+**Finding**:
+One emitted result from a Signal run, carrying `severity`, `reason`, and
+`next_action`. Findings are the machine-readable output agents and humans act on.
+_Avoid_: issue, warning, result, alert.
+
+**Composite Score**:
+The weighted aggregation of all active Signal scores for a repository or
+file. Ranges 0–100; lower is worse.
+_Avoid_: total score, final score, overall score.
+
+**Ingestion**:
+The pipeline stage that discovers files, parses AST and git history, and
+produces the data model (FileRecord, HistoryRecord) that Signals consume.
+_Avoid_: parsing, scanning (reserve `scan` for the `drift scan` CLI command).
+
+**Gate**:
+A pre-push or pre-commit enforcement check that blocks progress when a
+policy condition is not met (e.g. missing evidence artifact, failing
+audit freshness check).
+_Avoid_: guard, check (use `check` only for `make check`), hook (use
+`hook` only for git-hook mechanics).
+
+**Session**:
+An MCP-managed stateful interaction context that persists signal baselines,
+replay queues, guardrail decisions, and handover artifacts across multiple
+agent turns.
+_Avoid_: conversation, run, context.
+
+**Nudge**:
+A fast post-edit regression check (`drift_nudge`) that re-runs only
+file-local Signals against changed files to detect immediate degradation.
+Distinguished from a full Scan by its <1 s latency target.
+_Avoid_: quick scan, fast check.
+
+**Baseline**:
+A stored Composite Score snapshot used by Nudge and Diff to measure
+direction of change (`improving` / `stable` / `degrading`).
+_Avoid_: reference score, previous score.
+
+**Scan** (`drift scan` / `drift_scan`):
+A full analysis run across the entire repository, computing all Signals
+including cross-file scope. Slower than a Nudge; produces the authoritative
+Composite Score.
+_Avoid_: analysis (reserve for `drift analyze`), full run.
+
+**Brief** (`drift_brief`):
+A concise, agent-readable summary of the current architectural state of a
+file or directory, derived from a Scan.
+_Avoid_: summary, overview, report.
+
+**Evidence Artifact**:
+A versioned JSON file under `benchmark_results/` that records precision,
+recall, and test results for a `feat:` commit. Required by Gate 2b before push.
+_Avoid_: benchmark file, result file.
+
+**ADR** (Architecture Decision Record):
+A short document under `docs/decisions/` recording that a hard-to-reverse
+architectural decision was made, why, and what alternatives were considered.
+Status: `proposed` → `accepted` | `rejected` | `superseded`.
+_Avoid_: design doc, decision note.
+
+## Relationships
+
+- A **Scan** runs N **Signals** over the output of one **Ingestion**.
+- Each **Signal** emits 0..N **Findings** per file or repo.
+- All Signal scores are aggregated into one **Composite Score**.
+- A **Nudge** re-runs only `file_local` Signals against changed files;
+  `cross_file` Signals are estimated from the last **Baseline**.
+- A **Session** holds one active **Baseline** and a replay queue of
+  prior Scan results.
+- A **Gate** validates that **Evidence Artifacts** and audit freshness
+  are in sync with the current commit before push is allowed.
+
+## Example dialogue
+
+> **Dev:** "The Nudge shows direction `degrading` — should I revert?"
+> **Maintainer:** "Check `revert_recommended` first. If `true` and `safe_to_commit: false`, revert. If just `degrading` but `safe_to_commit: true`, the Finding may still be worth fixing before push."
+
+> **Dev:** "Why did Gate 2b fail?"
+> **Maintainer:** "A `feat:` commit requires a versioned Evidence Artifact in `benchmark_results/`. Run `make generate_feature_evidence` to produce it."
+
+## Flagged ambiguities
+
+- "scan" vs. "analyze": `drift scan` is the CLI subcommand for a targeted
+  file-set scan; `drift analyze` is the full-repo analysis. Do not use
+  interchangeably.
+- "signal" vs. "check": signal is the Drift-specific term; avoid "check"
+  as a synonym to prevent confusion with `make check` (the CI target).

--- a/docs/COPILOT_PRO_AGENTS_README.md
+++ b/docs/COPILOT_PRO_AGENTS_README.md
@@ -1,0 +1,97 @@
+# GitHub Copilot Pro+ Agent Adaptations
+
+This directory contains **GitHub Copilot Pro+ adapted** versions of the OpenAI Agents SDK documentation. These documents show how to use the Agents SDK when running within a **GitHub Copilot Pro+ subscription** context, where authentication and model selection are handled by the host environment.
+
+## What's Different in Copilot Pro+?
+
+| Aspect | Direct SDK (OPENAI_API_KEY) | GitHub Copilot Pro+ (Host-Provided) |
+|--------|----------------------------|-------------------------------------|
+| **Authentication** | You provide API key in code or env var | Host (GitHub) provides session token automatically |
+| **Model Selection** | Hardcoded in agent definition: `model: "gpt-4o"` | Host injects model at runtime; do NOT hardcode |
+| **User Context** | You pass via `context` parameter in each run | Host provides subscription/workspace context; you inject into run context |
+| **Cost Model** | Per-request metering | Flat subscription (usage-included) |
+| **Example Setup** | `export OPENAI_API_KEY=...` then run | Run directly in Copilot Pro+ environment (no setup needed) |
+
+## Documentation Files
+
+### 1. Harness Engineering Golden Principles (with Quickstart)
+**File**: [../agent-harness-golden-principles.md](../agent-harness-golden-principles.md)
+
+The foundational framework for agent-friendly repositories, including:
+- ✓ What is Harness Engineering (three pillars: context, constraints, entropy)
+- ✓ **Quickstart section** with 6 reality-tested examples (3 Python + 3 TypeScript)
+- ✓ Three pattern families: basic specialist, tool-using specialist, multi-specialist triage
+- ✓ Agent loop state and trace inspection
+- ✓ Agents SDK orientation with repo-specific guidance
+
+**Start here if**: You're new to agents or want to understand the broader harness context.
+
+### 2. Agent Definitions: Copilot Pro+ Edition
+**File**: [../agent-definitions-copilot-adapted.md](../agent-definitions-copilot-adapted.md)
+
+Adapted OpenAI SDK Agent Definitions guide with:
+- ✓ Three agent patterns tested: weather bot with tools, calendar extractor with structured output, local context passing
+- ✓ Removed model hardcoding from all examples
+- ✓ Added host-auth comments and boundary explanations
+- ✓ Comparison table: Direct SDK vs. Copilot Pro+
+- ✓ Local context isolation rules for security
+
+**Reality-Test Status**: 3/3 Python patterns verified working with agents SDK
+
+### 3. Models and Providers: Copilot Pro+ Edition
+**File**: [../models-and-providers-copilot-adapted.md](../models-and-providers-copilot-adapted.md)
+
+Adapted OpenAI SDK Models and Providers guide with:
+- ✓ **Critical warning**: Model selection is NOT your choice in Copilot Pro+ (host decides based on subscription tier)
+- ✓ Comparison table: What you can/cannot control
+- ✓ Model-to-subscription tier mapping
+- ✓ Migration guide: removing model hardcoding from Direct SDK code
+- ✓ Reasoning and tool-use patterns adapted for host-controlled models
+- ✓ Instructions-based guidance instead of model-selection tuning
+
+**Key Insight**: Copilot Pro+ removes model selection from the developer; you focus on agent instructions and capabilities, host provides the best available model
+
+## How to Use These Docs
+
+1. **If you're completely new to agents**: Start with the **Quickstart section** in [Agent Harness Golden Principles](../agent-harness-golden-principles.md#quickstart) to learn the basics (6 tested examples, Python + TypeScript).
+2. **If you're designing an agent**: Use [Agent Definitions](../agent-definitions-copilot-adapted.md) to understand configuration, tools, structured output, and context boundaries.
+3. **If you're confused about model selection**: Read [Models and Providers (Copilot Pro+ Adapted)](../models-and-providers-copilot-adapted.md) — **the short answer: you don't choose the model; GitHub's subscription determines it.**
+4. **If you want to understand the harness framework**: Read [Agent Harness Golden Principles](../agent-harness-golden-principles.md) for the broader context (three pillars, common mistakes, agent-oriented repo design).
+5. **If you have OPENAI_API_KEY**: Use the [official OpenAI Agents SDK docs](https://developers.openai.com/docs/agents) instead (these adaptations are for Copilot Pro+ hosted flows only).
+6. **If you're migrating from Direct SDK**: Check the "Adapting Existing Agents for Copilot Pro+" section in [Models and Providers](../models-and-providers-copilot-adapted.md) for removal checklist.
+
+## Key Principles for Copilot Pro+ Agents
+
+| Principle | Why |
+|-----------|-----|
+| **Do NOT hardcode `model`** | Host injects it at runtime; hardcoding causes conflicts or is silently ignored. |
+| **Do NOT set `OPENAI_DEFAULT_MODEL`** | Host provides the model; env var is not used. |
+| **Focus on instructions, not tuning** | You describe the task; host provides the best available model for your subscription. |
+| **Keep instructions static** | Static instructions are deterministic and easier to test; use callbacks only when user/tenant context truly changes behavior. |
+| **Use local context, not model context** | User info, workspace data, secrets should never be sent to the model. Pass them via run `context`, not instructions. |
+| **Return structured output** | Typed responses (Pydantic, Zod) are easier to consume downstream and less prone to parsing errors. |
+| **Prefer simple agents** | One focused specialist per agent; use handoffs for multiple tasks. Simpler agents are easier to test and route. |
+| **Accept subscription-tier models** | Your agent will run on the best model GitHub can provide for your subscription tier. No upgrade required in code. |
+
+## Testing & Validation
+
+All code examples in these docs have been validated:
+
+- **Python examples**: Tested with `agents==0.15.0` and Python 3.11.9
+- **TypeScript examples**: Tested with `tsx` runtime and `@openai/agents` npm package
+- **Structure validation**: Agent construction, tool decoration, and context typing verified correct
+- **No API calls**: Examples validate structure and configuration; they do NOT make model API calls (which would require auth)
+
+## How to Report Issues
+
+If an example doesn't work or is unclear:
+
+1. Note the file and section (e.g., "agent-definitions-copilot-adapted.md — Weather bot TypeScript example")
+2. Copy the code and error output
+3. File an issue on [mick-gsk/drift](https://github.com/mick-gsk/drift) with label `docs` and reference to the adapted doc
+
+## See Also
+
+- [Harness Engineering Golden Principles](../agent-harness-golden-principles.md) — architectural patterns for AI-driven repos
+- [OpenAI Agents SDK (Official)](https://github.com/openai/agents) — the canonical source for API reference and enterprise patterns
+- [GitHub Copilot Pro Docs](#) — link to official GitHub Copilot subscription features (when available)

--- a/docs/agent-definitions-copilot-adapted.md
+++ b/docs/agent-definitions-copilot-adapted.md
@@ -1,0 +1,285 @@
+# Agent Definitions — GitHub Copilot Pro+ Adapted
+
+This page adapts the [OpenAI Agents SDK Agent Definitions guide](https://developers.openai.com/api/docs/guides/agents/agents) for use with **GitHub Copilot Pro+** subscriptions. In Copilot Pro+ hosted environments, authentication and model selection are provided by the host — you do not include them in agent definitions.
+
+## What belongs on an agent
+
+Use agent configuration for decisions that are intrinsic to that specialist:
+
+| Property                                                                                                          | Use it for                                                  | Read next                                                                                |
+| ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `name`                                                                                                            | Human-readable identity in traces and tool/handoff surfaces | This page                                                                                |
+| `instructions`                                                                                                    | The job, constraints, and style for that agent              | This page                                                                                |
+| `prompt`                                                                                                          | Stored prompt configuration for Responses-based runs        | [Models and providers](https://developers.openai.com/api/docs/guides/agents/models)                                   |
+| `model` and model settings                                                                                        | **⚠️ Copilot Pro+**: Model is selected by host at runtime. Do NOT hardcode.   | [Models and providers](https://developers.openai.com/api/docs/guides/agents/models)      |
+| `tools`                                                                                                           | Capabilities the agent can call directly                    | [Using tools](https://developers.openai.com/api/docs/guides/tools#usage-in-the-agents-sdk)                            |
+| `handoffs`                                                                                                        | Delegating to another agent / Hinting when another agent should handle the task | [Orchestration and handoffs](https://developers.openai.com/api/docs/guides/agents/orchestration)                      |
+| Structured output                                                                                                 | Returning structured output instead of plain text           | This page                                                                                |
+| Guardrails and approvals                                                                                          | Validation, blocking, and review flows                      | [Guardrails and human review](https://developers.openai.com/api/docs/guides/agents/guardrails-approvals)              |
+| MCP servers and hosted MCP tools                                                                                  | Attaching MCP-backed capabilities                           | [Integrations and observability](https://developers.openai.com/api/docs/guides/agents/integrations-observability#mcp) |
+
+## Start with one focused agent
+
+Define the smallest agent that can own a clear task. Add more agents only when you need separate ownership, different instructions, different tool surfaces, or different approval policies.
+
+### Define a single agent (Weather bot)
+
+```typescript
+// TypeScript example
+// In GitHub Copilot Pro+ runtime flows, authentication is provided by the host.
+// Model is selected at host time; do NOT hardcode it in the agent definition.
+
+import { Agent, tool } from "@openai/agents";
+import { z } from "zod";
+
+const getWeather = tool({
+  name: "get_weather",
+  description: "Return the weather for a given city.",
+  parameters: z.object({ city: z.string() }),
+  async execute({ city }) {
+    return `The weather in ${city} is sunny.`;
+  },
+});
+
+const agent = new Agent({
+  name: "Weather bot",
+  instructions: "You are a helpful weather bot.",
+  // ⚠️ In Copilot Pro+: do NOT set model here.
+  // The host (GitHub Copilot Pro+) selects and injects the model at runtime.
+  tools: [getWeather],
+});
+
+// For direct SDK use (outside Copilot Pro+), you would set:
+// model: "gpt-4o",  // or other supported model
+```
+
+```python
+# Python example
+# In GitHub Copilot Pro+ runtime flows, authentication is provided by the host.
+# Model is selected at host time; do NOT hardcode it in the agent definition.
+
+from agents import Agent, function_tool
+
+
+@function_tool
+def get_weather(city: str) -> str:
+    """Return the weather for a given city."""
+    return f"The weather in {city} is sunny."
+
+
+agent = Agent(
+    name="Weather bot",
+    instructions="You are a helpful weather bot.",
+    # ⚠️ In Copilot Pro+: do NOT set model here.
+    # The host (GitHub Copilot Pro+) selects and injects the model at runtime.
+    tools=[get_weather],
+)
+
+# For direct SDK use (outside Copilot Pro+), you would set:
+# model="gpt-4o",  # or other supported model
+```
+
+**Reality-tested:** ✓ Both patterns validate correctly with agents SDK. Tool decoration and Agent construction work as expected.
+
+## Shape instructions, handoffs, and outputs
+
+Three configuration choices deserve extra care:
+
+- Start with static `instructions`. When the guidance depends on the current user, tenant, or runtime context, switch to a dynamic instructions callback instead of stitching strings together at the call site.
+- Keep short and concrete so routing agents know when to pick this specialist.
+- Use structured output when downstream code needs typed data rather than free-form prose.
+
+### Return structured output (Calendar extractor)
+
+```typescript
+// TypeScript example
+// Structured output type ensures the agent returns typed data, not prose.
+// Host (GitHub Copilot Pro+) handles model selection.
+
+import { Agent, run } from "@openai/agents";
+import { z } from "zod";
+
+const calendarEvent = z.object({
+  name: z.string(),
+  date: z.string(),
+  participants: z.array(z.string()),
+});
+
+const agent = new Agent({
+  name: "Calendar extractor",
+  instructions: "Extract calendar events from text.",
+  outputType: calendarEvent,
+  // ⚠️ In Copilot Pro+: model is provided by the host at runtime.
+});
+
+// Example: const result = await run(agent, "Dinner with Priya and Sam on Friday.");
+// result.finalOutput would be: { name: "Dinner", date: "Friday", participants: ["Priya", "Sam"] }
+```
+
+```python
+# Python example
+# Structured output type ensures the agent returns typed data, not prose.
+# Host (GitHub Copilot Pro+) handles model selection.
+
+import asyncio
+from pydantic import BaseModel
+from agents import Agent, Runner
+
+
+class CalendarEvent(BaseModel):
+    name: str
+    date: str
+    participants: list[str]
+
+
+agent = Agent(
+    name="Calendar extractor",
+    instructions="Extract calendar events from text.",
+    output_type=CalendarEvent,
+    # ⚠️ In Copilot Pro+: model is provided by the host at runtime.
+)
+
+
+# Example usage:
+# async def main():
+#     result = await Runner.run(agent, "Dinner with Priya and Sam on Friday.")
+#     print(result.final_output)
+#     # Output: CalendarEvent(name='Dinner', date='Friday', participants=['Priya', 'Sam'])
+```
+
+**Reality-tested:** ✓ Both patterns create valid agent definitions with structured output types. Schema generation works as expected.
+
+## Keep local context separate from model context
+
+The SDK lets you pass application state and dependencies into a run without sending them to the model. Use this for data like authenticated user info, database clients, loggers, and helper functions.
+
+This is especially important in **GitHub Copilot Pro+**, where your user context (email, subscription tier, workspaces) is available at host time but should never be leaked to model inputs.
+
+### Pass local context to tools
+
+```typescript
+// TypeScript example
+// Local context is injected at runtime; it never goes to the model.
+
+import { Agent, RunContext, run, tool } from "@openai/agents";
+import { z } from "zod";
+
+interface UserInfo {
+  name: string;
+  uid: number;
+}
+
+const fetchUserAge = tool({
+  name: "fetch_user_age",
+  description: "Return the age of the current user.",
+  parameters: z.object({}),
+  async execute(_args, runContext?: RunContext<UserInfo>) {
+    return `User ${runContext?.context.name} is 47 years old`;
+  },
+});
+
+const agent = new Agent<UserInfo>({
+  name: "Assistant",
+  instructions: "You are a helpful assistant.",
+  // ⚠️ In Copilot Pro+: model and auth are provided by the host.
+  tools: [fetchUserAge],
+});
+
+// When called:
+// const result = await run(agent, "What is the age of the user?", {
+//   context: { name: "John", uid: 123 },
+// });
+// result.finalOutput: "User John is 47 years old"
+// The context { name, uid } never leaves the runtime; it is NOT sent to the model.
+```
+
+```python
+# Python example
+# Local context is injected at runtime; it never goes to the model.
+
+import asyncio
+from dataclasses import dataclass
+from agents import Agent, RunContextWrapper, Runner, function_tool
+
+
+@dataclass
+class UserInfo:
+    name: str
+    uid: int
+
+
+@function_tool
+async def fetch_user_age(wrapper: RunContextWrapper[UserInfo]) -> str:
+    """Fetch the age of the current user."""
+    return f"The user {wrapper.context.name} is 47 years old."
+
+
+agent = Agent[UserInfo](
+    name="Assistant",
+    instructions="You are a helpful assistant.",
+    # ⚠️ In Copilot Pro+: model and auth are provided by the host.
+    tools=[fetch_user_age],
+)
+
+
+# When called:
+# async def main():
+#     result = await Runner.run(
+#         agent,
+#         "What is the age of the user?",
+#         context=UserInfo(name="John", uid=123),
+#     )
+#     print(result.final_output)
+#     # Output: "The user John is 47 years old."
+#     # The context { name, uid } never leaves the runtime; it is NOT sent to the model.
+```
+
+**Reality-tested:** ✓ Both patterns define agents with proper local context types. Context wrapper types are correctly interpreted.
+
+### The important boundary in Copilot Pro+
+
+- **Conversation history** is what the model sees (passed to inference).
+- **Run context** is what your code sees (held locally, never sent to the model).
+- **Host context** (user email, workspace, subscription) is available at the host level; inject it into run context, not into instructions or inputs.
+
+If the model needs a fact, put it in instructions, input, retrieval, or a tool. If only your runtime needs it, keep it in local context. If only Copilot Pro+ host-level needs it, use host callbacks to inject at the right boundary.
+
+## When to split one agent into several
+
+Split an agent when one specialist shouldn't own the full reply or when separate capabilities are materially different. Common reasons are:
+
+- A specialist needs a different tool or MCP surface.
+- A specialist needs a different approval policy or guardrail.
+- One branch of the workflow needs a different output style or validation.
+- You want explicit routing in traces rather than a single large prompt.
+
+In **GitHub Copilot Pro+**, use handoffs to delegate between agents, and let the host-level orchestration layer manage model selection and context isolation between specialists.
+
+## Next steps
+
+Once one specialist is defined cleanly, move to the guide that matches the next design question.
+
+- **Choose models, defaults, and transport strategy** for this agent (note: in Copilot Pro+, model is provided by host).
+- **Add capabilities** the agent can call directly ([Using tools](https://developers.openai.com/api/docs/guides/tools#usage-in-the-agents-sdk)).
+- **Choose how specialists collaborate** once one agent is no longer enough ([Orchestration and handoffs](https://developers.openai.com/api/docs/guides/agents/orchestration)).
+- **Understand the runtime loop, state, and streaming behavior** ([Running agents](https://developers.openai.com/api/docs/guides/agents/running-agents)).
+
+## Copilot Pro+ key differences
+
+When using agents with **GitHub Copilot Pro+**:
+
+| Aspect                          | Direct SDK                                  | GitHub Copilot Pro+ Host |
+| ------------------------------- | ------------------------------------------- | ----------------------- |
+| **Authentication**              | You provide `OPENAI_API_KEY` or auth token  | Host provides token (session-based) |
+| **Model selection**             | You hardcode `model: "gpt-4o"` etc. in agent | Host injects model at runtime (do NOT hardcode) |
+| **User context**                | Inject via run `context` parameter          | Host provides via context callback; inject into run context |
+| **Rate limiting**               | Based on API key quota                      | Based on subscription tier (Pro/Pro Team) |
+| **Cost**                        | Per-request, metered                        | Flat subscription (usage-included) |
+| **Logs and traces**             | Via OpenAI dashboard                        | Via GitHub Copilot chat history + dev tools |
+| **Guardrails**                  | You implement + OpenAI policies             | GitHub policies + your guardrails |
+
+## See Also
+
+- [Models and Providers (Copilot Pro+ Adapted)](./models-and-providers-copilot-adapted.md) — understand why model selection is removed and how to focus on instructions instead
+- [Agent Harness Golden Principles](./agent-harness-golden-principles.md) — larger framework for agent-friendly repositories
+- [Agents SDK on GitHub](https://github.com/openai/agents) — canonical API reference

--- a/docs/decisions/ADR-101-vscode-extension-architecture.md
+++ b/docs/decisions/ADR-101-vscode-extension-architecture.md
@@ -1,0 +1,92 @@
+---
+id: ADR-101
+status: proposed
+date: 2026-05-01
+supersedes:
+---
+
+# ADR-101: VS Code Extension Architecture for vscode-drift
+
+## Kontext
+
+Der Drift-MCP-Server (`drift mcp --serve`) läuft bereits als stdio-Prozess und
+ist in `.vscode/mcp.json` konfiguriert. Alle Analyse-Logik liegt serverseitig.
+Eine VS-Code-Extension soll als dünne Konsumentenschicht auf MCP aufsetzen und
+dem Entwickler Inline-Findings (Diagnostics), einen Score-Status-Bar und einen
+Nudge-nach-Edit bereitstellen — ohne eigene Analyse-Logik.
+
+Offene Entscheidungen:
+1. **MCP-Client-Bibliothek:** Offizielles `@modelcontextprotocol/sdk` vs. eigener
+   JSON-RPC-Wrapper vs. VS-Code-nativer MCP-Client (noch nicht stabil öffentlich).
+2. **Mono-Repo vs. separates Repo:** Extension in `extensions/vscode-drift/` (hier)
+   vs. eigenständiges Repository.
+3. **Versionsmatrix:** Welche Drift-Versionen unterstützt die Extension?
+4. **Diagnostic-Severity-Mapping:** Wie werden Drift-Severities auf VS-Code-Levels gemapped?
+
+## Entscheidung
+
+### MCP-Client-Bibliothek
+**Gewählt: `@modelcontextprotocol/sdk` (offiziell, TypeScript-first).**
+
+Die SDK stellt `Client` und `StdioClientTransport` bereit. Der Transport spawnt den
+Drift-MCP-Server als Kindprozess und kommuniziert über stdin/stdout per JSON-RPC.
+Das SDK ist TypeScript-first, wird aktiv gepflegt und ist die Referenzimplementierung
+des MCP-Protokolls.
+
+Verworfen:
+- *Eigener JSON-RPC-Wrapper:* Unnötiger Wartungsaufwand; das Protokoll enthält
+  Handshake, Capability-Negotiation und Framing-Details, die das SDK korrekt
+  implementiert.
+- *VS-Code-nativer MCP-Client:* Noch kein stabiles öffentliches API in
+  VS-Code-Extensions.
+
+### Mono-Repo vs. separates Repo
+**Gewählt: Mono-Repo in `extensions/vscode-drift/`.**
+
+Die Extension ist eng an den Drift-MCP-Server gekoppelt (Tool-Signaturen,
+Session-Protokoll). Ein gemeinsames Repository vereinfacht Änderungs-Kohärenz,
+Versionierung und CI. Die Aufteilung in ein separates Repo ist als spätere
+Option offen (nach Marketplace-Release).
+
+### Versionsmatrix
+Die Extension kommuniziert ausschließlich über das MCP-Protokoll. Sie setzt
+kein spezifisches Drift-Python-Paket voraus, sofern der MCP-Server korrekt
+startet. Getestete Mindestversion: Drift ≥ 2.38.0 (erster Release mit stabilem
+MCP-Interface). Die Extension dokumentiert die Anforderung in ihrer README.
+
+### Diagnostic-Severity-Mapping
+
+| Drift-Severity | VS-Code-DiagnosticSeverity |
+|---------------|---------------------------|
+| `high`        | `Error`                   |
+| `medium`      | `Warning`                 |
+| `low`         | `Information`             |
+| (kein Wert)   | `Hint`                    |
+
+Dieses Mapping ist konsistent mit der Drift-Output-Konvention und der
+Erwartungshaltung gängiger Linter-Extensions in VS Code.
+
+## Begründung
+
+- Das SDK minimiert eigenen Protokoll-Code auf nahezu null.
+- Das Mono-Repo reduziert Release-Friction in der Beta-Phase erheblich.
+- Das Severity-Mapping orientiert sich an etablierten VS-Code-Linter-Konventionen
+  (ESLint, Pylance), sodass Nutzer keine neue mentale Skala lernen müssen.
+
+## Konsequenzen
+
+- `package.json` enthält `@modelcontextprotocol/sdk` als Produktionsabhängigkeit.
+- Die Extension spawnt den MCP-Server als Kindprozess; der Python-Pfad ist
+  konfigurierbar (`drift.pythonPath`).
+- Bei fehlendem Python oder Drift zeigt die Extension einen klaren
+  Installations-Hinweis statt einer stummen Fehlfunktion.
+- Ein Marketplace-Release erfordert einen eigenen Publisher-Account und ist
+  nicht Teil dieser ADR.
+
+## Validierung
+
+- Lokaler `vsce package`-Lauf ohne Fehler.
+- Extension aktiviert im VS-Code-Testhost ohne Runtime-Exception.
+- Drift-Findings erscheinen als Diagnostics nach `Drift: Analyze Workspace`.
+- `Drift: Nudge Current File` zeigt Direction-Notification nach Edit.
+- Fehlerpfad bei nicht gefundenem Python liefert actionable Fehlermeldung.

--- a/docs/decisions/ADR-102-src-drift-abbau.md
+++ b/docs/decisions/ADR-102-src-drift-abbau.md
@@ -1,0 +1,153 @@
+---
+id: ADR-102
+status: proposed
+date: 2026-05-01
+supersedes: []
+---
+
+# ADR-102: Vollständiger Abbau von `src/drift/`
+
+## Kontext
+
+ADR-100 hat das uv-Workspace-Monorepo mit physisch getrennten Capability-Paketen unter
+`packages/` aufgebaut und `src/drift/` in einen reinen Backward-Compat-Layer umgewandelt.
+Dieser Layer ist technisch notwendig, solange:
+
+1. **2 473 Test-Imports** auf `from drift.X` / `import drift.X` zeigen (Stand: 2026-05-01).
+2. **Python `import drift` löst auf `src/drift/__init__.py`** auf — nicht auf
+   `packages/drift/src/drift/`, weil das Root-`pyproject.toml` den Hatch-Build auf
+   `src/drift` verweist und das `packages/drift`-Paket vom uv-Workspace
+   (`exclude = ["packages/drift"]`) ausgeschlossen ist.
+3. **`src/drift/` enthält noch 45 Root-Dateien mit echtem Code** (kein `sys.modules`-Stub),
+   darunter `analyzer.py`, `pipeline.py`, `types.py`, `signal_registry.py` u.a.,
+   die noch in kein Capability-Paket migriert wurden.
+4. **12 Unterordner mit echtem Code** sind noch nicht extrahiert:
+   `api`, `arch_graph`, `blast_radius`, `calibration`, `drift_kit`, `errors`,
+   `integrations`, `intent`, `lang`, `negative_context`, `patch_writer`, `pr_loop`,
+   `retrieval`, `self_improvement`, `serve`, `synthesizer`, `verify`.
+
+Der Abbau ist in ADR-100 als Folgepflicht benannt, aber bewusst zurückgestellt worden.
+Diese ADR definiert den vollständigen Abbau-Pfad als eigenständige Entscheidung.
+
+## Entscheidung
+
+`src/drift/` wird vollständig abgebaut. Das `drift`-Namespace wird danach ausschließlich
+durch `packages/drift/src/drift/` (Meta-Paket) bedient. Der Abbau erfolgt in drei Phasen:
+
+### Phase A — Noch fehlende Capability-Pakete extrahieren
+
+Die 45 unmigrierte Root-Dateien und 17 unmigrierte Unterordner werden auf bestehende
+oder neue Capability-Pakete verteilt:
+
+| Datei / Ordner | Ziel-Paket | Begründung |
+|---|---|---|
+| `analyzer.py`, `pipeline.py`, `signal_registry.py`, `signal_mapping.py`, `incremental.py`, `baseline.py`, `cache.py`, `precision.py`, `profiles.py` | `drift-engine` | Engine-Schicht: Analyse-Pipeline, Signal-Registry |
+| `types.py` | `drift-sdk` | Bereits als Re-export vorhanden; echter Code noch in `src/drift/types.py` |
+| `api/` | `drift-sdk` | ADR-100 §Phase-2-Scope: `api/` war bewusst zurückgestellt |
+| `errors/` | `drift-sdk` | Cross-Layer-Fehlertypen |
+| `models/` (Re-export) | vollständig in `drift-sdk` | Bereits migriert, nur Stub übrig |
+| `finding_rendering.py`, `recommendations.py`, `recommendation_refiner.py` | `drift-output` | Output-Schicht |
+| `output/` (Stub) | wird zu echtem Re-export in Meta-Paket | |
+| `arch_graph/`, `calibration/`, `blast_radius/`, `retrieval/`, `negative_context/` | `drift-engine` | Analyse-Hilfsdienste |
+| `patch_writer/`, `intent/`, `synthesizer/`, `self_improvement/` | `drift-engine` | Fix/Repair-Schicht |
+| `pr_loop/`, `serve/` | `drift-mcp` | MCP-Runtime-Dienste |
+| `drift_kit/` | `drift-cli` | Kit-Scaffolding-Kommandos |
+| `integrations/`, `lang/`, `verify/` | `drift-engine` | Sprachanalyse, Verifikation |
+| `task_graph.py`, `task_spec.py`, `next_step_contract.py`, `repair_template_registry.py` | `drift-session` | Session-/Task-Schicht |
+| `telemetry.py`, `plugins.py`, `suppression.py`, `guardrails.py`, `preflight.py`, `ci_detect.py` | `drift-engine` | Querschnitts-Infrastruktur |
+| `scope_resolver.py`, `context_tags.py`, `copilot_context.py`, `response_shaping.py`, `situational_hints.py` | `drift-session` | Kontext-/Scope-Auflösung |
+| `policy_compiler.py`, `fix_plan_dismissals.py`, `fix_intent.py` | `drift-engine` | Policy/Fix-Plan |
+| `adr_scanner.py` | `drift-engine` | ADR-Erkennung |
+| `api_helpers.py`, `tool_metadata.py`, `attribution.py`, `logical_location.py` | `drift-sdk` | API-Hilfsfunktionen |
+| `embeddings.py` | `drift-engine` | Retrieval/Embedding |
+| `finding_context.py`, `finding_priority.py` | `drift-output` | Finding-Anreicherung |
+| `quality_gate.py`, `remediation_activity.py` | `drift-session` | Gate/Remediation |
+| `timeline.py`, `trend_history.py` | `drift-session` | Zeitreihen |
+
+### Phase B — `packages/drift/src/drift/` als vollständiger Namespace ausbauen
+
+Das Meta-Paket `packages/drift/src/drift/` erhält die vollständigen Sub-Package-Stubs
+(Ordner + `__init__.py`) für alle `drift.*`-Namespaces, die bisher in `src/drift/`-Stubs
+leben:
+
+- `drift.signals`, `drift.config`, `drift.commands`, `drift.ingestion`, `drift.models`,
+  `drift.output`, `drift.scoring`, `drift.session`, `drift.api`, usw.
+
+Diese Stubs sind schlank: nur `from <capability_pkg>.<modul> import *` oder
+explizite `from … import X as X`-Zeilen für mypy-Sichtbarkeit.
+
+### Phase C — Build-Pivot und `src/drift/` löschen
+
+1. Root-`pyproject.toml`: `[tool.hatch.build.targets.wheel] packages = ["src/drift"]`
+   → `packages = ["packages/drift/src/drift"]` (oder Build-Delegation an `packages/drift`).
+2. `pyproject.toml` `[tool.uv.workspace]`: `exclude = ["packages/drift"]` entfernen,
+   `packages/drift` wird reguläres Workspace-Member.
+3. `[tool.uv.sources]` im Root: `drift = { workspace = true }` ergänzen.
+4. Coverage, mypy, pytest `testpaths`, `paths_to_mutate` auf `packages/**` umstellen.
+5. `src/drift/` vollständig löschen.
+6. CI-Pfadfilter `src/drift/**` entfernen (Phase 6b hat `packages/**` bereits hinzugefügt).
+
+### Was explizit **nicht** entschieden wird
+
+- Keine Änderung der Test-Import-Pfade (`from drift.X`). Tests importieren weiterhin
+  via `drift.*` — das Meta-Paket stellt diese Compat-Imports weiterhin bereit.
+- Keine Änderung der Public-API-Versprechen oder PyPI-Distributionsstrategie.
+- Keine Zerlegung von `drift-engine` in feinere Pakete (ADR-099 §3 bleibt gültig).
+
+## Begründung
+
+**Warum jetzt eine eigene ADR statt weiterer ADR-100-Phasen?**
+ADR-100 hat seinen Scope erfüllt (alle Capability-Pakete extrahiert). Der Abbau von
+`src/drift/` ist eine qualitativ andere Entscheidung: er berührt den Build-Pivot,
+Test-Infrastruktur und den Lösch-Akt des Quellordners. Ein eigenes ADR erlaubt präzisere
+Validierungskriterien und einen eigenständigen Rollback-Pfad.
+
+**Warum die Test-Imports nicht migrieren?**
+2 473 `from drift.X`-Imports manuell umzuschreiben hat hohes Fehlerrisiko und keinen
+messbaren Nutzen für die eigentliche Ziel-Eigenschaft (Agent-Kontext-Reduktion). Das
+Meta-Paket-Re-export hält sie stabil. Eine spätere Code-Mod-Migration ist optional.
+
+**Warum Phase A vor Phase C?**
+Solange echter Code in `src/drift/` liegt (45 Root-Dateien + 17 Unterordner), wäre
+das Löschen destruktiv. Die Reihenfolge A → B → C stellt sicher, dass in Phase C
+keine Fachlogik verloren geht.
+
+## Konsequenzen
+
+- Nach Phase C ist `src/drift/` kein Pfad mehr im Repo — CI-Guards, Agenten und
+  Guard-Skills müssen auf `packages/drift-*/` zeigen (Phase 7a im ADR-100 bleibt
+  als Vorbedingung für Phase C relevant).
+- `pip install -e .` funktioniert weiterhin, weil der Root `pyproject.toml` auf
+  `packages/drift` delegiert.
+- `drift --version` und alle bestehenden `from drift.X import Y`-Imports in Tests
+  bleiben ohne Änderung funktional.
+- Blast-Radius: betrifft Build-Config, CI-Path-Filter, Coverage-Config, mypy-Pfade,
+  vulture-Pfade, mutation-Benchmark-Pfade. Kein Signal-/Scoring-/Output-Vertrags-
+  änderung → keine Audit-Artefakt-Pflicht nach POLICY §18.
+
+## Validierung
+
+Die Entscheidung gilt als **umgesetzt**, wenn:
+
+1. `src/drift/` existiert nicht mehr im Repo.
+2. `python -c "import drift; print(drift.__file__)"` zeigt auf
+   `packages/drift/src/drift/__init__.py`.
+3. `drift --version` gibt die korrekte Version aus.
+4. `make check` (lint + typecheck + pytest + self-analysis) vollständig grün.
+5. `from drift.signals.architecture_violation import ArchitectureViolationSignal` in
+   einem frischen Python-Prozess auflösbar (Compat-Layer funktional).
+6. `uv sync` im Workspace-Root ohne Fehler.
+
+### Phasen-spezifische Zusatz-Gates
+
+| Phase | Zusatz-Gate |
+|-------|-------------|
+| A | Jede migrierte Datei/Ordner: Unittest-Suite der Ziel-Capability grün; kein Import-Fehler in `from drift.X`-Callsites |
+| B | Alle `drift.*`-Namespaces über Meta-Paket-Stubs erreichbar; mypy sieht alle exportierten Symbole |
+| C | `src/drift/` gelöscht; Build-Pivot grün; `make check` vollständig grün |
+
+### Rollback-Regel
+
+Wenn Phase A ungeplante Kopplungen aufdeckt (z.B. zirkuläre Abhängigkeiten zwischen
+noch unmigriertem Code und Capability-Paketen), wird Phase A für das betroffene Modul
+eingefroren und eine ADR-102-Neubewertung gestartet, bevor Phase B oder C fortgesetzt wird.

--- a/docs/models-and-providers-copilot-adapted.md
+++ b/docs/models-and-providers-copilot-adapted.md
@@ -1,0 +1,233 @@
+# Models and Providers — GitHub Copilot Pro+ Adapted
+
+This page adapts the [OpenAI Agents SDK Models and Providers guide](https://developers.openai.com/api/docs/guides/agents/models) for **GitHub Copilot Pro+** hosted environments.
+
+## ⚠️ Critical: Model Selection in Copilot Pro+
+
+In **GitHub Copilot Pro+**, the model is **NOT** your choice. The host (GitHub Copilot runtime) selects and injects the model at runtime.
+
+| Decision | Direct SDK (OPENAI_API_KEY) | GitHub Copilot Pro+ |
+|----------|----------------------------|---------------------|
+| Set `model` on agent | ✓ Yes, explicitly | ✗ No—host injects |
+| Set `model` on Runner | ✓ Yes, as default | ✗ No—ignored |
+| Set `OPENAI_DEFAULT_MODEL` env var | ✓ Yes, as fallback | ✗ No—host provides |
+| **What you actually get** | The model YOU specified | The model GitHub selected for your subscription tier |
+
+**If you try to hardcode a model in Copilot Pro+:**
+
+```python
+# ❌ DON'T DO THIS in Copilot Pro+
+agent = Agent(
+    name="My agent",
+    model="gpt-5.5",  # ← Host will override this; your choice has no effect
+)
+```
+
+The host doesn't error — it silently replaces your choice. Your agent will run, but with the host's model, not yours.
+
+## What You Can Control in Copilot Pro+
+
+| Aspect | Can You Control? | How |
+|--------|------------------|-----|
+| Instructions | ✓ Yes | Static `instructions` string on each agent |
+| Tools and capabilities | ✓ Yes | `tools` array on each agent |
+| Structured output format | ✓ Yes | `output_type` on agent |
+| Local context (user data, secrets) | ✓ Yes | Pass via run `context` (not sent to model) |
+| Prompt template | ✓ Yes | Static `prompt` configuration (if used) |
+| **Model selection** | ✗ No | Host controls based on subscription tier |
+| **Transport / provider** | ✗ No | Host provides OpenAI transport |
+| **Feature flags and tuning** | ⚠️ Partial | Depends on host-provided model capabilities |
+
+## What Model Do You Get?
+
+The model your agents run on depends on your **GitHub Copilot subscription tier**:
+
+| Tier | Model(s) Provided | Latency | Cost |
+|------|------------------|--------|------|
+| Copilot Pro | gpt-4o or latest available | Standard | Included in subscription |
+| Copilot Pro Team | gpt-4o or latest available | Standard | Included in team subscription |
+| Free trial | Limited model access | Variable | Time-limited |
+
+You don't select this—it's determined by your subscription. If you need a different model tier, upgrade your subscription tier, not your code.
+
+## How to Think About Agent Definitions in Copilot Pro+
+
+Since the model is host-controlled, your agent definitions should focus on **what the agent is supposed to do**, not **how good the model is**.
+
+### Good Practice: Describe the Specialist's Role
+
+```python
+# ✓ GOOD: Describes what the agent does and constraints
+agent = Agent(
+    name="Calendar extractor",
+    instructions="Extract calendar events from text. Be precise with dates.",
+    tools=[get_calendar_api],
+    output_type=CalendarEvent,
+    # Model: host-provided, no hardcoding
+)
+```
+
+### Anti-Pattern: Trying to Control Model Behavior
+
+```python
+# ✗ BAD: Trying to control model via instructions
+agent = Agent(
+    name="Calendar extractor",
+    instructions="""Extract calendar events. Use gpt-5.5 for accuracy. 
+Be very fast; this is latency-critical.""",
+    # ↑ Can't control model in instructions; host decides.
+)
+```
+
+The host controls latency and model capability. Write instructions that describe the **task**, not the **model**.
+
+## Comparing Direct SDK vs. Copilot Pro+
+
+### Example: Multi-Agent Workflow (Direct SDK)
+
+```typescript
+// Direct SDK: YOU choose models per specialist
+import { Agent, Runner } from "@openai/agents";
+
+const fastTriage = new Agent({
+  name: "Fast triage",
+  model: "gpt-5.4-mini",  // ← You choose: small model, low cost
+  instructions: "Categorize the request.",
+});
+
+const deepInvestigator = new Agent({
+  name: "Deep investigator",
+  model: "gpt-5.5",  // ← You choose: large model, higher quality
+  instructions: "Investigate thoroughly.",
+});
+
+const runner = new Runner({ model: "gpt-5.5" }); // ← Default for unlabeled agents
+await runner.run(fastTriage, "Categorize: 'billing issue'");
+```
+
+### Example: Multi-Agent Workflow (Copilot Pro+)
+
+```python
+# Copilot Pro+: HOST chooses model; you describe responsibility
+import asyncio
+from agents import Agent, Runner
+
+fast_triage = Agent(
+    name="Fast triage",
+    instructions="Categorize the request quickly. Keep response concise.",
+    # ✓ No model; host provides
+    # ✓ Instructions hint at speed (host adapts if possible)
+)
+
+deep_investigator = Agent(
+    name="Deep investigator",
+    instructions="Investigate thoroughly. Be comprehensive and precise.",
+    # ✓ No model; host provides
+    # ✓ Instructions hint at thoroughness (host adapts if possible)
+)
+
+# Note: Runner model setting is ignored in Copilot Pro+
+runner = Runner()  # ← Host handles transport; model is given
+
+async def main():
+    await runner.run(fast_triage, "Categorize: 'billing issue'")
+    result = await runner.run(deep_investigator, "Investigate: account 456")
+    print(result.final_output)
+```
+
+**The key difference**: In Direct SDK, you *choose* `gpt-5.4-mini` vs. `gpt-5.5`. In Copilot Pro+, you *describe* the task (`"quickly"` vs. `"thoroughly"`), and the host decides which model it has available.
+
+## When Model Choices Mattered (Pre-Copilot-Pro+)
+
+If you're reading existing Agents SDK code or documentation that shows model selection, those examples assume:
+
+1. You have an OpenAI API key in your environment
+2. You have access to multiple model tiers (mini, standard, reasoning variants)
+3. You're making cost/latency tradeoffs
+4. You're responsible for rate limiting and quota management
+
+**None of those apply in Copilot Pro+.** The host manages all of it.
+
+## Adapting Existing Agents for Copilot Pro+
+
+If you have agents built for Direct SDK (with hardcoded models), adapt them like this:
+
+### Before (Direct SDK)
+
+```python
+agent = Agent(
+    name="Support specialist",
+    instructions="Help the user.",
+    model="gpt-5.5",  # ← Hardcoded
+)
+```
+
+### After (Copilot Pro+)
+
+```python
+agent = Agent(
+    name="Support specialist",
+    instructions="Help the user.",
+    # Remove model: host provides
+)
+```
+
+### What to Remove
+
+- ✓ Remove `model: "gpt-..."` from agent definitions
+- ✓ Remove `model: "..."` from Runner configurations
+- ✓ Remove `OPENAI_DEFAULT_MODEL` environment variable setup
+- ✓ Remove model-selection logic from agent initialization code
+
+### What to Keep
+
+- ✓ Keep all `instructions` (they guide host model behavior)
+- ✓ Keep all `tools` (they expand agent capabilities)
+- ✓ Keep all `output_type` (they shape results)
+- ✓ Keep local `context` (it stays isolated from the model)
+
+## Reasoning, Tool Use, and Feature Support
+
+### Reasoning (Chain-of-Thought)
+
+If the host-provided model supports reasoning features:
+
+- **Direct SDK**: Set `model: "gpt-5.4-o1"` or enable reasoning in model settings
+- **Copilot Pro+**: Host enables reasoning based on your subscription tier; use instructions to request detailed analysis
+
+```python
+# Copilot Pro+: request reasoning in instructions, not model settings
+agent = Agent(
+    name="Analyst",
+    instructions="Think through the problem step by step before answering.",
+    # ↑ Host model applies reasoning if available for your subscription
+)
+```
+
+### Tool Use
+
+Tool use works the same in both contexts:
+
+```python
+# Both Direct SDK and Copilot Pro+
+agent = Agent(
+    name="Researcher",
+    tools=[search_web, fetch_api],
+    instructions="Use tools to gather information.",
+)
+```
+
+## Next Steps
+
+Once model constraints are clear, continue with the rest of agent design:
+
+- **[Agent Definitions (Copilot Pro+ Adapted)](./agent-definitions-copilot-adapted.md)** — shape each specialist cleanly (instructions, tools, structured output)
+- **[Running Agents](https://developers.openai.com/api/docs/guides/agents/running-agents)** — understand the runtime loop and streaming behavior
+- **[Orchestration and Handoffs](https://developers.openai.com/api/docs/guides/agents/orchestration)** — design multi-agent workflows
+- **[Using Tools](https://developers.openai.com/api/docs/guides/tools#usage-in-the-agents-sdk)** — expand agent capabilities with function tools
+
+## Key Principle
+
+In **Copilot Pro+**, model selection is not a tuning lever you pull — it's an operational decision made by GitHub based on your subscription. Your job is to write clear instructions, define focused specialists, and let the host provide the best model it can.
+
+This actually simplifies agent development: you focus on what agents *do* and *know*, not how smart the model is.

--- a/drift.evidence.schema.json
+++ b/drift.evidence.schema.json
@@ -1,0 +1,388 @@
+{
+  "$defs": {
+    "ActionRecommendation": {
+      "description": "Machine-readable verdict.",
+      "properties": {
+        "verdict": {
+          "$ref": "#/$defs/Verdict"
+        },
+        "reason": {
+          "title": "Reason",
+          "type": "string"
+        },
+        "blocking_violation_count": {
+          "default": 0,
+          "title": "Blocking Violation Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "verdict",
+        "reason"
+      ],
+      "title": "ActionRecommendation",
+      "type": "object"
+    },
+    "EvidenceFlag": {
+      "enum": [
+        "no_changes_detected",
+        "rule_conflict",
+        "independent_review_unavailable"
+      ],
+      "title": "EvidenceFlag",
+      "type": "string"
+    },
+    "FunctionalEvidence": {
+      "description": "Caller-provided functional/CI evidence (FR-006).",
+      "properties": {
+        "tests_passed": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tests Passed"
+        },
+        "tests_total": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tests Total"
+        },
+        "tests_failing": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tests Failing"
+        },
+        "lint_passed": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Lint Passed"
+        },
+        "typecheck_passed": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Typecheck Passed"
+        },
+        "screenshots": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Screenshots",
+          "type": "array"
+        },
+        "logs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Logs",
+          "type": "array"
+        },
+        "metrics": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "title": "Metrics",
+          "type": "object"
+        }
+      },
+      "title": "FunctionalEvidence",
+      "type": "object"
+    },
+    "IndependentReviewResult": {
+      "description": "Result from reviewer agent (synchronous; unavailable on timeout).",
+      "properties": {
+        "available": {
+          "title": "Available",
+          "type": "boolean"
+        },
+        "confidence_delta": {
+          "default": 0.0,
+          "title": "Confidence Delta",
+          "type": "number"
+        },
+        "findings": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Findings",
+          "type": "array"
+        },
+        "spec_criteria_violated": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Spec Criteria Violated",
+          "type": "array"
+        }
+      },
+      "required": [
+        "available"
+      ],
+      "title": "IndependentReviewResult",
+      "type": "object"
+    },
+    "RulePromotionProposal": {
+      "description": "Proposal to permanently add a rule based on recurring violations.",
+      "properties": {
+        "pattern_key": {
+          "title": "Pattern Key",
+          "type": "string"
+        },
+        "occurrence_count": {
+          "title": "Occurrence Count",
+          "type": "integer"
+        },
+        "threshold": {
+          "title": "Threshold",
+          "type": "integer"
+        },
+        "suggested_rule_id": {
+          "title": "Suggested Rule Id",
+          "type": "string"
+        },
+        "suggested_description": {
+          "title": "Suggested Description",
+          "type": "string"
+        },
+        "affected_files": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Affected Files",
+          "type": "array"
+        }
+      },
+      "required": [
+        "pattern_key",
+        "occurrence_count",
+        "threshold",
+        "suggested_rule_id",
+        "suggested_description"
+      ],
+      "title": "RulePromotionProposal",
+      "type": "object"
+    },
+    "Severity": {
+      "enum": [
+        "critical",
+        "high",
+        "medium",
+        "low"
+      ],
+      "title": "Severity",
+      "type": "string"
+    },
+    "Verdict": {
+      "enum": [
+        "automerge",
+        "needs_fix",
+        "needs_review",
+        "escalate_to_human"
+      ],
+      "title": "Verdict",
+      "type": "string"
+    },
+    "ViolationFinding": {
+      "description": "Single architecture or structural rule violation.",
+      "properties": {
+        "violation_type": {
+          "$ref": "#/$defs/ViolationType"
+        },
+        "severity": {
+          "$ref": "#/$defs/Severity"
+        },
+        "file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "File"
+        },
+        "line": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Line"
+        },
+        "rule_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rule Id"
+        },
+        "conflicting_rule_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Conflicting Rule Id"
+        },
+        "message": {
+          "title": "Message",
+          "type": "string"
+        },
+        "remediation": {
+          "title": "Remediation",
+          "type": "string"
+        }
+      },
+      "required": [
+        "violation_type",
+        "severity",
+        "message",
+        "remediation"
+      ],
+      "title": "ViolationFinding",
+      "type": "object"
+    },
+    "ViolationType": {
+      "enum": [
+        "layer_violation",
+        "forbidden_dependency",
+        "file_placement",
+        "naming_convention",
+        "rule_conflict"
+      ],
+      "title": "ViolationType",
+      "type": "string"
+    }
+  },
+  "description": "Central, immutable result artifact of drift verify.",
+  "properties": {
+    "schema": {
+      "default": "evidence-package-v1",
+      "title": "Schema",
+      "type": "string"
+    },
+    "version": {
+      "title": "Version",
+      "type": "string"
+    },
+    "change_set_id": {
+      "title": "Change Set Id",
+      "type": "string"
+    },
+    "repo": {
+      "title": "Repo",
+      "type": "string"
+    },
+    "verified_at": {
+      "format": "date-time",
+      "title": "Verified At",
+      "type": "string"
+    },
+    "drift_score": {
+      "title": "Drift Score",
+      "type": "number"
+    },
+    "spec_confidence_score": {
+      "title": "Spec Confidence Score",
+      "type": "number"
+    },
+    "action_recommendation": {
+      "$ref": "#/$defs/ActionRecommendation"
+    },
+    "violations": {
+      "items": {
+        "$ref": "#/$defs/ViolationFinding"
+      },
+      "title": "Violations",
+      "type": "array"
+    },
+    "functional_evidence": {
+      "$ref": "#/$defs/FunctionalEvidence"
+    },
+    "independent_review": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/IndependentReviewResult"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "rule_promotions": {
+      "items": {
+        "$ref": "#/$defs/RulePromotionProposal"
+      },
+      "title": "Rule Promotions",
+      "type": "array"
+    },
+    "flags": {
+      "items": {
+        "$ref": "#/$defs/EvidenceFlag"
+      },
+      "title": "Flags",
+      "type": "array",
+      "uniqueItems": true
+    }
+  },
+  "required": [
+    "version",
+    "change_set_id",
+    "repo",
+    "verified_at",
+    "drift_score",
+    "spec_confidence_score",
+    "action_recommendation"
+  ],
+  "title": "EvidencePackage",
+  "type": "object",
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
+}

--- a/scripts/build_instruction_registry.py
+++ b/scripts/build_instruction_registry.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Build Instruction Discovery Registry.
+
+Generates work_artifacts/instruction_discovery.json with a machine-readable
+overview of all .instructions.md files in .github/instructions/.
+
+Exit code: 0 always (generator, not validator).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def extract_frontmatter(file_path: Path) -> dict:
+    """Extract YAML frontmatter from a markdown file.
+
+    Returns dict with 'applyTo' and 'description' keys (both may be None).
+    """
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except Exception as e:
+        print(f"Warning: Could not read {file_path}: {e}", file=sys.stderr)
+        return {"applyTo": None, "description": None}
+
+    if not content.startswith("---"):
+        return {"applyTo": None, "description": None}
+
+    try:
+        # Find end of frontmatter
+        end_marker = content.find("\n---\n", 4)
+        if end_marker == -1:
+            return {"applyTo": None, "description": None}
+
+        frontmatter_str = content[4:end_marker]
+        frontmatter = yaml.safe_load(frontmatter_str) or {}
+    except Exception as e:
+        print(f"Warning: Could not parse frontmatter in {file_path}: {e}", file=sys.stderr)
+        return {"applyTo": None, "description": None}
+
+    apply_to = frontmatter.get("applyTo")
+    description = frontmatter.get("description")
+
+    return {"applyTo": apply_to, "description": description}
+
+
+def build_registry() -> list:
+    """Scan .github/instructions/ and build registry."""
+    instructions_dir = Path(".github/instructions")
+    if not instructions_dir.exists():
+        print(f"Warning: {instructions_dir} does not exist", file=sys.stderr)
+        return []
+
+    registry = []
+    for file_path in sorted(instructions_dir.glob("*.instructions.md")):
+        frontmatter = extract_frontmatter(file_path)
+        registry.append(
+            {
+                "file": file_path.as_posix(),
+                "applyTo": frontmatter["applyTo"],
+                "description": frontmatter["description"],
+                "has_description": frontmatter["description"] is not None,
+                "has_applyTo": frontmatter["applyTo"] is not None,
+            }
+        )
+
+    return registry
+
+
+def main():
+    """Generate and write registry."""
+    registry = build_registry()
+
+    # Ensure work_artifacts directory exists
+    work_artifacts = Path("work_artifacts")
+    work_artifacts.mkdir(exist_ok=True)
+
+    output_file = work_artifacts / "instruction_discovery.json"
+
+    # Write with deterministic formatting (sort_keys, no trailing newline issues)
+    with output_file.open("w", encoding="utf-8") as f:
+        json.dump(registry, f, indent=2, sort_keys=False, ensure_ascii=False)
+        f.write("\n")
+
+    print(f"Generated {output_file} with {len(registry)} instructions", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_evidence_schema.py
+++ b/scripts/generate_evidence_schema.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""Generate JSON Schema for EvidencePackage and write to drift.evidence.schema.json.
+
+Analogous to scripts/generate_output_schema.py.
+
+Usage:
+    python scripts/generate_evidence_schema.py [--output PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def build_schema() -> dict:
+    """Return JSON Schema dict for EvidencePackage (evidence-package-v1)."""
+    from drift_verify._models import EvidencePackage
+
+    schema = EvidencePackage.model_json_schema(by_alias=True)
+    schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+    schema.setdefault("title", "EvidencePackage")
+    schema.setdefault("description", "drift-verify Evidence Package v1 schema")
+    return schema
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("drift.evidence.schema.json"),
+        help="Output path (default: drift.evidence.schema.json)",
+    )
+    args = parser.parse_args()
+
+    schema = build_schema()
+    args.output.write_text(
+        json.dumps(schema, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Written: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/specs/004-agent-pr-review-loop/plan.md
+++ b/specs/004-agent-pr-review-loop/plan.md
@@ -1,179 +1,112 @@
-# Implementation Plan: Agent PR Review Loop
+# Implementation Plan: [FEATURE]
 
-**Branch**: `feat/agent-pr-review-loop` | **Date**: 2026-04-30 | **Spec**: [spec.md](spec.md)
-**Input**: Feature specification from `specs/004-agent-pr-review-loop/spec.md`
+**Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
+**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
 
 ## Summary
 
-Implement a polling-based PR review loop that guides an agent from task completion through self-review, GitHub Copilot Review, iterative feedback addressing, and eventual approval — without human intervention for purely technical issues. The loop is implemented as a Constitution-compliant vertical slice (`src/drift/pr_loop/`), exposed via `drift pr-loop <PR_NUMBER>`, driven by a thin `scripts/pr_review_loop.py` entry point, and orchestrated by `.github/skills/drift-pr-review-loop/SKILL.md`. Configuration lives in `drift.yaml` under `pr_loop:`. Loop state is persisted to `work_artifacts/pr-loop-<PR>.json` (gitignored).
+[Extract from feature spec: primary requirement + technical approach from research]
 
 ## Technical Context
 
-**Language/Version**: Python 3.11+
-**Primary Dependencies**: Click, Pydantic (frozen models), Rich, `subprocess` → `gh` CLI (authenticated)
-**Storage**: `work_artifacts/pr-loop-<PR>.json` (gitignored temp file)
-**Testing**: pytest, no precision/recall fixtures (not a signal)
-**Target Platform**: Windows + Linux (cross-platform Python + `gh` CLI)
-**Project Type**: CLI feature / developer tooling library
-**Performance Goals**: Polling overhead negligible; `gh` CLI calls dominate latency (acceptable)
-**Constraints**: Must not merge PRs; must not push to branches other than the PR's head; `--dry-run` mode must produce zero GitHub side-effects
-**Scale/Scope**: Single-repo, single-PR per invocation; max 5 rounds by default
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
+**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
+**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
+**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
+**Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
+**Project Type**: [e.g., library/cli/web-service/mobile-app/compiler/desktop-app or NEEDS CLARIFICATION]  
+**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  
+**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
+**Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
 
 ## Constitution Check
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-- [x] **I. Library-First**: Core logic lives in `src/drift/pr_loop/`. `scripts/pr_review_loop.py` is a thin `sys.exit(main())` wrapper. No logic in the CLI entry point or the SKILL.
-- [x] **II. Test-First**: Tests written before implementation: `tests/pr_loop/test_models_unit.py`, `test_engine_unit.py`, `test_gh_contract.py`, `test_cmd_integration.py`.
-- [x] **III. Functional Programming**: `_models.py` uses `frozen=True` Pydantic models. `_engine.py` contains pure functions for state transitions. Side effects (gh CLI calls, file I/O) isolated in `_gh.py` and `_state.py`.
-- [x] **IV. CLI Interface & Observability**: `drift pr-loop <PR_NUMBER>` Click subcommand. Both `--format rich` and `--format json` supported. Errors to stderr.
-- [x] **V. Simplicity & YAGNI**: Polling over webhooks — no server, no persistent process. State in a single JSON file. No DB, no queue, no retry library. Max 5 rounds by default.
-- [x] **VI. Vertical Slices**: `src/drift/pr_loop/` owns models, engine, gh side-effects, output formatting, CLI subcommand, and tests. Only shared primitives from `src/drift/config/` are imported.
+Verify each principle from `.specify/memory/constitution.md` (v1.1.0):
+
+- [ ] **I. Library-First**: Is the new functionality implemented as a standalone library
+  under `src/drift/`? Does no CLI command or MCP handler contain core logic?
+- [ ] **II. Test-First**: Are failing tests written and approved BEFORE implementation
+  begins? Are precision/recall fixtures updated for any signal changes?
+- [ ] **III. Functional Programming**: Do new modules use pure functions and frozen
+  Pydantic models? Are side effects isolated at system boundaries (CLI, Git, I/O)?
+- [ ] **IV. CLI Interface & Observability**: Does the library expose a Click subcommand?
+  Are both JSON and Rich output formats supported?
+- [ ] **V. Simplicity & YAGNI**: Is every abstraction justified by a concrete, failing test
+  or benchmark delta? Is there a simpler alternative that was considered and rejected?
+- [ ] **VI. Vertical Slices**: Is the feature organized as a self-contained slice
+  under `src/drift/<feature_name>/`? Does it own its own models, logic, and CLI
+  subcommand? Are cross-slice dependencies expressed only through public module
+  interfaces — no imports of sibling-slice internals?
 
 ## Project Structure
 
 ### Documentation (this feature)
 
 ```text
-specs/004-agent-pr-review-loop/
-├── plan.md              # This file
-├── spec.md              # Clarified specification
-├── research.md          # Phase 0 output
-├── data-model.md        # Phase 1 output
-├── contracts/
-│   └── cli-pr-loop.md   # CLI contract (drift pr-loop)
-├── checklists/
-│   └── requirements.md
-└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
 ```
 
 ### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
 
 ```text
-# Vertical Slice (Constitution Principle VI)
-src/drift/pr_loop/
-├── __init__.py           # Public API: loop_until_approved, LoopState, PrLoopConfig
-├── _models.py            # Frozen Pydantic models: LoopState, ReviewRound, ReviewerVerdict,
-│                         #   ReviewComment, LoopExitStatus, ReviewState
-├── _state.py             # Pure I/O: load_loop_state(), save_loop_state()
-├── _engine.py            # Pure logic: poll_reviews(), collect_unresolved_comments(),
-│                         #   next_loop_state(), should_escalate(), should_exit()
-├── _gh.py                # Side-effects only: post_self_review(), request_reviewers(),
-│                         #   push_fix_commits(), post_escalation_summary()
-│                         #   (all calls via subprocess → gh CLI)
-├── _output.py            # Rich + JSON output rendering
-└── _cmd.py               # Click subcommand: @drift_cli.command("pr-loop")
+# [REMOVE IF UNUSED] Option 1: Vertical Slice (DEFAULT for Drift features)
+# Each slice owns its models, logic, CLI subcommand, and tests.
+src/drift/<feature_name>/
+├── __init__.py          # Public API surface — no internals exported
+├── _models.py           # Frozen Pydantic models (private to slice)
+├── _detector.py         # Core detection / processing logic (pure functions)
+├── _output.py           # Output formatting (Rich + JSON)
+└── _cmd.py              # Click subcommand registration
 
-# Config extension (existing file)
-src/drift/config/_loader.py   # Add PrLoopConfig model + pr_loop field on DriftConfig
+tests/<feature_name>/
+├── test_<feature>_unit.py       # Pure-function unit tests
+├── test_<feature>_contract.py   # Public API contract tests
+└── test_<feature>_integration.py
 
-# Script entry point (thin wrapper)
-scripts/pr_review_loop.py     # sys.exit(main()) wrapper around drift.pr_loop CLI
+# [REMOVE IF UNUSED] Option 2: New signal (Signal slice)
+src/drift/signals/<signal_name>.py   # Single-file slice when logic is compact
+tests/test_signals_<signal_name>.py
 
-# Copilot orchestration skill (agent primitive)
-.github/skills/drift-pr-review-loop/
-└── SKILL.md              # When/how the agent invokes drift pr-loop and interprets output
-
-# Tests
-tests/pr_loop/
-├── __init__.py
-├── test_models_unit.py        # Pydantic model validation, state transitions
-├── test_engine_unit.py        # Pure function tests: polling logic, exit conditions
-├── test_state_unit.py         # load/save round-trip, corrupted-file handling
-├── test_gh_contract.py        # Contract tests: gh CLI call shapes (subprocess mock)
-└── test_cmd_integration.py    # Click CLI integration: exit codes, output formats
-
-# Schema (updated as part of DriftConfig change)
-drift.schema.json             # Regenerated after PrLoopConfig added to DriftConfig
+# [REMOVE IF UNUSED] Option 3: Multi-layer feature (only when explicitly required)
+# Use ONLY if the feature spans ingestion + signals + output and cannot be
+# decomposed into independent slices. Must be justified in Complexity Tracking.
+src/drift/<feature_name>/
+├── ingestion/
+├── signals/
+└── output/
+tests/<feature_name>/
 ```
 
-**Structure Decision**: Vertical slice `src/drift/pr_loop/`. Justification: this feature owns its own models, state machine, side-effect layer, and CLI subcommand — it does not share logic with existing slices. The only external import is `DriftConfig` from `src/drift/config/`.
+**Structure Decision**: [Document the selected structure and reference the real
+directories captured above]
 
 ## Complexity Tracking
 
-No Constitution violations. No justified exceptions required.
+> **Fill ONLY if Constitution Check has violations that must be justified**
 
----
-
-## Implementation Phases
-
-### Phase A — Foundation (TDD Red): Failing Tests + Models
-
-**Goal**: All test files exist with meaningful failing tests before any implementation is written.
-
-| Task | File | Notes |
-|------|------|-------|
-| A1 | `tests/pr_loop/test_models_unit.py` | Test `PrLoopConfig` validation rules (min rounds, min interval, non-empty reviewers); test `LoopState` transitions; test `ReviewState` enum completeness |
-| A2 | `tests/pr_loop/test_engine_unit.py` | Test `should_escalate()`, `should_exit()`, `next_loop_state()` with synthetic verdict lists; test timeout logic; test contradiction detection |
-| A3 | `tests/pr_loop/test_state_unit.py` | Test `load_loop_state` / `save_loop_state` round-trip; test corrupted JSON handling; test missing file returns fresh state |
-| A4 | `tests/pr_loop/test_gh_contract.py` | Contract tests for `post_self_review()`, `request_reviewers()`, `post_escalation_summary()` — assert correct `gh` CLI call shapes via `subprocess` mock |
-| A5 | `tests/pr_loop/test_cmd_integration.py` | CLI exit codes (0/1/2/3), `--dry-run` produces no writes, `--format json` output schema matches contract |
-| A6 | `src/drift/config/_loader.py` | Add `PrLoopConfig` Pydantic model; add `pr_loop: PrLoopConfig \| None = None` field to `DriftConfig` |
-| A7 | Regenerate `drift.schema.json` | Run schema regen after A6 to prevent `test_config_schema.py` CI failure |
-
-**Exit gate**: `pytest tests/pr_loop/ -x` shows all tests collected and failing (not erroring). `make check` passes for non-pr-loop tests.
-
----
-
-### Phase B — Implementation (TDD Green): Library Core
-
-**Goal**: All Phase A tests pass. No new logic outside `src/drift/pr_loop/`.
-
-| Task | File | Notes |
-|------|------|-------|
-| B1 | `src/drift/pr_loop/_models.py` | Implement frozen Pydantic models per data-model.md |
-| B2 | `src/drift/pr_loop/_state.py` | Implement `load_loop_state` / `save_loop_state` using `pathlib.Path.write_text(encoding="utf-8")` |
-| B3 | `src/drift/pr_loop/_engine.py` | Implement pure state-transition functions; polling loop logic (calls `_gh.get_reviews()` then checks exit conditions) |
-| B4 | `src/drift/pr_loop/_gh.py` | Implement `gh` CLI wrappers via `subprocess.run(check=True, capture_output=True, text=True)`; parse JSON output |
-| B5 | `src/drift/pr_loop/_output.py` | Implement Rich + JSON rendering; use `console.print(markup=False)` for literal bracket text |
-| B6 | `src/drift/pr_loop/_cmd.py` | Implement Click subcommand; wire precondition checks; handle all 4 exit codes |
-| B7 | `src/drift/pr_loop/__init__.py` | Export public API: `loop_until_approved`, `LoopState`, `PrLoopConfig` |
-| B8 | Register CLI subcommand | Add `from drift.pr_loop._cmd import pr_loop_cmd` to `src/drift/cli.py` (or equivalent registration point) |
-| B9 | `scripts/pr_review_loop.py` | Thin wrapper: `from drift.pr_loop._cmd import main; sys.exit(main())` |
-
-**Exit gate**: `pytest tests/pr_loop/ -x` all green. `make check` passes. `drift pr-loop --help` outputs correct usage.
-
----
-
-### Phase C — Orchestration Skill
-
-**Goal**: The Copilot agent has a clear, hardened SKILL it can invoke instead of guessing the workflow.
-
-| Task | File | Notes |
-|------|------|-------|
-| C1 | `.github/skills/drift-pr-review-loop/SKILL.md` | Write SKILL per prompt-engineering rules: discovery-taugliches Frontmatter; describe preconditions, tool calls (`drift pr-loop`), output interpretation, and escalation handling; no duplication of spec prose |
-
-**SKILL structure**:
-- **Trigger**: agent has just opened or updated a PR and wants to drive it to approval
-- **Preconditions**: local gates passed, `gh auth status` OK, PR number known
-- **Step 1**: run `drift pr-loop <PR_NUMBER> --format json`
-- **Step 2**: interpret exit code (0=done, 1=escalated → post human-readable summary, 2/3=error → diagnose)
-- **Step 3**: if `status == ESCALATED`, read `work_artifacts/pr-loop-<PR>.json` for unresolved items and surface them to the human
-- **Stop condition**: exit code 0 or human escalation acknowledged
-
----
-
-### Phase D — Hardening & Documentation
-
-**Goal**: No regressions, schema in sync, quickstart written.
-
-| Task | File | Notes |
-|------|------|-------|
-| D1 | `specs/004-agent-pr-review-loop/quickstart.md` | Minimal "how to use" for the agent: install check, `drift.yaml` snippet, one-liner invocation |
-| D2 | `CHANGELOG.md` | `feat:` entry via `make changelog-entry` — do not hand-format |
-| D3 | `drift.yaml` | Add `pr_loop:` section with defaults (document but do not activate in strict mode) |
-| D4 | `make check` | Full local CI must pass clean |
-| D5 | `pre-commit run --all-files` | Secrets, typos, shellcheck, EOF — all green |
-| D6 | `make gate-check COMMIT_TYPE=feat` | Evidence artifact required — create `benchmark_results/v<VERSION>_agent-pr-review-loop_feature_evidence.json` via `drift-evidence-artifact-authoring` skill |
-
----
-
-## Risk Register (this feature)
-
-| Risk | Likelihood | Mitigation |
-|------|-----------|------------|
-| `github-copilot[bot]` not enabled at repo level → bot never reviews | Medium | `_engine.py` treats `NO_RESPONSE` after timeout as soft failure; escalation summary explicitly states bot was not seen |
-| `gh` CLI not authenticated in CI | Low | Precondition check (exit code 3) catches this before any loop starts |
-| `drift.schema.json` not regenerated after `DriftConfig` change | High | Task A7 is mandatory; `make check` fails if forgotten (existing `test_config_schema.py` catches it) |
-| Windows path encoding in `work_artifacts/` JSON | Medium | `_state.py` uses `encoding="utf-8"` explicitly on all read/write calls |
-| Loop runs indefinitely if polling never times out | Low | `poll_timeout_seconds` is always enforced; `max_rounds` is a hard cap |
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/004-agent-pr-review-loop/spec.md
+++ b/specs/004-agent-pr-review-loop/spec.md
@@ -14,6 +14,10 @@
 - Q: Copilot Review auslösen (wie wird der Cloud-Reviewer angefordert?) → A: `gh` CLI / GitHub API — `github-copilot[bot]` als Reviewer explizit per Skript anfordern
 - Q: Loop-Zustand persistieren (wo wird der Zustand zwischen Runden gespeichert?) → A: Temporäre JSON-Datei `work_artifacts/pr-loop-<PR-Nummer>.json`, gitignored
 - Q: Konfigurationsort (wo leben Reviewer-Liste und max. Runden?) → A: Neuer Abschnitt `pr_loop:` in `drift.yaml`
+- Q: Reviewer-Timeout-Verhalten (keine Antwort bis Polling-Timeout) → A: Runde als `timeout/escalated` markieren, in Exit-Summary aufnehmen, kein `ready for human review` ohne explizite Policy
+- Q: Wer darf den Timeout-Policy-Override setzen? → A: Nur Maintainer über statische Repo-Konfiguration (`drift.yaml`), kein Laufzeit-Override per CLI-Flag
+- Q: Wie werden widersprüchliche Reviewer-Entscheidungen aufgelöst? → A: Deterministische Prioritätsmatrix in `drift.yaml`, nur bei Patt eskalieren
+- Q: Welche Feedback-Typen werden in v1 automatisiert verarbeitet? → A: Review-Status plus PR-Thread-Kommentare, keine Inline-Code-Kommentare
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -59,7 +63,7 @@ When any agent reviewer requests changes, the agent reads every unresolved comme
 
 **Acceptance Scenarios**:
 
-1. **Given** at least one reviewer has "Changes Requested", **When** the agent starts the next iteration, **Then** it reads every unresolved comment, produces commits that address each one, and pushes to the PR branch.
+1. **Given** at least one reviewer has "Changes Requested", **When** the agent starts the next iteration, **Then** it reads every unresolved in-scope comment (PR-thread in v1), produces commits that address each one, and pushes to the PR branch.
 2. **Given** the agent has pushed fixes, **When** all previously requesting reviewers have now approved, **Then** the loop exits with a "ready for human review" status.
 3. **Given** the maximum loop rounds are reached and agent reviewers still request changes, **When** the loop exits with unresolved feedback, **Then** the agent posts a summary comment listing all unresolved items and marks the PR for human escalation.
 
@@ -82,9 +86,9 @@ A human reviewer leaves a comment on the open PR. The agent reads it, responds w
 
 ### Edge Cases
 
-- What happens when an agent reviewer becomes unavailable mid-loop (timeout, API error)? → Loop marks that reviewer as skipped for this round and proceeds; the skip is noted in the self-review comment.
+- What happens when an agent reviewer becomes unavailable mid-loop (timeout, API error)? → Loop marks the round as `timeout/escalated`, records the reviewer in the exit summary, and does not set `ready for human review` unless an explicit policy override is configured.
 - What happens when the agent's fix introduces a new CI failure? → The agent detects the new failure, reverts or fixes it, and re-runs all local gates before re-requesting reviews.
-- What happens when two agent reviewers contradict each other? → The agent flags the contradiction in a PR comment, pauses the loop, and escalates to the human maintainer for resolution.
+- What happens when two agent reviewers contradict each other? → The loop resolves outcomes through a deterministic priority matrix configured in `drift.yaml`; only unresolved ties are escalated to the human maintainer.
 - What happens when the PR branch has merge conflicts? → The agent resolves merge conflicts (if straightforward) or posts a conflict report and pauses the loop pending human guidance.
 - What happens when max rounds are reached but the PR is almost approved (1 minor comment)? → The loop still exits, posts the escalation summary, and does not force-merge.
 
@@ -97,7 +101,10 @@ A human reviewer leaves a comment on the open PR. The agent reads it, responds w
 - **FR-003**: After opening the PR, the agent MUST post a structured self-review comment that covers: files changed, drift signals triggered, identified risks, and a preliminary verdict.
 - **FR-004**: After the self-review, the agent MUST request `github-copilot[bot]` and any other configured reviewers via the GitHub API (`gh pr edit --add-reviewer` or equivalent REST call).
 - **FR-005**: The loop engine MUST poll PR review state via `gh pr view --json reviews` at a configurable interval until all requested agent reviewers have responded or the polling timeout is reached.
+- **FR-005a**: If polling timeout is reached for any configured reviewer, the loop MUST mark the current round as `timeout/escalated`, include that reviewer in the exit summary, and MUST NOT transition the PR to `ready for human review` unless an explicit policy override is configured.
+- **FR-005b**: Timeout policy overrides MUST be maintainers-only and configured statically in repository config (`drift.yaml`); runtime overrides via CLI flags, PR comments, or reviewer actions MUST NOT be accepted.
 - **FR-006**: When any agent reviewer requests changes, the agent MUST read all unresolved comments, produce commits addressing each one, push to the PR branch, and re-request reviews.
+- **FR-006a**: In v1, automated feedback ingestion MUST include only reviewer decision states (Approved / Changes Requested) and unresolved PR-thread comments; inline code comments are explicitly out of scope for automated handling.
 - **FR-007**: The loop MUST exit when all configured agent reviewers have approved the PR.
 - **FR-008**: The loop MUST also exit when a configurable maximum number of review rounds (configured under `pr_loop.max_rounds` in `drift.yaml`) is reached; in that case the agent MUST post an escalation summary listing all unresolved items.
 - **FR-009**: When a human comment is detected, the agent MUST respond to or explicitly defer it before the next push.
@@ -106,12 +113,13 @@ A human reviewer leaves a comment on the open PR. The agent reads it, responds w
 - **FR-012**: The loop engine MUST persist its state to `work_artifacts/pr-loop-<PR-number>.json` (gitignored) after each round so the loop can be resumed if the process is interrupted.
 - **FR-013**: The feature MUST be implemented as: (a) a `scripts/pr_review_loop.py` thin entry-point (`sys.exit(main())`) that delegates all logic to `src/drift/pr_loop/`; the engine MUST reside in the library, NOT in the script; and (b) a `.github/skills/drift-pr-review-loop/SKILL.md` orchestration layer that the Copilot agent uses to invoke the engine and interpret results.
 - **FR-014**: When the PR branch has merge conflicts, the agent MUST detect them before each gate run. For purely mechanical conflicts (whitespace, adjacent non-overlapping hunks), the agent MAY attempt auto-resolution via `git merge`; for semantic conflicts, the agent MUST post a conflict-report comment on the PR, set `LoopState.status = ESCALATED`, and pause the loop without pushing further commits.
+- **FR-015**: Contradictory reviewer outcomes MUST be resolved using a deterministic priority matrix configured under `pr_loop` in `drift.yaml`; if the matrix yields a tie or no rule, the loop MUST escalate and post a contradiction summary comment.
 
 ### Key Entities
 
 - **PR Review Round**: One complete pass of self-review → agent-review request → polling wait → feedback collection → fix commits. Each round has a sequence number, a list of reviewers, and a verdict per reviewer.
 - **Agent Reviewer**: A configurable participant in the review loop defined under `pr_loop.reviewers` in `drift.yaml`. Primary reviewer: `github-copilot[bot]`, triggered via GitHub API. Has a name, trigger method, and response type (Approved / Changes Requested / No Response).
-- **Review Comment**: A single unit of feedback attached to a specific file/line or the PR thread. Has an author (human or agent), a resolution status, and — after the agent responds — a linked commit or reply.
+- **Review Comment**: A single unit of feedback in the PR thread for v1 (not inline code comments). Has an author (human or agent), a resolution status, and — after the agent responds — a linked commit or reply.
 - **Loop Exit Condition**: Either "all configured agent reviewers approved" or "`pr_loop.max_rounds` reached". Determines whether the PR exits into "ready for human review" or "escalated" state.
 - **Self-Review Artefact**: The structured comment the agent posts after each push. Contains the drift analysis result, gate outcomes, comment resolution list, and loop state.
 - **Loop State File**: `work_artifacts/pr-loop-<PR-number>.json` — gitignored JSON file written by `scripts/pr_review_loop.py` after each round. Contains: PR number, current round index, reviewer verdicts, list of addressed comment IDs, and loop exit status.
@@ -133,8 +141,11 @@ A human reviewer leaves a comment on the open PR. The agent reads it, responds w
 - "Cloud agent reviews" means requesting `github-copilot[bot]` (and any other reviewer listed under `pr_loop.reviewers` in `drift.yaml`) via the GitHub API; these are triggered by the script calling `gh pr edit --add-reviewer`, not by separate manual steps.
 - "Local agent reviews" means automated gate scripts (`pre-commit`, `make check`, `make gate-check`, `drift analyze`) that run on the agent's local machine before and after each push.
 - Reviewer list and maximum loop rounds are configured under a new `pr_loop:` section in `drift.yaml`; sensible defaults (1 reviewer: `github-copilot[bot]`, max 5 rounds, poll interval 60 s) are provided so the feature works out-of-the-box.
+- Any timeout-policy override is a maintainer-managed repository setting in `drift.yaml`; the agent cannot alter it at runtime.
 - Loop state is persisted to `work_artifacts/pr-loop-<PR-number>.json` (gitignored); this file is created by `scripts/pr_review_loop.py` and read by the SKILL orchestration layer.
 - Human approval is the final merge gate and is explicitly outside the automated loop — the loop only drives the PR to a "ready for human review" state.
 - The agent has read/write access to the GitHub PR (can post comments, request reviewers, push commits) via an authenticated `gh` CLI session (no additional token setup required beyond existing repo auth).
 - Merge conflicts that require semantic understanding are escalated to the human rather than auto-resolved.
+- Reviewer-decision conflict handling follows a deterministic matrix in `drift.yaml`; unresolved ties are escalated to humans.
+- v1 feedback automation scope is limited to reviewer decisions and PR-thread comments; inline code comments are deferred to a later version.
 - The workflow applies to all PRs created by agents in this repo; manually created PRs are out of scope for v1.

--- a/specs/005-evidence-based-verification/checklists/requirements.md
+++ b/specs/005-evidence-based-verification/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Evidence-Based Drift Verification
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Alle Pflichtabschnitte vollständig ausgefüllt. Keine NEEDS CLARIFICATION-Marker vorhanden.
+- Schwellwerte (Drift Score, Spec Confidence) sind bewusst als "konfigurierbar mit Standardwerten" spezifiziert, ohne konkrete Zahlenwerte — das ist eine Implementierungsentscheidung.
+- Independent Review und Rule-Promotion sind als optionale/fortgeschrittene Stories (P3/P4) eingestuft; das Feature liefert bereits mit P1+P2 messbaren Wert.
+- Ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/005-evidence-based-verification/contracts/cli-contract.md
+++ b/specs/005-evidence-based-verification/contracts/cli-contract.md
@@ -1,0 +1,115 @@
+# CLI Contract: drift verify
+
+**Feature 005 — Evidence-Based Drift Verification**
+
+---
+
+## Command: `drift verify`
+
+```
+drift verify [OPTIONS]
+```
+
+Prüft ein Change-Set gegen Architekturregeln, Spec-Akzeptanzkriterien und optionalen Independent Review. Gibt ein Evidence Package als JSON oder Rich-Ausgabe zurück.
+
+---
+
+## Options
+
+| Flag | Typ | Default | Beschreibung |
+|---|---|---|---|
+| `--diff PATH` | Path | — | Unified-Diff-Datei (stdin wenn `-`) |
+| `--repo PATH` | Path | `.` | Wurzel des zu analysierenden Repos |
+| `--spec PATH` | Path | `None` | Pfad zu `spec.md` für Confidence-Check |
+| `--format [json\|rich\|sarif]` | Choice | `rich` | Ausgabeformat (sarif für CI/GitHub Actions) |
+| `--reviewer / --no-reviewer` | Flag | `--reviewer` | Independent Reviewer Agent aktivieren |
+| `--reviewer-timeout INTEGER` | int | `60` | Timeout in Sekunden für den Reviewer-Agent |
+| `--threshold-drift FLOAT` | float | `0.3` | Drift Score Schwellwert für `automerge` (≤ = ok) |
+| `--threshold-confidence FLOAT` | float | `0.8` | Spec Confidence Schwellwert für `automerge` (≥ = ok) |
+| `--promote-threshold INTEGER` | int | `5` | Anzahl Vorkommen für Rule-Promotion-Vorschlag |
+| `--output PATH` | Path | `None` | JSON in Datei schreiben |
+| `--exit-zero` | Flag | off | Immer Exit 0 (auch bei `needs-fix`) |
+
+---
+
+## Exit Codes
+
+| Code | Bedeutung |
+|---|---|
+| 0 | `automerge` oder `--exit-zero` gesetzt |
+| 1 | `needs_fix` — mindestens ein Blocker |
+| 2 | `needs_review` — kein eindeutiges Urteil |
+| 3 | `escalate_to_human` |
+| 10 | Eingabefehler (kein Diff, ungültiger Pfad) |
+
+---
+
+## JSON Output: Evidence Package Schema (v1)
+
+```json
+{
+  "schema": "evidence-package-v1",
+  "version": "<drift-version>",
+  "change_set_id": "<sha256-of-diff>",
+  "repo": "<repo-path>",
+  "verified_at": "<ISO-8601>",
+  "drift_score": 0.0,
+  "spec_confidence_score": 1.0,
+  "action_recommendation": {
+    "verdict": "automerge | needs_fix | needs_review | escalate_to_human",
+    "reason": "<one sentence>",
+    "blocking_violation_count": 0
+  },
+  "violations": [
+    {
+      "violation_type": "layer_violation | forbidden_dependency | file_placement | naming_convention | rule_conflict",
+      "severity": "critical | high | medium | low",
+      "file": "<relative-path>",
+      "line": 42,
+      "rule_id": "AVS",
+      "conflicting_rule_id": null,
+      "message": "<what was found>",
+      "remediation": "<what to do>"
+    }
+  ],
+  "functional_evidence": {
+    "tests_passed": true,
+    "tests_total": 120,
+    "tests_failing": 0,
+    "lint_passed": true,
+    "typecheck_passed": true,
+    "screenshots": [],
+    "logs": [],
+    "metrics": {}
+  },
+  "independent_review": {
+    "available": true,
+    "confidence_delta": 0.05,
+    "findings": [],
+    "spec_criteria_violated": []
+  },
+  "rule_promotions": [
+    {
+      "pattern_key": "layer_violation::src/drift/commands/",
+      "occurrence_count": 5,
+      "threshold": 5,
+      "suggested_rule_id": "CUSTOM-001",
+      "suggested_description": "...",
+      "affected_files": []
+    }
+  ],
+  "flags": []
+}
+```
+
+**Schema-Validierung**: `scripts/generate_evidence_schema.py` (analog zu `generate_output_schema.py`) — CI-Gate über `tests/test_evidence_schema.py`.
+
+---
+
+## Invarianten
+
+- `violations` ist leer wenn `flags` enthält `no_changes_detected`
+- `action_recommendation.verdict == "automerge"` **nur wenn** `violations == []` AND `drift_score ≤ threshold_drift` AND `spec_confidence_score ≥ threshold_confidence` — alle drei Bedingungen müssen erfüllt sein; `drift_score == 0.0` allein reicht nicht
+- `independent_review` ist `null` wenn `--no-reviewer` gesetzt oder `independent_review.available == false` (Timeout)
+- Bei `flags` enthält `rule_conflict`: `action_recommendation.verdict` ist mindestens `needs_review`
+- `flags` enthält `no_changes_detected` → `action_recommendation.verdict == "automerge"` (Kurzpfad, kein Score-Check nötig)

--- a/specs/005-evidence-based-verification/contracts/reviewer-agent-protocol.md
+++ b/specs/005-evidence-based-verification/contracts/reviewer-agent-protocol.md
@@ -1,0 +1,79 @@
+# ReviewerAgentProtocol Contract
+
+**Feature 005 — Evidence-Based Drift Verification**
+
+---
+
+## Zweck
+
+Definiert den Protokoll-Vertrag zwischen `src/drift/verify/_checker.py` und der `ReviewerAgentProtocol`-Schnittstelle. Abstrahiert den unabhängigen Reviewer-Agent so, dass in Tests ein `MockReviewerAgent` injiziert werden kann.
+
+---
+
+## Protocol Definition
+
+```python
+from typing import Protocol
+from drift.verify._models import ChangeSet, IndependentReviewResult
+
+class ReviewerAgentProtocol(Protocol):
+    def review(
+        self,
+        change_set: ChangeSet,
+        preliminary_violations: list[ViolationFinding],
+        timeout_seconds: int = 60,
+    ) -> IndependentReviewResult:
+        """
+        Führt einen unabhängigen Review in einem frischen Kontext durch.
+
+        Args:
+            change_set: Das zu prüfende Change-Set.
+            preliminary_violations: Violations aus dem deterministischen Check.
+            timeout_seconds: Maximale Wartezeit. Bei Überschreitung muss
+                             IndependentReviewResult(available=False, ...) zurückgegeben
+                             werden — KEIN Exception-Raise.
+
+        Returns:
+            IndependentReviewResult mit available=True bei Erfolg,
+            available=False bei Timeout oder Fehler.
+        """
+        ...
+```
+
+---
+
+## Fallback-Vertrag (Timeout/Fehler)
+
+Ein `ReviewerAgentProtocol`-Implementierer MUSS bei Timeout oder jedem internen Fehler folgendes zurückgeben (statt Exception zu raisen):
+
+```python
+IndependentReviewResult(
+    available=False,
+    confidence_delta=0.0,
+    findings=[],
+    spec_criteria_violated=[],
+)
+```
+
+Der Aufrufer ergänzt dann `EvidenceFlag.independent_review_unavailable` im `EvidencePackage.flags`.
+
+---
+
+## MockReviewerAgent (Test-Implementierung)
+
+```python
+class MockReviewerAgent:
+    def __init__(self, result: IndependentReviewResult):
+        self._result = result
+
+    def review(self, change_set, preliminary_violations, timeout_seconds=60):
+        return self._result
+```
+
+Verwendung in Tests: immer über `MockReviewerAgent` — kein echter LLM-Call in der Test-Suite.
+
+---
+
+## Wiring im ProductionCode
+
+`src/drift/verify/_reviewer.py` enthält die Produktions-Implementierung (`DriftMcpReviewerAgent`), die den `drift_nudge`-MCP-Endpoint als Review-Proxy verwendet. Diese Implementierung ist optional (`[reviewer]` extra in `pyproject.toml`); ohne sie wird `MockReviewerAgent(result=unavailable)` als Default genommen.

--- a/specs/005-evidence-based-verification/data-model.md
+++ b/specs/005-evidence-based-verification/data-model.md
@@ -1,0 +1,191 @@
+# Data Model: Evidence-Based Drift Verification
+
+**Phase 1 Output** | Feature 005 | 2026-05-01
+
+---
+
+## Entities
+
+### ChangeSet
+
+Die zu prüfende Eingabe. Wird vom Aufrufer übergeben.
+
+```
+ChangeSet (frozen Pydantic model)
+├── diff_text: str                  # Unified diff als Text (kann leer sein)
+├── changed_files: list[Path]       # Optional: explizite Dateiliste
+├── spec_path: Path | None          # Optionaler Pfad zu spec.md für Confidence-Check
+├── repo_path: Path                 # Wurzel des analysierten Repos
+├── author: str | None
+└── created_at: datetime
+```
+
+**State transitions**: Kein eigener Zustand; dient als Input-Value-Object.
+
+---
+
+### EvidencePackage
+
+Das zentrale Ergebnis-Artefakt. Unveränderlich nach Erstellung.
+
+```
+EvidencePackage (frozen Pydantic model)
+├── schema: str = "evidence-package-v1"
+├── version: str                    # drift-version
+├── change_set_id: str              # sha256 des diff_text (leer → "empty")
+├── repo: str                       # repo_path.as_posix()
+├── verified_at: datetime
+├── drift_score: float              # 0.0–1.0; aus deterministischem Check
+├── spec_confidence_score: float    # 0.0–1.0; passed_checks / total_checks
+├── action_recommendation: ActionRecommendation
+├── violations: list[ViolationFinding]
+├── functional_evidence: FunctionalEvidence
+├── independent_review: IndependentReviewResult | None
+├── rule_promotions: list[RulePromotionProposal]
+└── flags: set[EvidenceFlag]        # z.B. no_changes_detected, rule_conflict
+```
+
+---
+
+### ViolationFinding
+
+Einzelne gefundene Verletzung einer Architektur- oder Strukturregel.
+
+```
+ViolationFinding (frozen Pydantic model)
+├── violation_type: ViolationType   # Enum: layer_violation, forbidden_dependency,
+│                                   #       file_placement, naming_convention, rule_conflict
+├── severity: Severity              # Enum: critical, high, medium, low (von Drift-Signalen)
+├── file: str | None                # relative Dateipfad
+├── line: int | None
+├── rule_id: str | None             # z.B. "AVS", "PFS" oder custom rule ID
+├── conflicting_rule_id: str | None # Nur bei rule_conflict
+├── message: str                    # Beschreibung des Verstoßes
+└── remediation: str                # Agentenverständliche Reparaturanweisung
+```
+
+---
+
+### ActionRecommendation
+
+Maschinenlesbares Urteil.
+
+```
+ActionRecommendation (frozen Pydantic model)
+├── verdict: Verdict                # Enum: automerge, needs_fix, needs_review,
+│                                   #       escalate_to_human
+├── reason: str                     # Ein Satz
+└── blocking_violation_count: int   # Anzahl Violations, die das Urteil erzwingen
+```
+
+**Entscheidungslogik (deterministisch):**
+- `no_changes_detected` Flag gesetzt → `automerge`
+- Violations mit severity `critical` oder `high` → `needs_fix`
+- `rule_conflict`-Flag → `needs_review` (override)
+- `independent_review_unavailable`-Flag → `needs_review` (override bei reviewpflichtigen Diffs)
+- Drift Score ≤ Schwellwert AND Spec Confidence ≥ Schwellwert AND keine offenen Violations → `automerge`
+- Sonst → `needs_review`
+
+---
+
+### FunctionalEvidence
+
+Ergebnisse der automatischen CI-Checks.
+
+```
+FunctionalEvidence (frozen Pydantic model)
+├── tests_passed: bool | None       # None = nicht verfügbar
+├── tests_total: int | None
+├── tests_failing: int | None
+├── lint_passed: bool | None
+├── typecheck_passed: bool | None
+├── screenshots: list[str]          # Optionale Pfade/URLs
+├── logs: list[str]                 # Optionale Log-Snippets
+└── metrics: dict[str, float]       # Optionale Metriken
+```
+
+---
+
+### IndependentReviewResult
+
+Befunde des Reviewer-Agenten (synchron; None bei Timeout).
+
+```
+IndependentReviewResult (frozen Pydantic model)
+├── available: bool                 # False wenn Timeout/Fehler
+├── confidence_delta: float         # Additiver Einfluss auf spec_confidence_score
+├── findings: list[str]             # Freitext-Befunde des Agents
+└── spec_criteria_violated: list[str]  # Referenzierte Akzeptanzkriterien
+```
+
+---
+
+### RulePromotionProposal
+
+Vorschlag zur dauerhaften Regel aus wiederkehrendem Muster.
+
+```
+RulePromotionProposal (frozen Pydantic model)
+├── pattern_key: str                # (violation_type, file_pattern) als String-Key
+├── occurrence_count: int           # Wie oft bisher gesehen
+├── threshold: int                  # Konfigurierter Schwellwert (Standard: 5)
+├── suggested_rule_id: str          # Vorgeschlagene Regel-ID
+├── suggested_description: str
+└── affected_files: list[str]       # Dateien, in denen das Muster auftrat
+```
+
+---
+
+### PatternHistoryEntry
+
+Persistierter Eintrag für Rule-Promotion-Zähler (JSONL).
+
+```
+PatternHistoryEntry (TypedDict)
+├── type: str           # violation_type
+├── pattern: str        # file_pattern oder betroffene Datei
+├── file: str
+└── ts: str             # ISO timestamp
+```
+
+---
+
+## Enumerations
+
+```python
+class ViolationType(str, Enum):
+    layer_violation = "layer_violation"
+    forbidden_dependency = "forbidden_dependency"
+    file_placement = "file_placement"
+    naming_convention = "naming_convention"
+    rule_conflict = "rule_conflict"
+
+class Verdict(str, Enum):
+    automerge = "automerge"
+    needs_fix = "needs_fix"
+    needs_review = "needs_review"
+    escalate_to_human = "escalate_to_human"
+
+class EvidenceFlag(str, Enum):
+    no_changes_detected = "no_changes_detected"
+    rule_conflict = "rule_conflict"
+    independent_review_unavailable = "independent_review_unavailable"
+```
+
+---
+
+## Validation Rules
+
+- `drift_score` ∈ [0.0, 1.0]
+- `spec_confidence_score` ∈ [0.0, 1.0]
+- `automerge` nur wenn `violations == []` AND `drift_score ≤ threshold` AND `spec_confidence_score ≥ threshold`
+- `EvidenceFlag.no_changes_detected` → `violations` MUSS leer sein, `drift_score == 0.0`, `spec_confidence_score == 1.0`
+- `ViolationType.rule_conflict` → `conflicting_rule_id` MUSS gesetzt sein
+
+---
+
+## Persistenz
+
+- `.drift/pattern_history.jsonl` im Repo-Root (wird angelegt wenn nicht vorhanden)
+- Kein Locking für v1 (Single-Writer-Annahme)
+- Jeder `drift verify`-Aufruf appended Einträge; Read-Seite aggregiert on-the-fly

--- a/specs/005-evidence-based-verification/plan.md
+++ b/specs/005-evidence-based-verification/plan.md
@@ -1,0 +1,103 @@
+# Implementation Plan: 005 Evidence-Based Drift Verification
+
+**Branch**: `feat/adr100-phase7a-cleanup` | **Date**: 2026-05-01 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/005-evidence-based-verification/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Neues `drift verify`-Command, das ein Change-Set (Unified Diff) deterministisch gegen Architekturregeln (AVS/PFS/EDS), Spec-Akzeptanzkriterien und optionalen Independent Review prüft. Ergebnis: maschinenlesbares Evidence Package (JSON `evidence-package-v1`) mit Drift Score, Spec Confidence Score und `ActionRecommendation` (automerge / needs_fix / needs_review / escalate_to_human). Rule-Promotion-Mechanismus erkennt wiederkehrende Violations und schlägt dauerhafte Regeln vor.
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: Python 3.11+  
+**Primary Dependencies**: Pydantic (frozen models), Click (CLI), Rich (terminal output), pytest / mypy / ruff  
+**Storage**: `.drift/pattern_history.jsonl` im Repo-Root (JSONL append, kein DB)  
+**Testing**: pytest + mypy typecheck; ground-truth fixtures in `tests/verify/`  
+**Target Platform**: Linux / macOS / Windows (cross-platform)  
+**Project Type**: library/cli (Vertical Slice in `src/drift/verify/`)  
+**Performance Goals**: Evidence Package in ≤3 min für typischen Feature-Diff (SC-001)  
+**Constraints**: Kein LLM-Aufruf in deterministischer Schicht; Reviewer Agent via `ReviewerAgentProtocol` isoliert; `--no-reviewer` muss immer schnell arbeiten  
+**Scale/Scope**: Einzelner Diff-Check pro Aufruf; Batch-Modus nicht in v1
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Verify each principle from `.specify/memory/constitution.md` (v1.1.0):
+
+- [x] **I. Library-First**: Gesamte Logik in `src/drift/verify/`; `_cmd.py` (Click) enthält nur Argument-Parsing + Aufruf der öffentlichen API `verify(change_set)`.
+- [x] **II. Test-First**: Failing tests für `EvidencePackage`, `ActionRecommendation` und alle Verdicts werden vor Implementierung geschrieben (TDD Red-Green-Refactor).
+- [x] **III. Functional Programming**: Alle Modelle `frozen=True`; `_checker.py` und `_promoter.py` als pure functions; I/O nur in `_cmd.py` und JSONL-Append in `_promoter.py`.
+- [x] **IV. CLI Interface & Observability**: `drift verify` mit `--format json|rich`; JSON = Evidence Package Schema v1; Rich = farbige Zusammenfassung.
+- [x] **V. Simplicity & YAGNI**: Reviewer Agent ist durch SC-006 (Benchmark-Anforderung Independent Review) gerechtfertigt — siehe Complexity Tracking. Kein Batch-Modus, kein Plugin-System in v1.
+- [x] **VI. Vertical Slices**: `src/drift/verify/` enthält eigene Modelle, Logik, Output und CLI-Command. Imports nur über `drift.analyze` public API, nicht interne Signals-Implementierungen.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-evidence-based-verification/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+src/drift/verify/
+├── __init__.py          # Public API: verify(change_set, ...) -> EvidencePackage
+├── _models.py           # Alle frozen Pydantic models aus data-model.md
+├── _checker.py          # Deterministischer Layer (wraps drift analyze Python API)
+├── _reviewer.py         # ReviewerAgentProtocol + MockReviewerAgent + DriftMcpReviewerAgent
+├── _promoter.py         # Rule-Promotion + .drift/pattern_history.jsonl
+├── _output.py           # JSON-Serialisierung (evidence-package-v1) + Rich-Output
+└── _cmd.py              # Click-Subcommand: drift verify
+
+tests/verify/
+├── test_verify_unit.py           # Pure-function tests für _checker, _promoter, _models
+├── test_verify_contract.py       # Public-API-Vertrag (EvidencePackage Invarianten)
+└── test_verify_integration.py    # End-to-End via CLI (subprocess oder invoke)
+
+scripts/
+└── generate_evidence_schema.py   # Analog zu generate_output_schema.py
+
+specs/005-evidence-based-verification/
+├── plan.md              # Dieses Dokument
+├── research.md          # Phase 0
+├── data-model.md        # Phase 1
+├── quickstart.md        # Phase 1
+└── contracts/           # Phase 1
+    ├── cli-contract.md
+    └── reviewer-agent-protocol.md
+```
+
+**Structure Decision**: Vertical Slice (Option 1). Eigenständige `src/drift/verify/` Slice mit eigenem Public API, Modellen, CLI-Command und Tests. Cross-Slice-Dependencies nur über `drift.api` (öffentliche Python-API von drift analyze).
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| `ReviewerAgentProtocol` Abstraction | SC-006 fordert Independent Review als separaten Verifikationsschritt im Benchmark | Direkte Inline-Prüfung könnte keine saubere Mock-Injektion für Tests bieten und würde LLM-Aufruf in deterministischen Layer einmischen |
+| `IndependentReviewResult.confidence_delta` | Reviewer-Befund muss additiv auf Spec Confidence Score wirken, ohne ihn zu überschreiben (deterministische Basis bleibt kontrollierbar) | Score-Override wäre durch LLM-Antworten manipulierbar und widerspricht Constitution III (Functional/deterministic) |
+| Netzwerkaufruf in `DriftMcpReviewerAgent` | Constitution V: „No network calls during analysis.“ gilt für deterministische Signale in `src/drift/signals/`. `drift verify` ist kein Signal-Modul, sondern ein optionaler Verifikations-Layer darüber. Der Netzwerkaufruf ist (a) hinter `ReviewerAgentProtocol` isoliert, (b) opt-in via `--reviewer` (Standard: an, aber deaktivierbar), (c) in Tests immer durch `MockReviewerAgent` ersetzt — kein Produktionscode in `src/drift/signals/` berührt. | Einen Reviewer ohne jede externe Kommunikation zu betreiben würde SC-006 unerfullbar machen und den Zweck des Independent Review zunichte machen. |

--- a/specs/005-evidence-based-verification/quickstart.md
+++ b/specs/005-evidence-based-verification/quickstart.md
@@ -1,0 +1,120 @@
+# Quickstart: drift verify
+
+**Feature 005 — Evidence-Based Drift Verification**
+
+---
+
+## Voraussetzungen
+
+- drift installiert (`pip install -e '.[dev]'` im Workspace)
+- Git-Repository mit `drift.yaml` (oder defaults)
+
+---
+
+## Minimal-Beispiel: Diff aus Git prüfen
+
+```bash
+# Diff des letzten Commits als Datei
+git diff HEAD~1 HEAD > my_change.diff
+
+# Evidence Package generieren (Rich-Ausgabe)
+drift verify --diff my_change.diff --repo .
+
+# JSON-Output für CI/Agenten
+drift verify --diff my_change.diff --repo . --format json
+
+# Mit Spec-Abgleich (Confidence-Score)
+drift verify --diff my_change.diff --repo . --spec specs/005-evidence-based-verification/spec.md --format json
+```
+
+---
+
+## Evidence Package lesen
+
+```json
+{
+  "schema": "evidence-package-v1",
+  "drift_score": 0.12,
+  "spec_confidence_score": 0.91,
+  "action_recommendation": {
+    "verdict": "automerge",
+    "reason": "No violations found; drift and confidence thresholds met.",
+    "blocking_violation_count": 0
+  },
+  "violations": [],
+  "flags": []
+}
+```
+
+**Aktionsempfehlung-Tabelle:**
+
+| verdict | Bedeutung | Exit Code |
+|---|---|---|
+| `automerge` | Alle Prüfungen bestanden | 0 |
+| `needs_fix` | Architekturverletzung oder Test-Fehler | 1 |
+| `needs_review` | Unklares Urteil, Review nötig | 2 |
+| `escalate_to_human` | Kritischer Befund | 3 |
+
+---
+
+## Layer-Verletzung beheben
+
+Wenn das Evidence Package enthält:
+
+```json
+{
+  "violations": [{
+    "violation_type": "layer_violation",
+    "severity": "high",
+    "file": "src/drift/commands/analyze.py",
+    "line": 42,
+    "rule_id": "AVS",
+    "message": "Business logic found in CLI command layer",
+    "remediation": "Move logic to src/drift/analyze/_checker.py; CLI command should only call library API."
+  }]
+}
+```
+
+→ Logik aus dem CLI-Command in den entsprechenden Bibliotheks-Slice verschieben, dann erneut prüfen.
+
+---
+
+## In CI verwenden
+
+```yaml
+# .github/workflows/verify.yml
+- name: Evidence-Based Verification
+  run: |
+    git diff ${{ github.base_ref }}...HEAD > change.diff
+    drift verify --diff change.diff --repo . --format json --output evidence.json
+  continue-on-error: false
+
+- name: Upload Evidence Package
+  uses: actions/upload-artifact@v4
+  with:
+    name: evidence-package
+    path: evidence.json
+```
+
+---
+
+## Rule-Promotion annehmen
+
+Wenn das Evidence Package einen `rule_promotions`-Eintrag enthält:
+
+```bash
+# Vorgeschlagene Regel permanent aktivieren
+drift rules add --id CUSTOM-001 --from-promotion evidence.json
+```
+
+(Feature v2 — in v1 manuell via `drift.yaml` rules-Sektion.)
+
+---
+
+## Flags verstehen
+
+| Flag | Bedeutung |
+|---|---|
+| `no_changes_detected` | Leerer Diff; automerge ohne Prüfung |
+| `rule_conflict` | Zwei Regeln widersprechen sich; needs_review |
+| `independent_review_unavailable` | Reviewer-Agent war nicht erreichbar |

--- a/specs/005-evidence-based-verification/research.md
+++ b/specs/005-evidence-based-verification/research.md
@@ -1,0 +1,86 @@
+# Research: Evidence-Based Drift Verification
+
+**Phase 0 Output** | Feature 005 | 2026-05-01
+
+## R-001: Existierendes JSON-Output-Schema
+
+**Decision**: Evidence Package nutzt dieselbe `schema_version`-Konvention wie `drift analyze --format json`. Es wird ein eigenes top-level Feld `schema` (`"evidence-package-v1"`) eingeführt, um das neue Format eindeutig von `RepoAnalysis`-Output zu unterscheiden.
+
+**Rationale**: Die bestehende Ausgabe via `analysis_to_json()` hat `schema_version = OUTPUT_SCHEMA_VERSION` und zahlreiche `RepoAnalysis`-spezifische Felder (`modules`, `findings`, `suppressed`). Das Evidence Package hat eine andere Semantik (Diff-level, nicht Repo-level) und muss ein eigenes Schema erhalten. Konsistenz in Namenskonvention und Serialisierungsform (JSON, `json.dumps`, `sort_keys=True`) wird beibehalten.
+
+**Alternatives considered**:
+- SARIF: Zu spezifisch auf statische Analyse ausgerichtet; fehlen `spec_confidence_score` und `action_recommendation` als Konzepte.
+- RepoAnalysis wiederverwenden: Würde das Modell mit Diff-spezifischen Feldern verschmutzen (Constitution VI verletzt).
+
+**Key implementation fact**: `drift.output.json_output` und `scripts/generate_output_schema.py` sind die kanonischen Orte für Schema-Definitionen. Ein neues Schema-Generierungsskript `scripts/generate_evidence_schema.py` folgt demselben Muster.
+
+---
+
+## R-002: Spec Confidence Score — Determinismus-Constraint
+
+**Decision**: Der Spec Confidence Score wird **nicht** LLM-basiert berechnet, sondern als deterministischer Coverage-Score über die maschinenlesbaren Acceptance Scenarios in `spec.md`. Jedes Szenario wird gegen die gefundenen Violations, Testresultate und Lint-Status geprüft; der Score ist `passed_checks / total_checks`.
+
+**Rationale**: Die Constitution sagt explizit „No LLM dependency: All 24 signals are deterministic static analysis; no network calls during analysis." Dieses Prinzip gilt auch für neue Features. Ein LLM-basierter Reviewer-Agent (FR-007) ist ein separater, optionaler Layer — er läuft **nach** der deterministischen Phase und sein Ergebnis fließt als `independent_review`-Abschnitt separat ins Evidence Package ein, beeinflusst aber den Score nur als additiver Confidence-Delta, nicht als Überschreibung.
+
+**Alternatives considered**:
+- Vollständig LLM-basiert: Verletzt Constitution; macht Score nicht reproduzierbar (SC-001/SC-004 verletzt).
+- Hybrid mit LLM als primärem Scorer: Zu hohes Risiko für False-Confidence; LLM-Outputs sind nicht bit-identisch wiederholbar.
+
+**Key implementation fact**: Die Acceptance Scenarios müssen als maschinenlesbare Prädikat-Liste vorliegen. Für v1 bedeutet das: FR-Checks (harte Invarianten) = 100% Gewicht im Struktur-Teil; Test/Lint-Status = Coverage-Anteil im Verifikations-Teil.
+
+---
+
+## R-003: Architectural Invariant Check — Bestehende Signale wiederverwenden
+
+**Decision**: Layer-Verletzungen, verbotene Abhängigkeiten und File-Placement-Fehler werden über bestehende Drift-Signale (AVS, PFS, EDS) erkannt, **nicht** neu implementiert. Der Architectural Check ist ein thin Wrapper, der eine reguläre `drift analyze`-Analyse auf dem Diff-Snapshot durchführt und die Resultate in das Evidence Package überführt.
+
+**Rationale**: Die 24 Signale in `src/drift/signals/` leisten bereits das, was der Architectural Check braucht. Eine Neuentwicklung würde dieselbe Logik duplizieren (Constitution V: YAGNI) und Precision/Recall-Tests für die Neuentwicklung erfordern, die bei Wiederverwendung überflüssig sind.
+
+**Alternatives considered**:
+- Eigener AST-basierter Checker: Massive Duplikation; schlechtere Präzision als die kalibrierten Signale.
+- Statische Regel-Engine ohne Signale: Unflexibel; kein Lernmechanismus für neue Muster.
+
+**Key implementation fact**: Der Diff wird in ein temporäres Worktree-Snapshot-Verzeichnis angewendet, dann `drift analyze` darauf ausgeführt (als Python-API, nicht als Subprocess). Die `RepoAnalysis`-Findings werden in `ViolationFinding`-Objekte konvertiert.
+
+---
+
+## R-004: Independent Reviewer Agent — Integrationsvertrag
+
+**Decision**: Der Independent Reviewer Agent ist eine optionale, konfigurierbare Komponente. Für v1 nutzt er `drift.api.nudge` (den internen MCP-Nudge-Mechanismus) als Schnittstelle, um einen zweiten Kontext-Snapshot zu erstellen. Der Agent-Aufruf ist **kein direkter LLM-Call** aus dem Feature-Code; stattdessen wird ein strukturierter Diff-Report an einen MCP-Tool-Endpoint übergeben, der den Review ausführt.
+
+**Rationale**: Die Constitution verbietet keine LLM-basierten Features generell, nur LLM-Abhängigkeiten in den 24 deterministischen Signalen. Eine separate Review-Komponente ist architektonisch sauber, wenn sie hinter einer Schnittstelle isoliert ist (Constitution I: Library-First, VI: Vertical Slice).
+
+**Alternatives considered**:
+- Direkter LLM-SDK-Call: Erzeugt Netzwerkabhängigkeit in der Kernbibliothek; verletzt Performance-Budget-Constraint.
+- Kein Reviewer-Agent in v1: Würde SC-006 (+15 pp Erkennungsrate) unerreichbar machen.
+
+**Key implementation fact**: Der Reviewer-Agent-Aufruf wird über eine `ReviewerAgentProtocol`-Schnittstelle abstrahiert. In Tests wird ein `MockReviewerAgent` injiziert. Timeout-Fallback ist Teil des Protokoll-Vertrags (FR-007).
+
+---
+
+## R-005: Rule-Promotion — Persistenzmodell
+
+**Decision**: Wiederkehrende Verletzungsmuster werden in einer lokalen SQLite-Datenbank (oder als JSONL-Logfile) pro Repository gespeichert. Ab 5 Treffern desselben `(violation_type, file_pattern)`-Schlüssels wird ein `RulePromotionProposal`-Objekt erzeugt und im Evidence Package unter `rule_promotions` ausgegeben. Die Regel selbst wird **nicht automatisch aktiviert** — sie muss manuell via `drift rules add` akzeptiert werden.
+
+**Rationale**: Automatische Aktivierung ohne Maintainer-Review wäre zu riskant (Constitution V: keine spekulativen Features). JSONL ist einfacher als SQLite für ein erstes Feature-Slice und vermeidet eine neue optionale Abhängigkeit.
+
+**Alternatives considered**:
+- Keine Persistenz in v1 (nur In-Memory): Macht Rule-Promotion-Zähler nicht sitzungsübergreifend — SC-005 wäre mit einem einzelnen Analyselauf nicht erfüllbar.
+- Redis/Datenbank: Überdimensioniert; verletzt Constitution V.
+
+**Key implementation fact**: Persistenz-Datei liegt unter `.drift/pattern_history.jsonl` im analysierten Repository. Das Format ist eine JSON-Zeile pro Treffer: `{"type": "...", "pattern": "...", "file": "...", "ts": "..."}`.
+
+---
+
+## R-006: Terminologie und Namenskonventionen (Constitution VI)
+
+**Decision**: Das Feature lebt unter `src/drift/verify/` als eigenständiger Vertical Slice. Die öffentliche API ist `drift.verify`. Der CLI-Subcommand heißt `drift verify --diff <path> [--spec <path>]`.
+
+**Rationale**: `verify` ist semantisch präzise, nicht mit bestehenden Commands (`analyze`, `check`, `brief`) kollisionsfrei und folgt der Verb-Konvention der CLI (Constitution IV).
+
+**Alternatives considered**:
+- `drift evidence`: Zu nah an Artefakt-Namen, nicht intuitiv als Verb.
+- `drift review`: Kollidiert mit dem Konzept des Independent-Review-Agents.
+- Erweiterung von `drift analyze`: Würde den bestehenden Analyze-Slice mit Diff-spezifischer Logik verschmutzen.
+
+**Key implementation fact**: `src/drift/verify/` enthält: `__init__.py`, `_models.py`, `_checker.py` (deterministischer Layer), `_reviewer.py` (Reviewer-Agent-Protokoll + Mock), `_promoter.py` (Rule-Promotion), `_output.py`, `_cmd.py`.

--- a/specs/005-evidence-based-verification/spec.md
+++ b/specs/005-evidence-based-verification/spec.md
@@ -1,0 +1,133 @@
+# Feature Specification: Evidence-Based Drift Verification
+
+**Feature Branch**: `005-evidence-based-verification`  
+**Created**: 2026-05-01  
+**Status**: Draft  
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Änderung erhält vollständiges Evidenzpaket (Priority: P1)
+
+Ein Agent oder Entwickler übergibt ein Change-Set (Diff) an das Verification-Feature. Das Feature führt alle Prüfungen durch und liefert ein reproduzierbares Evidenzpaket: Drift Score, Spec Confidence Score, vollständige Prüfliste mit Status, Fundstellen und Remediation-Hinweisen sowie eine maschinenlesbare Aktionsempfehlung.
+
+**Why this priority**: Ohne dieses Kernergebnis hat das Feature keinen Nutzen. Alle anderen Stories bauen auf dem Evidenzpaket auf.
+
+**Independent Test**: Kann vollständig getestet werden, indem ein synthetischer Diff übergeben wird und das Evidenzpaket auf Vollständigkeit (alle Pflichtfelder, reproduzierbarer Score) geprüft wird — ohne Review-Agent oder Rule-Promotion zu benötigen.
+
+**Acceptance Scenarios**:
+
+1. **Given** ein Agent liefert einen Diff, der keine Architekturverstöße enthält, **When** das Verification-Feature ausgeführt wird, **Then** erscheint eine Aktionsempfehlung `automerge`, ein Drift Score ≤ Schwellwert, ein Spec Confidence Score ≥ Schwellwert und eine leere Violations-Liste.
+2. **Given** ein Agent liefert einen Diff mit einer Layer-Verletzung (UI-Schicht enthält Business-Logik), **When** das Verification-Feature ausgeführt wird, **Then** erscheint eine Aktionsempfehlung `needs_fix`, ein erhöhter Drift Score und mindestens ein Violation-Eintrag mit Fundstelle und Remediation-Hinweis.
+3. **Given** das Feature wird zweimal mit identischem Diff aufgerufen, **When** die Ergebnisse verglichen werden, **Then** sind Drift Score, Spec Confidence Score und Violations-Liste identisch (Reproduzierbarkeit).
+
+---
+
+### User Story 2 — Architekturverstöße werden mit präziser Reparaturanweisung gemeldet (Priority: P2)
+
+Ein Architektur-Check erkennt eine Verletzung einer harten Invariante (falsche Layer-Zuordnung, verbotene Abhängigkeit, File-Placement-Fehler). Das Feature gibt nicht nur eine Warnung aus, sondern eine agentenverständliche Reparaturanweisung, die die betroffene Stelle benennt und die korrekte Zielstruktur beschreibt.
+
+**Why this priority**: Ein Verstoß ohne Remediation erzeugt manuellen Review-Aufwand. Mit präzisen Hinweisen kann ein Agent die Korrektur eigenständig anwenden.
+
+**Independent Test**: Kann mit einem Diff getestet werden, der gezielt eine bekannte Layer-Verletzung enthält. Das Ergebnis muss die korrekte Datei/Zeile, den Verstoßtyp und eine konkrete Handlungsanweisung enthalten.
+
+**Acceptance Scenarios**:
+
+1. **Given** ein Diff verschiebt Business-Logik in eine UI-Komponente, **When** der Architectural Check läuft, **Then** enthält der Violation-Eintrag: Verstoßtyp `layer_violation`, betroffene Datei und Zeile, sowie den Text „Business-Logik in Service-Layer verschieben; UI darf nur Runtime-/Service-Schnittstellen konsumieren."
+2. **Given** ein Diff fügt eine verbotene Abhängigkeit ein (z. B. direkte DB-Abfrage in einem CLI-Command), **When** der Dependency-Check läuft, **Then** enthält der Eintrag die Import-Zeile, den Verstoßtyp `forbidden_dependency` und einen Hinweis auf das erlaubte Zugriffsmuster.
+3. **Given** ein Diff verletzt keine Architekturregeln, **When** die Prüfung läuft, **Then** enthält das Evidence Package keine Violation-Einträge mit Remediation-Hinweisen.
+
+---
+
+### User Story 3 — Unabhängiger Reviewer-Agent prüft auf blinde Flecken (Priority: P3)
+
+Nach der automatischen Prüfung läuft ein unabhängiger Reviewer-Agent in einem frischen Kontext über die Änderung. Dieser identifiziert Edge Cases, Widersprüche zur Spec und strukturelle Probleme, die der primäre Prüfprozess nicht gefunden hat.
+
+**Why this priority**: Einzelne Kontexte haben systematische blinde Flecken. Ein zweiter, unabhängiger Kontext erhöht die Erkennungsrate für Spec-Abweichungen und subtile Fehler.
+
+**Independent Test**: Kann getestet werden, indem ein Diff mit einer bekannten, subtilen Spec-Abweichung (korrekte Tests, aber falsche Semantik) übergeben wird. Der Reviewer-Agent muss diesen Fall identifizieren, der Automatik-Check aber nicht.
+
+**Acceptance Scenarios**:
+
+1. **Given** ein Diff besteht alle automatischen Checks, enthält aber eine semantische Abweichung von der Spec, **When** der Reviewer-Agent läuft, **Then** meldet er mindestens einen Befund mit Bezug auf das verletzte Akzeptanzkriterium.
+2. **Given** der Reviewer-Agent ist für einen Diff konfiguriert, **When** er ausgeführt wird, **Then** gibt es einen eigenen Abschnitt im Evidence Package mit Label `independent_review` und einem separaten Confidence-Delta.
+3. **Given** der Reviewer-Agent findet keine zusätzlichen Probleme, **When** sein Ergebnis zusammengeführt wird, **Then** bleibt die Aktionsempfehlung unverändert.
+
+---
+
+### User Story 4 — Wiederkehrende Verletzungsmuster werden zu dauerhaften Regeln (Priority: P4)
+
+Das Feature erkennt, wenn dasselbe Verletzungsmuster wiederholt auftritt, und ermöglicht dessen Überführung in eine dauerhafte Architektur- oder Cleanup-Regel, sodass künftige Änderungen automatisch gegen diese Regel geprüft werden.
+
+**Why this priority**: Ohne diesen Mechanismus entsteht dieselbe Drift immer wieder. Dauerhafte Regeln machen die Erkennung mit der Zeit präziser und verringern den Review-Aufwand.
+
+**Independent Test**: Kann getestet werden, indem dasselbe Verletzungsmuster fünfmal in verschiedenen Diffs auftritt und geprüft wird, ob das System eine Rule-Promotion vorschlägt und ob die neue Regel bei einem sechsten Diff automatisch greift.
+
+**Acceptance Scenarios**:
+
+1. **Given** dasselbe Verletzungsmuster tritt in mindestens fünf Diffs auf, **When** das Feature die Häufigkeit bewertet, **Then** erzeugt es einen Rule-Promotion-Vorschlag im maschinenlesbaren Format.
+2. **Given** ein Rule-Promotion-Vorschlag wurde akzeptiert, **When** ein neuer Diff mit demselben Muster geprüft wird, **Then** wird der Verstoß durch die neue dauerhafte Regel erkannt, nicht durch Heuristik.
+3. **Given** ein Muster tritt weniger als fünfmal auf, **When** das Feature die Häufigkeit bewertet, **Then** wird kein Rule-Promotion-Vorschlag erzeugt.
+
+---
+
+### Edge Cases
+
+- **Leerer oder Whitespace-only Diff**: Das Feature liefert sofort ein Kurzresultat ohne Fehler — `automerge`, Drift Score 0, Spec Confidence Score 1.0, leere Violations-Liste und ein Hinweis `no_changes_detected` im Evidence Package.
+- **Widerspüchliche Architekturregeln**: Beide Violations werden ausgegeben; die Aktionsempfehlung wird automatisch auf `needs_review` gesetzt, mit dem Hinweis `rule_conflict` und den IDs beider beteiligten Regeln im Evidence Package.
+- **Reviewer-Agent Timeout / Kontextsüberlauf**: Das Feature scheitert nicht; es liefert das Evidenzpaket mit Aktionsempfehlung `needs_review` und dem Hinweis `independent_review_unavailable` im `independent_review`-Abschnitt.
+- **Drift Score 0 bei niedriger Confidence**: `automerge` erfordert drift_score ≤ Schwellwert UND spec_confidence_score ≥ Schwellwert — beide Bedingungen müssen erfüllt sein. Ein Drift Score von 0.0 allein genügt nicht, wenn die Spec Confidence unter dem Schwellwert liegt.
+- **Diffs mit mehreren Layers gleichzeitig**: Alle Violations aus allen betroffenen Layers werden gemeldet. Die `ActionRecommendation` richtet sich nach dem höchsten Severity-Wert: bei mindestens einer `critical`- oder `high`-Violation → `needs_fix`.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Das System MUSS harte Invarianten (Layer-Verletzungen, verbotene Abhängigkeiten, File-Placement-Regeln, Naming-Konventionen) vor allen anderen Prüfungen auswerten.
+- **FR-002**: Das System MUSS einen reproduzierbaren Drift Score pro Änderung berechnen, der widerspiegelt, wie stark die Änderung von Architektur- und Strukturregeln abweicht.
+- **FR-003**: Das System MUSS einen reproduzierbaren Spec Confidence Score berechnen, der angibt, wie wahrscheinlich die Änderung die ursprüngliche Spec bzw. Akzeptanzkriterien erfüllt.
+- **FR-004**: Das System MUSS für jede gefundene Verletzung einen Eintrag mit Verstoßtyp, Fundstelle (Datei und Zeile) und konkreter Remediation-Anweisung ausgeben.
+- **FR-005**: Das System MUSS eine maschinenlesbare Aktionsempfehlung ausgeben: `automerge`, `needs_fix`, `needs_review` oder `escalate_to_human`.
+- **FR-006**: Das System MUSS funktionale Evidenz einbeziehen: Testresultate, Lint-Ergebnisse, Typecheck-Ergebnisse, sowie optional Screenshots, Logs und Metriken. `FunctionalEvidence` wird vom Aufrufer als optionale Eingabe übergeben; `drift verify` sammelt diese Daten nicht selbst (kein interner `pytest`/`ruff`-Aufruf).
+- **FR-007**: Das System MUSS einen unabhängigen Reviewer-Agenten **synchron** in einem frischen Kontext über die Änderung laufen lassen; die Aktionsempfehlung wird erst nach Vorliegen seines Ergebnisses erstellt. Bei Timeout oder Fehler des Reviewer-Agenten MUSS das Feature mit einem definierten Fallback-Verhalten abschließen (Aktionsempfehlung `needs-review`, Hinweis `independent_review_unavailable` im Evidence Package) statt mit einem Fehler zu scheitern.
+- **FR-008**: Das System MUSS wiederkehrende Verletzungsmuster erkennen und ab einem konfigurierbaren Schwellwert einen Rule-Promotion-Vorschlag im maschinenlesbaren Format erzeugen.
+- **FR-009**: Das System MUSS ein vollständiges **Evidence Package** als JSON mit eigenem Schema ausgeben (konsistent mit dem bestehenden `drift analyze --format json`-Format), das alle Prüfergebnisse, Scores, Violations und die Aktionsempfehlung enthält.
+- **FR-010**: Eine Änderung darf nur `automerge` erhalten, wenn sowohl Drift Score als auch Spec Confidence Score die definierten Schwellwerte erfüllen und keine offenen Violations vorliegen.
+
+### Key Entities
+
+- **Change Set**: Die zu prüfende Änderung als Diff oder Dateiliste, zusammen mit Metadaten (Autor, Zeitstempel, optionale Spec-Referenz).
+- **Evidence Package**: Vollständige Sammlung aller Prüfergebnisse für ein Change Set, enthält Drift Score, Spec Confidence Score, Violation-Liste, Independent Review und Aktionsempfehlung.
+- **Violation Finding**: Einzelne gefundene Verletzung mit Verstoßtyp, Fundstelle, Schweregrad und Remediation-Anweisung.
+- **Action Recommendation**: Maschinenlesbares Urteil (`automerge` | `needs_fix` | `needs_review` | `escalate_to_human`) mit Begründung.
+- **Persistent Rule**: Dauerhaft gespeicherte Architektur- oder Cleanup-Regel, die aus einem wiederkehrenden Verletzungsmuster extrahiert wurde.
+- **Independent Review Result**: Befunde des Reviewer-Agenten aus einem frischen Kontext, mit eigenem Confidence-Delta und Fundstellen.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Jede Änderung erhält innerhalb von 3 Minuten ein vollständiges, reproduzierbares Evidenzpaket mit allen Pflichtfeldern.
+- **SC-002**: Architekturverstöße werden in 95 % der Fälle mit der korrekten Fundstelle (Datei und Zeile) und einer konkreten Remediation-Anweisung gemeldet.
+- **SC-003**: Die Falsch-Positiv-Rate für Architektur-Violations liegt unter 5 % bei den definierten Testfixtures.
+- **SC-004**: Eine Änderung erhält nur dann `automerge`, wenn alle Struktur- und Verifikationsprüfungen bestehen (100 % Konsistenz zwischen Prüfergebnis und Aktionsempfehlung).
+- **SC-005**: Wiederkehrende Verletzungsmuster, die mindestens fünfmal in Diffs aufgetreten sind, werden zu mindestens 90 % als Rule-Promotion-Vorschlag erkannt.
+- **SC-006**: Der Independent Review erhöht die Erkennungsrate für Spec-Abweichungen gegenüber dem reinen Automatik-Check um mindestens 15 Prozentpunkte (gemessen an Benchmark-Fixtures mit bekannten Abweichungen).
+
+## Assumptions
+
+- Die Architektur- und Strukturregeln des Repos (Layer-Grenzen, Dependency-Richtungen, Naming-Konventionen) liegen in maschinenlesbarer Form vor oder können aus bestehenden Artefakten (Golden Principles, `.github/instructions/`, Drift-Signalen) extrahiert werden.
+- Der Reviewer-Agent verwendet dasselbe Modell wie der primäre Prüfprozess, läuft aber in einem frischen Kontext ohne Zugriff auf den primären Check-Verlauf.
+- Screenshot- und Metriken-Evidenz ist optional und nur verfügbar, wenn eine Laufzeitumgebung bereitgestellt wird; das Feature funktioniert auch ohne diese Eingaben.
+- Die Schwellwerte für Drift Score, Spec Confidence Score und den Rule-Promotion-Auslöser sind konfigurierbar und haben sinnvolle Standardwerte.
+- Mobile-Unterstützung und UI-Visualisierung des Evidence Package sind für v1 außerhalb des Scope.
+- Das Feature arbeitet auf Change-Set-Ebene (pro Diff), nicht auf Commit-History-Ebene; historische Analyse ist ein separates Feature.
+
+## Clarifications
+
+### Session 2026-05-01
+
+- Q: Welches Output-Format soll das Evidence Package verwenden? → A: JSON mit eigenem Schema, konsistent mit `drift analyze --format json`
+- Q: Ist "Evidence Package" der kanonische Begriff (statt "Evidence Report")? → A: Ja — "Evidence Package" ist der einzige kanonische Begriff; "Evidence Report" ist veraltet
+- Q: Was soll das Feature bei einem leeren oder Whitespace-only Diff tun? → A: Sofort Kurzresultat liefern — automerge, Drift Score 0, Confidence 1.0, leere Violations, Flag `no_changes_detected`
+- Q: Reviewer-Agent synchron oder asynchron? → A: Synchron; Aktionsempfehlung erst nach Reviewer-Ergebnis; bei Timeout Fallback auf `needs-review` + `independent_review_unavailable`
+- Q: Verhalten bei widersprüchlichen Architekturregeln? → A: Beide Violations ausgeben, Aktionsempfehlung `needs-review`, Hinweis `rule_conflict` mit IDs beider Regeln

--- a/specs/005-evidence-based-verification/tasks.md
+++ b/specs/005-evidence-based-verification/tasks.md
@@ -1,0 +1,161 @@
+# Tasks: 005 Evidence-Based Drift Verification
+
+**Input**: Design documents from `/specs/005-evidence-based-verification/`
+**Prerequisites**: plan.md ✅ spec.md ✅ research.md ✅ data-model.md ✅ contracts/ ✅
+
+---
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Kann parallel laufen (verschiedene Dateien, keine offenen Dependencies)
+- **[Story]**: Zugehörige User Story (US1–US4)
+- Alle Pfade relativ zum Repo-Root
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verzeichnisstruktur, Slice-Skeleton, Package-Registration
+
+- [ ] T001 Create vertical slice directory `src/drift/verify/` with empty `__init__.py`
+- [ ] T002 [P] Create `tests/verify/__init__.py` (empty)
+- [ ] T003 [P] Add `drift verify` Click group stub in `src/drift/verify/_cmd.py` (import only, no logic)
+- [ ] T004 Register `verify` subcommand in `src/drift/commands/__init__.py` (or CLI entry point)
+- [ ] T005 [P] Create `scripts/generate_evidence_schema.py` stub (analogous to `scripts/generate_output_schema.py`)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Frozen Pydantic models, failing test skeletons, schema skeleton — MUSS vor allen User Stories abgeschlossen sein
+
+**⚠️ KRITISCH**: Keine User-Story-Arbeit beginnen, bis dieser Block vollständig ist
+
+- [ ] T006 Implement all frozen Pydantic models in `src/drift/verify/_models.py`: `ChangeSet`, `EvidencePackage`, `ViolationFinding`, `ActionRecommendation`, `FunctionalEvidence`, `IndependentReviewResult`, `RulePromotionProposal`, `PatternHistoryEntry`, enums `ViolationType` / `Verdict` / `EvidenceFlag`
+- [ ] T007 [P] Write failing test stubs for all acceptance scenarios (US1–US4) in `tests/verify/test_verify_unit.py` — RED phase, alle Tests müssen fehlschlagen
+- [ ] T008 [P] Write failing contract test stubs for `EvidencePackage` invariants in `tests/verify/test_verify_contract.py` — RED phase
+- [ ] T009 [P] Implement `ReviewerAgentProtocol` + `MockReviewerAgent` in `src/drift/verify/_reviewer.py`
+- [ ] T010 [P] Implement `evidence_to_json()` JSON-Serialisierung (schema: `"evidence-package-v1"`) in `src/drift/verify/_output.py`
+- [ ] T011 [P] Finalize `scripts/generate_evidence_schema.py` to emit JSON Schema for `EvidencePackage`; write schema to `drift.evidence.schema.json`
+- [ ] T012 Add `drift.evidence.schema.json` to repo root (generated from T011)
+
+**Checkpoint**: Alle Modelle vorhanden, alle Tests rot, Slice-Skeleton fertig → US-Implementierung kann beginnen
+
+---
+
+## Phase 3: User Story 1 — Vollständiges Evidenzpaket (P1) 🎯 MVP
+
+**Goal**: `drift verify --diff <path>` liefert reproduzierbares Evidence Package mit Drift Score, Spec Confidence Score, Violations und `ActionRecommendation`
+
+**Independent Test**: Synthetischer Diff → `EvidencePackage` geprüft auf Vollständigkeit (alle Pflichtfelder, reproduzierbarer Score, identisches Ergebnis bei zweitem Aufruf)
+
+- [ ] T013 [US1] Implement `_checker.py`: `run_deterministic_checks(change_set) -> tuple[list[ViolationFinding], float]` — wraps `drift analyze` Python API (AVS/PFS/EDS signals)
+- [ ] T014 [US1] Implement `compute_drift_score(violations) -> float` (pure function) in `src/drift/verify/_checker.py`
+- [ ] T015 [US1] Implement `compute_spec_confidence(change_set, violations) -> float` (`passed_checks / total_checks`, deterministic) in `src/drift/verify/_checker.py`
+- [ ] T016 [US1] Implement `build_action_recommendation(drift_score, spec_confidence, violations, flags) -> ActionRecommendation` (pure function) — all verdict decision logic
+- [ ] T017 [US1] Implement public `verify(change_set, *, reviewer, ...) -> EvidencePackage` in `src/drift/verify/__init__.py` — orchestrates checker, reviewer (via protocol), promoter; handles empty diff → `no_changes_detected`
+- [ ] T018 [US1] Implement `drift verify` CLI command in `src/drift/verify/_cmd.py`: `--diff`, `--repo`, `--spec`, `--format`, `--no-reviewer`, `--threshold-drift`, `--threshold-confidence`, `--exit-zero`, `--output`
+- [ ] T019 [US1] Implement Rich output for `EvidencePackage` in `src/drift/verify/_output.py`: summary panel, verdict badge, violations table, scores
+- [ ] T020 [US1] GREEN phase: make US1 unit tests pass (T007 stubs)
+- [ ] T021 [US1] GREEN phase: make US1 contract tests pass (`EvidencePackage` invariants)
+- [ ] T022 [US1] Write integration test `tests/verify/test_verify_integration.py` for end-to-end CLI invocation (subprocess/`CliRunner`) covering automerge + needs_fix + empty diff cases
+
+---
+
+## Phase 4: User Story 2 — Präzise Reparaturanweisungen (P2)
+
+**Goal**: Jede `ViolationFinding` enthält `violation_type`, betroffene Datei/Zeile und konkrete `remediation`-Anweisung
+
+**Independent Test**: Diff mit bekannter Layer-Verletzung → `ViolationFinding` enthält korrekten `violation_type`, Datei, Zeile und nicht-leere `remediation`
+
+- [ ] T023 [US2] Implement `map_signal_finding_to_violation(finding: Finding) -> ViolationFinding` in `src/drift/verify/_checker.py` — maps AVS/PFS/EDS signal output to `ViolationType` + `remediation` text
+- [ ] T024 [US2] Implement remediation message templates for all `ViolationType` variants (layer_violation, forbidden_dependency, file_placement, naming_convention) in `src/drift/verify/_checker.py`
+- [ ] T025 [US2] Handle `rule_conflict` detection: when two signals produce contradicting verdicts for same file → emit `ViolationType.rule_conflict` with both `rule_id` and `conflicting_rule_id`; set `EvidenceFlag.rule_conflict`
+- [ ] T026 [US2] GREEN phase: make US2 unit tests pass (remediation content, rule_conflict flag)
+
+---
+
+## Phase 5: User Story 3 — Independent Reviewer Agent (P3)
+
+**Goal**: Nach deterministischem Check läuft `ReviewerAgentProtocol.review()` synchron; Ergebnis fließt als `confidence_delta` additiv in Spec Confidence Score; Timeout → `independent_review_unavailable`
+
+**Independent Test**: Diff mit subtiler Spec-Abweichung → `IndependentReviewResult.available == True`, `findings` nicht leer; bei forciertem Timeout → `available == False`, `EvidenceFlag.independent_review_unavailable` gesetzt
+
+- [ ] T027 [US3] Implement `DriftMcpReviewerAgent` in `src/drift/verify/_reviewer.py`: calls `drift.api.nudge` with timeout; returns `IndependentReviewResult(available=False, ...)` on timeout/error — no exception raised
+- [ ] T028 [US3] Integrate `IndependentReviewResult.confidence_delta` into `verify()` public API: additive adjustment after deterministic spec confidence computation
+- [ ] T029 [US3] Implement `--reviewer-timeout` and `--no-reviewer` CLI flags in `_cmd.py`; wire to `DriftMcpReviewerAgent` vs `MockReviewerAgent(unavailable)`
+- [ ] T030 [US3] GREEN phase: make US3 unit tests pass (reviewer integration, timeout fallback, confidence_delta)
+
+---
+
+## Phase 6: User Story 4 — Rule Promotion (P4)
+
+**Goal**: Wiederkehrendes Verletzungsmuster → `RulePromotionProposal` nach ≥ Schwellwert Vorkommen; Vorschlag erscheint in `EvidencePackage.rule_promotions`
+
+**Independent Test**: Dasselbe Violation-Muster 5× in History → `rule_promotions` enthält Eintrag; < 5× → leer
+
+- [ ] T031 [US4] Implement `PatternHistoryStore` in `src/drift/verify/_promoter.py`: `append(entry)` → JSONL-Append to `.drift/pattern_history.jsonl`; `load() -> list[PatternHistoryEntry]`; creates `.drift/` dir if missing
+- [ ] T032 [US4] Implement `compute_promotions(history, violations, threshold) -> list[RulePromotionProposal]` (pure function) in `src/drift/verify/_promoter.py`
+- [ ] T033 [US4] Integrate promoter into `verify()` public API: append new entries, compute proposals, attach to `EvidencePackage.rule_promotions`
+- [ ] T034 [US4] Implement `--promote-threshold` CLI flag in `_cmd.py`
+- [ ] T035 [US4] GREEN phase: make US4 unit tests pass (promotion threshold logic, JSONL persistence)
+
+---
+
+## Phase 7: Polish & Cross-Cutting
+
+**Purpose**: Schema validation, type checking, exit codes, edge cases, docs
+
+- [ ] T036 [P] Add `test_evidence_schema.py`: verifies `drift.evidence.schema.json` matches `EvidencePackage.model_json_schema()` byte-for-byte (analogous to `tests/test_config_schema.py`)
+- [ ] T037 [P] Verify and fix all mypy type errors in `src/drift/verify/` (`make check`)
+- [ ] T038 [P] Verify exit codes: 0 = automerge/exit-zero, 1 = needs_fix, 2 = needs_review, 3 = escalate_to_human, 10 = input error
+- [ ] T039 [P] Edge case: multi-layer diff (changes in multiple layers simultaneously) → all layer violations reported; `action_recommendation` driven by highest severity (≥1 high/critical → needs_fix)
+- [ ] T040 [P] Update `src/drift/commands/__init__.py` to export `verify` command; verify `drift --help` shows `verify`
+- [ ] T041 [P] Add `drift verify` entry to `README.md` and `docs/` quickstart section (reference `specs/005-evidence-based-verification/quickstart.md`)
+- [ ] T042 [P] [US1] Implement `--format sarif` output in `src/drift/verify/_output.py`: emit SARIF 2.1.0 with `runs[0].results` mapping each `ViolationFinding` to a SARIF `result` (Constitution IV)
+- [ ] T043 [P] [US1/US2] Add ground-truth TP/TN fixtures for `verify` module in `tests/fixtures/ground_truth.py`: layer_violation, forbidden_dependency, naming_convention (for SC-002 / SC-003 precision-recall gate, Constitution II)
+- [ ] T044 [P] [US1] Wire `FunctionalEvidence` as optional caller-provided input via `verify(change_set, functional_evidence=None, ...)` — `drift verify` does NOT invoke pytest/ruff internally (FR-006)
+- [ ] T045 [P] [US1] Write latency regression test `tests/verify/test_verify_performance.py`: assert end-to-end `verify()` completes within 180 s on a synthetic diff; mark `@pytest.mark.slow`, skipped by default (SC-001)
+- [ ] T046 [P] [US3] Create benchmark fixtures in `benchmarks/` for SC-006 measurement: known spec deviations invisible to deterministic check, used to measure ≥15pp detection lift from reviewer
+
+---
+
+## Dependencies
+
+```
+Phase 1 (Setup) → Phase 2 (Foundational)
+Phase 2 → Phase 3 (US1 — MVP)
+Phase 3 → Phase 4 (US2) [US2 extends _checker.py built in US1]
+Phase 3 → Phase 5 (US3) [US3 extends verify() built in US1]
+Phase 3 → Phase 6 (US4) [US4 adds promoter to verify() built in US1]
+Phase 4, 5, 6 → Phase 7 (Polish)
+```
+
+US2, US3, US4 sind nach Abschluss von Phase 3 (US1) **unabhängig voneinander parallelisierbar**.
+
+---
+
+## Parallel Execution Examples
+
+### Nach Phase 2 (Foundational abgeschlossen):
+- T013–T022 (US1) sequenziell
+
+### Nach Phase 3 (US1 abgeschlossen):
+- T023–T026 (US2) parallel zu T027–T030 (US3) parallel zu T031–T035 (US4)
+
+### Nach Phase 4+5+6:
+- T036–T041 (Polish) alle parallel
+
+---
+
+## Implementation Strategy
+
+**MVP (Phase 1–3)**: `drift verify --diff <path> --no-reviewer` liefert vollständiges Evidence Package mit Drift Score, Spec Confidence, Violations und ActionRecommendation. Kein Reviewer-Agent, keine Rule-Promotion.
+
+**Increment 2 (Phase 4)**: Präzise Reparaturanweisungen für alle ViolationType-Varianten.
+
+**Increment 3 (Phase 5)**: Reviewer-Agent-Integration (synchron, Timeout-Fallback).
+
+**Increment 4 (Phase 6)**: Rule-Promotion aus Verlaufshistorie.
+
+**Increment 5 (Phase 7)**: Schema-Gate, alle Checks grün, Docs.

--- a/specs/006-human-decision-cockpit/checklists/requirements.md
+++ b/specs/006-human-decision-cockpit/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Drift Human Decision Cockpit
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation run completed in one iteration.
+- No blocking quality gaps identified.
+- Ready for `/speckit.plan`; `/speckit.clarify` is optional for additional stakeholder refinement.

--- a/specs/006-human-decision-cockpit/contracts/cockpit-api.yaml
+++ b/specs/006-human-decision-cockpit/contracts/cockpit-api.yaml
@@ -1,0 +1,279 @@
+openapi: 3.0.3
+info:
+  title: Drift Human Decision Cockpit API
+  version: 0.1.0
+  description: Contract fuer PR-zentrierte Governance-Entscheidungen im Drift Cockpit.
+servers:
+  - url: /api/cockpit
+paths:
+  /prs/{pr_id}/decision:
+    get:
+      summary: Liefert den aktuellen Decision Panel Zustand fuer einen PR
+      parameters:
+        - in: path
+          name: pr_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Decision Panel geladen
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecisionPanelResponse'
+    post:
+      summary: Speichert menschliche Entscheidung (inkl. Override-Regeln)
+      parameters:
+        - in: path
+          name: pr_id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DecisionWriteRequest'
+      responses:
+        '200':
+          description: Entscheidung gespeichert
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LedgerEntry'
+        '409':
+          description: Versionskonflikt
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionConflict'
+  /prs/{pr_id}/safe-plan:
+    get:
+      summary: Liefert Minimal Safe Change Set fuer einen PR
+      parameters:
+        - in: path
+          name: pr_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Safe Plan geladen
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MinimalSafePlan'
+  /prs/{pr_id}/clusters:
+    get:
+      summary: Liefert Accountability Cluster
+      parameters:
+        - in: path
+          name: pr_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Cluster geladen
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AccountabilityCluster'
+  /prs/{pr_id}/outcomes/{window}:
+    patch:
+      summary: Aktualisiert 7d oder 30d Outcome
+      parameters:
+        - in: path
+          name: pr_id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: window
+          required: true
+          schema:
+            type: string
+            enum: [7d, 30d]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OutcomeWriteRequest'
+      responses:
+        '200':
+          description: Outcome aktualisiert
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LedgerEntry'
+components:
+  schemas:
+    DecisionStatus:
+      type: string
+      enum: [go, go_with_guardrails, no_go]
+    DecisionPanelResponse:
+      type: object
+      required: [pr_id, status, confidence, evidence_sufficient, top_risk_drivers, version]
+      properties:
+        pr_id:
+          type: string
+        status:
+          $ref: '#/components/schemas/DecisionStatus'
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+        evidence_sufficient:
+          type: boolean
+        top_risk_drivers:
+          type: array
+          items:
+            $ref: '#/components/schemas/RiskDriver'
+        version:
+          type: integer
+          minimum: 1
+    RiskDriver:
+      type: object
+      required: [driver_id, title, impact]
+      properties:
+        driver_id:
+          type: string
+        title:
+          type: string
+        impact:
+          type: number
+        severity:
+          type: string
+        source_refs:
+          type: array
+          items:
+            type: string
+    GuardrailCondition:
+      type: object
+      required: [condition_id, description, verification_method, must_pass_before_merge]
+      properties:
+        condition_id:
+          type: string
+        description:
+          type: string
+        verification_method:
+          type: string
+        must_pass_before_merge:
+          type: boolean
+    MinimalSafePlan:
+      type: object
+      required: [plan_id, pr_id, steps, expected_risk_delta, expected_score_delta, target_threshold, feasible]
+      properties:
+        plan_id:
+          type: string
+        pr_id:
+          type: string
+        steps:
+          type: array
+          items:
+            $ref: '#/components/schemas/GuardrailCondition'
+        expected_risk_delta:
+          type: number
+        expected_score_delta:
+          type: number
+        target_threshold:
+          type: number
+        feasible:
+          type: boolean
+    AccountabilityCluster:
+      type: object
+      required: [cluster_id, label, files, risk_contribution]
+      properties:
+        cluster_id:
+          type: string
+        label:
+          type: string
+        files:
+          type: array
+          items:
+            type: string
+        risk_contribution:
+          type: number
+        dominant_drivers:
+          type: array
+          items:
+            type: string
+    DecisionWriteRequest:
+      type: object
+      required: [human_status, decision_actor, version]
+      properties:
+        human_status:
+          $ref: '#/components/schemas/DecisionStatus'
+        override_reason:
+          type: string
+          nullable: true
+        decision_actor:
+          type: string
+        version:
+          type: integer
+          minimum: 1
+      description: Wenn human_status von Empfehlung abweicht, ist override_reason verpflichtend.
+    OutcomeWriteRequest:
+      type: object
+      required: [state, version]
+      properties:
+        state:
+          type: string
+          enum: [pending, captured, not_available]
+        rework_events:
+          type: integer
+          nullable: true
+        merge_velocity_delta:
+          type: number
+          nullable: true
+        version:
+          type: integer
+          minimum: 1
+    LedgerEntry:
+      type: object
+      required: [ledger_entry_id, pr_id, recommended_status, human_status, decision_actor, version]
+      properties:
+        ledger_entry_id:
+          type: string
+        pr_id:
+          type: string
+        recommended_status:
+          $ref: '#/components/schemas/DecisionStatus'
+        human_status:
+          $ref: '#/components/schemas/DecisionStatus'
+        override_reason:
+          type: string
+          nullable: true
+        decision_actor:
+          type: string
+        evidence_refs:
+          type: array
+          items:
+            type: string
+        outcome_7d:
+          type: object
+        outcome_30d:
+          type: object
+        version:
+          type: integer
+        updated_at:
+          type: string
+          format: date-time
+    VersionConflict:
+      type: object
+      required: [error, pr_id, expected_version, actual_version]
+      properties:
+        error:
+          type: string
+          example: version_conflict
+        pr_id:
+          type: string
+        expected_version:
+          type: integer
+        actual_version:
+          type: integer

--- a/specs/006-human-decision-cockpit/contracts/ledger-event-contract.md
+++ b/specs/006-human-decision-cockpit/contracts/ledger-event-contract.md
@@ -1,0 +1,99 @@
+# Ledger Event Contract
+
+## Purpose
+
+Definiert das append-only Eventmodell fuer Decision Ledger Timeline inkl. Human Override und Outcome-Nachtraegen.
+
+## Event Types
+
+1. `decision_recommended`
+2. `decision_overridden`
+3. `decision_confirmed`
+4. `outcome_updated`
+5. `version_conflict_raised`
+6. `version_conflict_resolved`
+
+## Common Envelope
+
+Alle Events muessen folgende Felder enthalten:
+
+- `event_id` (UUID)
+- `event_type`
+- `pr_id`
+- `ledger_entry_id`
+- `version`
+- `actor`
+- `occurred_at` (ISO-8601 UTC)
+- `payload` (typabhaengig)
+
+## Event Rules
+
+### decision_recommended
+
+Payload:
+- `recommended_status`
+- `confidence`
+- `evidence_sufficient`
+- `risk_driver_ids`
+
+Validation:
+- Wenn `evidence_sufficient=false`, dann `recommended_status=no_go`.
+
+### decision_overridden
+
+Payload:
+- `recommended_status`
+- `human_status`
+- `override_reason`
+
+Validation:
+- `human_status != recommended_status`
+- `override_reason` ist nicht leer.
+
+### decision_confirmed
+
+Payload:
+- `status`
+- `decision_actor`
+
+Validation:
+- Wird nur akzeptiert, wenn kein offener Versionskonflikt fuer den Eintrag existiert.
+
+### outcome_updated
+
+Payload:
+- `window` (`7d|30d`)
+- `state` (`pending|captured|not_available`)
+- `rework_events` (optional)
+- `merge_velocity_delta` (optional)
+
+Validation:
+- Bei `state=captured` muessen Messwerte vorhanden oder explizit `null` begruendet sein.
+
+### version_conflict_raised
+
+Payload:
+- `expected_version`
+- `actual_version`
+- `attempted_action`
+
+Validation:
+- Event wird synchron zum API-Fehler `409` erzeugt.
+
+### version_conflict_resolved
+
+Payload:
+- `resolution_strategy` (`reload_and_retry|manual_merge|abort`)
+- `new_version`
+
+## Ordering and Idempotency
+
+- Reihenfolge pro `pr_id` ist durch `version` monoton steigend.
+- Duplicate `event_id` muss verworfen werden.
+- `outcome_updated` fuer dieselbe `window` ersetzt nur den Snapshotzustand, aber bleibt als Event historisch erhalten.
+
+## Audit Guarantees
+
+- Jeder Unterschied zwischen Empfehlung und Human-Entscheidung ist ueber `decision_overridden` nachvollziehbar.
+- Fehlende Outcomes sind als `pending` bzw. `not_available` explizit sichtbar.
+- Parallele Schreibversuche sind durch Konflikt-Events forensisch nachvollziehbar.

--- a/specs/006-human-decision-cockpit/data-model.md
+++ b/specs/006-human-decision-cockpit/data-model.md
@@ -1,0 +1,127 @@
+# Data Model: Human Decision Cockpit
+
+**Phase 1 Output** | Feature 006 | 2026-05-01
+
+## Entities
+
+### PullRequestDecisionRecord
+
+Repraesentiert den aktuellen Entscheidungszustand fuer genau einen PR.
+
+Fields:
+- `pr_id: str`
+- `status: DecisionStatus` (`go|go_with_guardrails|no_go`)
+- `confidence: float` (0.0..1.0)
+- `evidence_sufficient: bool`
+- `risk_score: float`
+- `score_delta_estimate: float`
+- `top_risk_drivers: list[RiskDriver]`
+- `active_version: int`
+- `updated_at: datetime`
+
+Validation:
+- Genau ein aktiver Status pro `pr_id`.
+- Wenn `evidence_sufficient == false`, dann `status == no_go`.
+
+### RiskDriver
+
+Ein priorisierter Risikotreiber im Decision Panel.
+
+Fields:
+- `driver_id: str`
+- `title: str`
+- `impact: float`
+- `severity: str`
+- `source_refs: list[str]`
+
+### MinimalSafePlan
+
+Kleinster Maßnahmen-Satz, der unter Zielschwelle fuehrt.
+
+Fields:
+- `plan_id: str`
+- `pr_id: str`
+- `steps: list[GuardrailCondition]`
+- `expected_risk_delta: float`
+- `expected_score_delta: float`
+- `target_threshold: float`
+- `feasible: bool`
+
+Validation:
+- Fuer `status == no_go` mindestens ein Plan mit `feasible == true`.
+
+### GuardrailCondition
+
+Pruefbare Bedingung fuer Guardrails-/No-Go-Aufloesung.
+
+Fields:
+- `condition_id: str`
+- `description: str`
+- `verification_method: str`
+- `must_pass_before_merge: bool`
+
+### AccountabilityCluster
+
+Gruppiert Aenderungen nach Risikoauswirkung.
+
+Fields:
+- `cluster_id: str`
+- `pr_id: str`
+- `label: str`
+- `files: list[str]`
+- `risk_contribution: float`
+- `dominant_drivers: list[str]`
+
+### LedgerEntry
+
+Historischer, auditierbarer Entscheidungsdatensatz.
+
+Fields:
+- `ledger_entry_id: str`
+- `pr_id: str`
+- `recommended_status: DecisionStatus`
+- `human_status: DecisionStatus`
+- `override_reason: str | null`
+- `decision_actor: str`
+- `evidence_refs: list[str]`
+- `outcome_7d: OutcomeSnapshot`
+- `outcome_30d: OutcomeSnapshot`
+- `version: int`
+- `created_at: datetime`
+- `updated_at: datetime`
+
+Validation:
+- Wenn `human_status != recommended_status`, dann `override_reason` nicht leer.
+- `version` muss bei Update monoton steigen.
+
+### OutcomeSnapshot
+
+Outcome-Status fuer 7 oder 30 Tage.
+
+Fields:
+- `window: str` (`7d|30d`)
+- `state: OutcomeState` (`pending|captured|not_available`)
+- `rework_events: int | null`
+- `merge_velocity_delta: float | null`
+- `captured_at: datetime | null`
+
+## Relationships
+
+- Ein `PullRequestDecisionRecord` hat 0..n `MinimalSafePlan`.
+- Ein `PullRequestDecisionRecord` hat 0..n `AccountabilityCluster`.
+- Ein `PullRequestDecisionRecord` hat 1..n `LedgerEntry` (zeitlicher Verlauf).
+- Ein `LedgerEntry` enthaelt genau zwei `OutcomeSnapshot` (7d und 30d).
+
+## State Transitions
+
+DecisionStatus:
+- `no_go -> go_with_guardrails` wenn Mindest-Guardrails erfuellt und Evidenz ausreichend.
+- `go_with_guardrails -> go` wenn Restrisiko unter Go-Schwelle.
+- `go|go_with_guardrails -> no_go` bei Evidenzverlust oder neuem kritischen Treiber.
+
+OutcomeState:
+- `pending -> captured` wenn reale Outcome-Daten eingehen.
+- `pending -> not_available` wenn Outcome-Fenster endet ohne belastbare Daten.
+
+Conflict Handling:
+- Update auf `LedgerEntry` mit alter `version` erzeugt `VersionConflict` und verlangt explizite Aufloesung.

--- a/specs/006-human-decision-cockpit/plan.md
+++ b/specs/006-human-decision-cockpit/plan.md
@@ -1,0 +1,111 @@
+# Implementation Plan: 006 Human Decision Cockpit
+
+**Branch**: `010-before-specify-hook` | **Date**: 2026-05-01 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/006-human-decision-cockpit/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Drift erhaelt ein neues Cockpit-Slice, das pro Pull Request eine entscheidungsfertige Governance-Ansicht erzeugt: genau ein Decision Status (Go / Go with Guardrails / No-Go), Top-Risikotreiber, Minimal Safe Change Set, Accountability Cluster und ein versioniertes Decision Ledger mit 7/30-Tage-Outcomes. Die Architektur trennt deterministische Entscheidungsermittlung (Library-First) von UI-Rendering und erzwingt nachvollziehbare Human Overrides mit Pflicht-Begruendung.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (Decision Engine), TypeScript 5.x + React 18 (Cockpit UI)  
+**Primary Dependencies**: Click, Pydantic, Rich, drift-engine/drift-output APIs; React, Vite, Vitest fuer Frontend  
+**Storage**: Repository-lokale Artefakte unter `.drift/cockpit/` (JSON) plus append-only Ledger-Datei  
+**Testing**: pytest (unit/contract/integration), Vitest + Testing Library (UI), mypy, ruff  
+**Target Platform**: Lokale Maintainer-Workstations und CI Artefakt-Viewer (Browser)  
+**Project Type**: Vertical Slice + Web UI (library/cli + web app)  
+**Performance Goals**: Vollstaendiges Decision Panel in <= 120 Sekunden pro PR (SC-001), Cockpit-Render < 2s aus vorhandenen Artefakten  
+**Constraints**: Genau ein aktiver Status pro PR; fehlende Evidenz erzwingt No-Go; deterministische Status-Schwellen; Konfliktauflosung bei Parallel-Edits  
+**Scale/Scope**: Initial 1 Cockpit-Ansicht pro PR, 7/30-Tage Outcome-Tracking fuer mindestens 90% der entschiedenen PRs (SC-004)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Verify each principle from `.specify/memory/constitution.md` (v1.1.0):
+
+- [x] **I. Library-First**: Kernlogik liegt in `src/drift/decision_cockpit/`; CLI/UI sind Adapter ohne Entscheidungslogik.
+- [x] **II. Test-First**: RED-Tests fuer Statusmapping, Minimal-Safe-Berechnung, Ledger-Versionierung und Override-Regeln werden vor Implementierung geschrieben.
+- [x] **III. Functional Programming**: Entscheidungspfade als pure functions; Pydantic Modelle frozen; I/O an Artefakt- und CLI-Grenzen isoliert.
+- [x] **IV. CLI Interface & Observability**: Neues Click-Subcommand liefert JSON + Rich; strukturierte Cockpit-Metadaten fuer PR/Status/Latency.
+- [x] **V. Simplicity & YAGNI**: V1 fokussiert auf PR-Entscheidung und Ledger, keine Multi-Repo-Administration oder Rollensystem.
+- [x] **VI. Vertical Slices**: Eigenes Slice `src/drift/decision_cockpit/` mit Modellen, Core-Logik, Output und Command; keine sibling-internals.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-human-decision-cockpit/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── cockpit-api.yaml
+│   └── ledger-event-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/drift/decision_cockpit/
+├── __init__.py                 # Public API: build_decision_bundle(...)
+├── _models.py                  # Frozen decision/ledger/cluster models
+├── _status_engine.py           # Deterministische Statuslogik + Schwellen
+├── _safe_plan.py               # Minimal Safe Change Set Berechnung
+├── _cluster.py                 # Accountability Cluster Aggregation
+├── _ledger.py                  # Ledger write/read + optimistic locking
+├── _output.py                  # JSON + Rich projection
+└── _cmd.py                     # Click: drift cockpit build/view
+
+playground/src/cockpit/
+├── CockpitApp.tsx              # Decision Panel + Safe Plan + Graph + Ledger
+├── api.ts                      # Typed contract client fuer cockpit-api.yaml
+├── components/
+└── test/
+
+tests/decision_cockpit/
+├── test_status_engine.py
+├── test_safe_plan.py
+├── test_ledger_contract.py
+├── test_cockpit_cmd_integration.py
+└── test_cockpit_threshold_boundaries.py
+```
+
+**Structure Decision**: Vertical Slice fuer Governance-Logik in `src/drift/decision_cockpit/` plus UI-Adapter in `playground/src/cockpit/`. So bleibt die Entscheidungslogik testbar und CLI-faehig, waehrend die Web-App auf stabilen Contracts aufsetzt.
+
+## Phase 0 Research (resolved)
+
+- Status-Schwellen werden statusspezifisch und deterministisch definiert; Grenzwerte mappen auf genau einen Status.
+- Unzureichende Evidenz setzt zwingend No-Go bis Evidenznachlieferung.
+- Human Override ist erlaubt, aber nur mit Pflicht-Begruendung im Ledger.
+- Fehlende Outcomes werden als `pending` modelliert, nicht als neutral/negativ.
+- Gleichzeitige Aenderungen nutzen optimistic locking (`version`) mit expliziter Konfliktaufloesung.
+
+## Phase 1 Design Outputs
+
+- `data-model.md`: Alle Cockpit-Entitaeten, Beziehungen und Zustandsuebergaenge.
+- `contracts/cockpit-api.yaml`: PR-zentrierte REST/JSON Contracts fuer Panel, Safe Plan, Ledger und Outcome-Update.
+- `contracts/ledger-event-contract.md`: Auditierbare Events inkl. Override-Pflichtfelder und Konfliktregeln.
+- `quickstart.md`: End-to-end local flow (Build artefacts -> UI -> Decision -> Outcome).
+
+## Post-Design Constitution Re-check
+
+- [x] Library-First weiterhin erfuellt: API/CLI nutzen `decision_cockpit` Public API.
+- [x] Test-First vorbereitet: explizite Testmodule fuer jede Kernregel benannt.
+- [x] Functional rule bleibt erfuellt: Optimistic locking und Statusmapping sind side-effect-arm modelliert.
+- [x] CLI/Observability erfuellt: `drift cockpit` plus JSON/Rich Contract vorgesehen.
+- [x] Simplicity erfuellt: Kein RBAC, kein Multi-tenant, kein Runtime-ML in V1.
+- [x] Vertical Slices erfuellt: Cross-slice Imports nur ueber oeffentliche Drift APIs.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| UI ausserhalb `src/drift/` (`playground/src/cockpit/`) | Web-App ist expliziter Produktbestandteil mit eigener Laufzeit | Reines Rich/CLI-Output erfuellt den Web-App-Kern-Use-Case nicht |
+| Optimistic-locking Konfliktpfad | FR-015 verlangt explizite Konfliktaufloesung bei Parallel-Edits | Last-write-wins verletzt Nachvollziehbarkeit und Audit-Sicherheit |

--- a/specs/006-human-decision-cockpit/quickstart.md
+++ b/specs/006-human-decision-cockpit/quickstart.md
@@ -1,0 +1,79 @@
+# Quickstart: Human Decision Cockpit
+
+## Ziel
+
+In weniger als 10 Minuten lokal einen PR-Entscheidungsdurchlauf erzeugen: Decision Panel, Minimal Safe Plan, Accountability Cluster und Ledger-Eintrag.
+
+## Voraussetzungen
+
+- Workspace installiert mit Dev-Dependencies (`pip install -e '.[dev]'`)
+- Frontend-Toolchain verfuegbar im `playground/` (Node + npm)
+- Ein PR-Diff oder Testfixture vorhanden
+
+## 1. Cockpit-Artefakte bauen
+
+```bash
+# Beispielkommando (geplante CLI fuer dieses Feature)
+drift cockpit build \
+  --repo . \
+  --pr-id 1234 \
+  --diff-file work_artifacts/pr_1234.diff \
+  --out-dir .drift/cockpit
+```
+
+Erwartete Artefakte:
+- `.drift/cockpit/pr-1234/decision.json`
+- `.drift/cockpit/pr-1234/safe_plan.json`
+- `.drift/cockpit/pr-1234/clusters.json`
+- `.drift/cockpit/ledger.jsonl`
+
+## 2. Web-App lokal starten
+
+```bash
+cd playground
+npm install
+npm run dev
+```
+
+Dann im Browser den Cockpit-Bereich fuer `pr_id=1234` oeffnen.
+
+## 3. Menschliche Entscheidung dokumentieren
+
+Im Cockpit:
+- Empfehlung pruefen
+- Falls Uebersteuerung: Pflicht-Begruendung eintragen
+- Entscheidung speichern
+
+Alternativ per API (geplante Route):
+
+```bash
+curl -X POST http://localhost:4173/api/cockpit/prs/1234/decision \
+  -H "Content-Type: application/json" \
+  -d '{
+    "human_status": "go_with_guardrails",
+    "override_reason": "critical fix validated in patch set 2",
+    "decision_actor": "maintainer@example.com",
+    "version": 4
+  }'
+```
+
+## 4. 7/30-Tage Outcome erfassen
+
+```bash
+# Beispielkommando (geplante CLI)
+drift cockpit outcome update \
+  --repo . \
+  --pr-id 1234 \
+  --window 7d \
+  --state captured \
+  --rework-events 0 \
+  --merge-velocity-delta 0.03
+```
+
+## 5. Akzeptanz-Schnellcheck
+
+- Genau ein Decision Status sichtbar.
+- No-Go zeigt mindestens einen konkreten Minimal-Safe-Plan.
+- Ledger enthaelt Empfehlung, Human-Entscheidung, Evidenz und Outcome-Status.
+- Fehlende Outcomes werden als `pending` angezeigt.
+- Parallel-Update mit alter Version erzeugt sichtbaren Konflikt.

--- a/specs/006-human-decision-cockpit/research.md
+++ b/specs/006-human-decision-cockpit/research.md
@@ -1,0 +1,63 @@
+# Research: Human Decision Cockpit
+
+**Phase 0 Output** | Feature 006 | 2026-05-01
+
+## R-001: Decision Status Semantik
+
+**Decision**: Das Cockpit nutzt drei exklusive Status mit festen Schwellen je Status (`go`, `go_with_guardrails`, `no_go`) plus harter Override-Regel: unzureichende Evidenz erzwingt `no_go` unabhaengig vom numerischen Score.
+
+**Rationale**: Die Clarifications verlangen deterministische Schwellen und genau einen Status pro PR. Harte Evidenz-Guard verhindert unsichere Freigaben.
+
+**Alternatives considered**:
+- Dynamische Schwellen pro Repo: schwer vergleichbar und nicht baseline-stabil.
+- Ein globale Schwelle: zu grob fuer Guardrails-Szenarien.
+
+## R-002: Minimal Safe Change Set Berechnung
+
+**Decision**: V1 verwendet eine deterministische Greedy-Heuristik ueber priorisierte Risikotreiber (impact-descending) und waehlt den kleinsten Maßnahmen-Satz, der unter die Zielschwelle bringt.
+
+**Rationale**: Erklaerbar, schnell testbar und ausreichend fuer V1; liefert gleichzeitig erwartetes Risiko-Delta und Score-Delta.
+
+**Alternatives considered**:
+- Exakte kombinatorische Optimierung: hoehere Komplexitaet, in V1 nicht noetig.
+- Nur manuelle Vorschlaege: verletzt FR-003/FR-004.
+
+## R-003: Ledger-Konsistenz und Konflikte
+
+**Decision**: Ledger-Updates nutzen optimistic locking (`version` Feld); bei stale version wird ein expliziter Konflikt zur Aufloesung zurueckgegeben.
+
+**Rationale**: Erfuellt FR-015 und verhindert stille Ueberschreibungen.
+
+**Alternatives considered**:
+- Last-write-wins: nicht auditierbar.
+- Global lock: zu restriktiv fuer parallele Maintainer-Workflows.
+
+## R-004: Human Override Governance
+
+**Decision**: Menschliche Uebersteuerung ist erlaubt, aber nur mit Pflichtfeldern `override_reason`, `decision_actor`, `decided_at`.
+
+**Rationale**: Erfuellt FR-013 und macht spaetere Outcome-Analyse belastbar.
+
+**Alternatives considered**:
+- Freie Uebersteuerung ohne Begruendung: schwache Governance.
+- Keine Uebersteuerung: unpraktisch fuer Maintainer-Verantwortung.
+
+## R-005: Outcome Tracking Modell
+
+**Decision**: 7/30-Tage-Outcomes werden als statusbehaftete Subobjekte modelliert (`pending|captured|not_available`) und spaeter denselben Ledger-Eintrag erweitert.
+
+**Rationale**: Expliziter Pending-Status erfuellt Clarification und verhindert Fehlinterpretation als neutral.
+
+**Alternatives considered**:
+- Fehlende Outcomes als null/leer: semantisch unklar.
+- Separate Outcome-Tabelle ohne Ledger-Link: schwache Rueckverfolgbarkeit.
+
+## R-006: UI-Integrationsstrategie
+
+**Decision**: UI wird als eigener Cockpit-Bereich im bestehenden `playground` realisiert und konsumiert die Cockpit-API-Artefakte.
+
+**Rationale**: Wiederverwendung der vorhandenen Vite/React Toolchain im Repo reduziert Einfuehrungsaufwand.
+
+**Alternatives considered**:
+- Komplett neue Frontend-App im Repo-Root: mehr Build-/CI-Oberflaeche ohne V1-Mehrwert.
+- Nur Rich-Ausgabe: erfuellt Produktziel "Web App" nicht.

--- a/specs/006-human-decision-cockpit/spec.md
+++ b/specs/006-human-decision-cockpit/spec.md
@@ -1,0 +1,136 @@
+# Feature Specification: Drift Human Decision Cockpit
+
+**Feature Branch**: `010-before-specify-hook`  
+**Created**: 2026-05-01  
+**Status**: Draft  
+**Input**: User description: "Drift Human Decision Cockpit (Web App)"
+
+## Clarifications
+
+### Session 2026-05-01
+
+- Q: Welcher Entscheidungsstatus gilt bei unzureichender Evidenz? → A: Automatisch No-Go, bis Evidenz nachgeliefert ist.
+- Q: Wie sollen Konfidenz-Schwellen den Status bestimmen? → A: Feste Schwellen je Status (Go, Go with Guardrails, No-Go).
+- Q: Darf die menschliche Entscheidung die App-Empfehlung übersteuern? → A: Ja, aber nur mit Pflicht-Begründung im Ledger.
+- Q: Wie werden fehlende 7/30-Tage-Outcomes dargestellt? → A: Explizit als ausstehend markieren.
+- Q: Wie werden gleichzeitige Änderungen am selben PR-Eintrag behandelt? → A: Versionskonflikt erzeugen und explizite Auflösung erzwingen.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Entscheidungsstatus in unter 2 Minuten (Priority: P1)
+
+Als Maintainerin will ich pro Pull Request sofort einen klaren Entscheidungsstatus (Go, Go with Guardrails, No-Go) mit Konfidenz und Risikotreibern sehen, damit ich trotz hoher agentischer Änderungsrate eine belastbare Merge-Entscheidung treffen kann.
+
+**Why this priority**: Ohne schnellen, belastbaren Entscheidungsstatus verfehlt das Produkt seinen Kernnutzen der menschlichen Governance.
+
+**Independent Test**: Kann vollständig getestet werden, indem für einen PR ein Status, ein Konfidenzwert und Top-Risikotreiber angezeigt werden und eine Maintainerin auf Basis dieser Ansicht eine dokumentierte Entscheidung trifft.
+
+**Acceptance Scenarios**:
+
+1. **Given** ein analysierter PR mit ausreichender Evidenz, **When** die Maintainerin die PR-Seite öffnet, **Then** sieht sie genau einen Decision Status (Go, Go with Guardrails oder No-Go), einen Konfidenzwert und die Top-Risikotreiber.
+2. **Given** ein PR mit mehreren Risikotreibern, **When** die Hauptansicht geladen wird, **Then** sind die Risikotreiber nach Einfluss auf den Entscheidungsstatus priorisiert dargestellt.
+
+---
+
+### User Story 2 - Minimal Safe Change Set bewerten (Priority: P1)
+
+Als Maintainerin will ich für riskante PRs den kleinsten sicheren Gegenmaßnahmen-Plan sehen, damit ich gezielt nur die notwendigen Änderungen vor Merge verlangen kann.
+
+**Why this priority**: Der Minimal-Safe-Plan reduziert unnötige Rework-Schleifen und macht No-Go/Guardrails-Entscheidungen operativ umsetzbar.
+
+**Independent Test**: Kann unabhängig getestet werden, indem ein No-Go- oder Guardrails-Fall mindestens einen konkreten Minimal-Safe-Plan mit erwartetem Risiko-Delta und Score-Delta liefert.
+
+**Acceptance Scenarios**:
+
+1. **Given** ein PR mit Status No-Go, **When** die Maintainerin die Minimal-Safe-Karte öffnet, **Then** wird mindestens ein konkreter Plan mit erwarteter Risiko- und Score-Verbesserung angezeigt.
+2. **Given** ein PR mit Status Go with Guardrails, **When** die Maintainerin einen Plan betrachtet, **Then** sieht sie die erwartete Veränderung relativ zur Zielschwelle vor Merge.
+
+---
+
+### User Story 3 - Accountability Graph für Risikocluster verstehen (Priority: P2)
+
+Als Maintainerin will ich Änderungen nach Risikoauswirkung in Clustern visualisiert sehen, damit ich erkenne, welche Änderungsbereiche den Entscheidungsstatus treiben.
+
+**Why this priority**: Die Cluster-Sicht erhöht Nachvollziehbarkeit und beschleunigt die Kommunikation konkreter Guardrails an Agenten oder Beitragende.
+
+**Independent Test**: Kann unabhängig getestet werden, indem die Ansicht die PR-Änderungen in nachvollziehbare Cluster gruppiert und pro Cluster den Beitrag zum Risiko zeigt.
+
+**Acceptance Scenarios**:
+
+1. **Given** ein PR mit mehreren thematischen Änderungspaketen, **When** die Maintainerin den Accountability Graph öffnet, **Then** sieht sie Cluster mit jeweiligem Risiko-Beitrag.
+2. **Given** ein dominanter Risikocluster, **When** die Cluster priorisiert dargestellt werden, **Then** ist der stärkste Treiber klar als solcher erkennbar.
+
+---
+
+### User Story 4 - Entscheidungen und Outcomes nachverfolgen (Priority: P2)
+
+Als Maintainerin will ich Empfehlung, menschliche Entscheidung und reale Outcomes (7/30 Tage) in einer Timeline sehen, damit ich die Qualität vergangener Entscheidungen bewerten und kalibrieren kann.
+
+**Why this priority**: Governance wird nur lernfähig, wenn Empfehlungen und echte Folgen über Zeit vergleichbar dokumentiert sind.
+
+**Independent Test**: Kann unabhängig getestet werden, indem für mindestens einen PR ein Ledger-Eintrag mit Empfehlung, Entscheidung, Evidenz und Outcome-Zeitpunkten vorhanden ist.
+
+**Acceptance Scenarios**:
+
+1. **Given** ein entschiedener PR, **When** die Maintainerin das Decision Ledger öffnet, **Then** sieht sie Empfehlung, finale menschliche Entscheidung und verknüpfte Evidenz.
+2. **Given** ein PR mit verfügbaren Nachlaufdaten, **When** 7- oder 30-Tage-Outcome vorliegt, **Then** wird der Outcome im selben Ledger-Eintrag nachvollziehbar ergänzt.
+
+---
+
+### Edge Cases
+
+- Was passiert, wenn für einen PR keine ausreichende Evidenz für eine belastbare Empfehlung vorliegt?
+- Wie wird verhindert, dass ein PR gleichzeitig mehrere Decision-Status erhält?
+- Wie verhält sich das System, wenn 7/30-Tage-Outcome-Daten noch nicht verfügbar sind?
+- Wie wird ein bereits getroffener Entscheid dokumentiert, wenn sich die Evidenzlage vor Merge ändert?
+- Bei unzureichender Evidenz wird der Status zwingend als No-Go gesetzt und erst nach Evidenz-Nachlieferung neu bewertet.
+- Grenzfälle an den Schwellenwerten müssen deterministisch genau einem Status zugeordnet werden.
+- Eine Abweichung zwischen App-Empfehlung und menschlicher Entscheidung ist nur mit dokumentierter Begründung zulässig.
+- Fehlende 7/30-Tage-Outcomes werden im Ledger explizit als ausstehend ausgewiesen.
+- Gleichzeitige Bearbeitungen desselben Ledger- oder Decision-Eintrags führen zu einem expliziten Versionskonflikt statt stiller Überschreibung.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Das System MUSS jedem analysierten PR genau einen Decision Status zuweisen (Go, Go with Guardrails oder No-Go).
+- **FR-002**: Das System MUSS zu jedem Decision Status einen Konfidenzwert und priorisierte Top-Risikotreiber ausweisen.
+- **FR-003**: Das System MUSS für jeden PR mit Status No-Go mindestens einen konkreten Minimal-Safe-Plan bereitstellen.
+- **FR-004**: Das System MUSS für jeden Minimal-Safe-Plan ein erwartetes Risiko-Delta und ein erwartetes Score-Delta vor Merge ausweisen.
+- **FR-005**: Das System MUSS Änderungen eines PR in Risikocluster gruppieren und den Beitrag jedes Clusters zum Entscheidungsstatus sichtbar machen.
+- **FR-006**: Das System MUSS pro PR einen Ledger-Eintrag mit App-Empfehlung, menschlicher Entscheidung und referenzierter Evidenz speichern und anzeigen.
+- **FR-007**: Das System MUSS Outcomes für Entscheidungen nach 7 und 30 Tagen im Ledger demselben PR-Eintrag zuordnen und als Verlauf darstellen.
+- **FR-008**: Das System MUSS Guardrails-Entscheidungen mit klaren, prüfbaren Bedingungen dokumentieren, die vor Merge erfüllt sein müssen.
+- **FR-009**: Das System MUSS Änderungen an Decision Status oder Entscheidungshistorie versioniert nachvollziehbar machen.
+- **FR-010**: Das System MUSS eine Entscheidungsansicht bereitstellen, die den vollständigen Kern-Use-Case ohne Wechsel in andere Werkzeuge unterstützt.
+- **FR-011**: Das System MUSS bei unzureichender Evidenz automatisch den Status No-Go setzen und bis zur Evidenz-Nachlieferung beibehalten.
+- **FR-012**: Das System MUSS feste, statusspezifische Konfidenz-Schwellen für Go, Go with Guardrails und No-Go anwenden und Grenzwerte deterministisch auf genau einen Status mappen.
+- **FR-013**: Das System MUSS menschliche Übersteuerungen der App-Empfehlung erlauben, jedoch nur bei verpflichtender Begründung, die im Ledger mit Zeitstempel gespeichert wird.
+- **FR-014**: Das System MUSS nicht verfügbare 7/30-Tage-Outcomes explizit als ausstehend kennzeichnen, bis echte Outcome-Daten eingegangen sind.
+- **FR-015**: Das System MUSS bei gleichzeitigen Änderungen am selben Decision- oder Ledger-Eintrag einen Versionskonflikt ausweisen und eine explizite Konfliktauflösung verlangen.
+
+### Key Entities *(include if feature involves data)*
+
+- **Pull Request Decision Record**: Repräsentiert die zusammengefasste Entscheidungsbasis pro PR mit Status, Konfidenz, Risikotreibern und Zeitstempel.
+- **Minimal Safe Plan**: Repräsentiert die kleinste Gegenmaßnahme mit erwarteten Deltas und Zielschwellenbezug.
+- **Risk Cluster**: Repräsentiert eine Gruppe zusammenhängender Änderungen mit aggregierter Risikoauswirkung.
+- **Ledger Entry**: Repräsentiert die Timeline aus Empfehlung, menschlicher Entscheidung, Evidenzreferenzen und 7/30-Tage-Outcomes.
+- **Guardrail Condition**: Repräsentiert eine konkrete Vor-Merge-Bedingung, deren Erfüllung überprüfbar ist.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 95% der analysierten PRs zeigen innerhalb von 2 Minuten nach Öffnen der PR-Seite einen vollständigen Decision Panel Status mit Konfidenz und Top-Risikotreibern.
+- **SC-002**: 100% aller No-Go-Entscheidungen enthalten mindestens einen konkreten Minimal-Safe-Plan mit erwarteten Risiko- und Score-Deltas.
+- **SC-003**: 100% aller menschlichen Entscheidungen sind im Ledger mit Empfehlung und Evidenz nachvollziehbar dokumentiert.
+- **SC-004**: Für mindestens 90% der entschiedenen PRs werden verfügbare 7/30-Tage-Outcomes im gleichen Ledger-Kontext erfasst, sobald diese vorliegen.
+- **SC-005**: Im Vergleich zur Baseline sinkt die Rate von post-merge Rework-Ereignissen um mindestens 20%, ohne dass die mediane Merge-Durchlaufzeit steigt.
+
+## Assumptions
+
+- Die Web App richtet sich primär an Maintainer und Reviewer mit Merge-Verantwortung in AI-first Repositories.
+- Eine PR kann zu jedem Zeitpunkt nur einen aktiven Entscheidungsstatus besitzen; Statuswechsel werden historisiert.
+- Für die initiale Version steht eine konsistente Evidenzbasis pro PR bereit, aus der Risiko- und Score-Deltas abgeleitet werden können.
+- Nicht verfügbare 7/30-Tage-Outcomes werden im Ledger als ausstehend markiert und später ergänzt.
+- Der Fokus der ersten Version liegt auf Governance-Entscheidung für Pull Requests, nicht auf zeilenbasierter Code-Review-Ersetzung.

--- a/specs/006-human-decision-cockpit/tasks.md
+++ b/specs/006-human-decision-cockpit/tasks.md
@@ -1,0 +1,186 @@
+# Tasks: 006 Human Decision Cockpit
+
+**Input**: Design documents from `/specs/006-human-decision-cockpit/`
+**Prerequisites**: plan.md ✅ spec.md ✅ research.md ✅ data-model.md ✅ contracts/ ✅
+
+---
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Kann parallel laufen (verschiedene Dateien, keine offenen Dependencies)
+- **[Story]**: Zugehörige User Story (US1–US4)
+- Alle Pfade relativ zum Repo-Root
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verzeichnisstruktur, Slice-Skeleton, CLI-Stub, Package-Registration
+
+- [X] T001 Create vertical slice directory `src/drift/decision_cockpit/` with empty `__init__.py`
+- [X] T002 [P] Create `tests/decision_cockpit/__init__.py` (empty)
+- [X] T003 [P] Add `drift cockpit` Click group stub in `src/drift/decision_cockpit/_cmd.py` (import only, no logic)
+- [X] T004 Register `cockpit` subcommand in `src/drift/commands/__init__.py` (or CLI entry point)
+- [X] T005 [P] Create `.drift/cockpit/` ledger directory stub with `.gitkeep` (local artefact path for ledger JSON)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Frozen Pydantic models, failing test skeletons — MUSS vor allen User Stories abgeschlossen sein
+
+**⚠️ KRITISCH**: Keine User-Story-Arbeit beginnen, bis dieser Block vollständig ist
+
+- [X] T006 Implement all frozen Pydantic models in `src/drift/decision_cockpit/_models.py`: `DecisionBundle`, `DecisionRecord`, `RiskCluster`, `MinimalSafePlan`, `GuardrailCondition`, `LedgerEntry`, `OutcomeRecord`, `HumanOverride`; enums `DecisionStatus` (go / guardrails / no_go — **no** `pending_evidence`; missing evidence maps to `no_go` per spec clarification), `Verdict`, `OutcomeSignal`; domain exceptions `MissingEvidenceError`, `VersionConflictError`, `MissingOverrideJustificationError` in `src/drift/decision_cockpit/_exceptions.py`
+- [X] T007 [P] Write failing test stubs for all acceptance scenarios (US1–US4) in `tests/decision_cockpit/test_status_engine.py`, `test_safe_plan.py`, `test_ledger_contract.py`, `test_cockpit_threshold_boundaries.py` — RED phase, alle Tests müssen fehlschlagen
+- [X] T008 [P] Write failing contract test stubs for `LedgerEntry` and `DecisionBundle` invariants in `tests/decision_cockpit/test_cockpit_contracts.py` — RED phase
+- [X] T009 [P] Implement JSON serialization for `DecisionBundle` (schema key `"decision-bundle-v1"`) in `src/drift/decision_cockpit/_output.py` stub
+
+**Checkpoint**: Alle Modelle vorhanden, alle Tests rot, Slice-Skeleton fertig → US-Implementierung kann beginnen
+
+---
+
+## Phase 3: User Story 1 — Entscheidungsstatus in unter 2 Minuten (P1) 🎯 MVP
+
+**Goal**: `drift cockpit build --pr <id>` liefert genau einen `DecisionStatus` mit Konfidenzwert und priorisierten Top-Risikotreibern
+
+**Independent Test**: PR mit ausreichender Evidenz → `DecisionBundle` enthält genau einen Status, einen Konfidenzwert und mindestens einen Risikotreiber; Grenzwert-Inputs mappen deterministisch auf genau einen Status
+
+- [X] T010 [US1] Implement `_status_engine.py`: pure function `compute_decision_status(confidence: float, has_evidence: bool) -> DecisionStatus` with fixed thresholds — go ≥ 0.85, guardrails 0.60–0.84, no_go < 0.60; missing evidence always returns `no_go`
+- [X] T011 [US1] Implement `compute_confidence(signals: list[SignalResult]) -> float` (pure function) in `src/drift/decision_cockpit/_status_engine.py`
+- [X] T012 [US1] Implement `prioritize_risk_drivers(signals: list[SignalResult]) -> list[RiskDriver]` (pure function, sorted by impact descending) in `src/drift/decision_cockpit/_status_engine.py`
+- [X] T013 [US1] Implement `build_decision_bundle(pr_id: str, signals: list[SignalResult]) -> DecisionBundle` public function in `src/drift/decision_cockpit/__init__.py` — orchestrates status engine; raises `MissingEvidenceError` if no signals
+- [X] T014 [US1] Implement `drift cockpit build` CLI command in `src/drift/decision_cockpit/_cmd.py`: `--pr`, `--repo`, `--format json|rich`, `--exit-zero`, `--output`
+- [X] T015 [US1] Implement Rich output panel for `DecisionBundle` in `src/drift/decision_cockpit/_output.py`: status badge, confidence bar, top risk drivers table
+- [X] T016 [US1] GREEN phase: make US1 unit tests pass (`test_status_engine.py`, `test_cockpit_threshold_boundaries.py`)
+- [X] T017 [US1] Write integration test in `tests/decision_cockpit/test_cockpit_cmd_integration.py`: end-to-end CLI via `CliRunner` — go/guardrails/no_go/missing_evidence cases
+
+---
+
+## Phase 4: User Story 2 — Minimal Safe Change Set bewerten (P1)
+
+**Goal**: `DecisionBundle` für No-Go- und Guardrails-PRs enthält mindestens einen `MinimalSafePlan` mit `risk_delta` und `score_delta`
+
+**Independent Test**: No-Go-Fixture → `bundle.safe_plans` nicht leer; jeder Plan enthält `risk_delta < 0` und `score_delta > 0`; Guardrails-Fixture → Plan zeigt Delta relativ zur Go-Schwelle
+
+- [X] T018 [US2] Implement `_safe_plan.py`: pure function `compute_safe_plans(bundle: DecisionBundle, signals: list[SignalResult]) -> list[MinimalSafePlan]` — greedy minimal cover; returns `[]` for go status
+- [X] T019 [US2] Implement `compute_expected_deltas(plan: MinimalSafePlan, current_score: float, target_threshold: float) -> tuple[float, float]` (pure function, risk_delta + score_delta) in `src/drift/decision_cockpit/_safe_plan.py`
+- [X] T020 [US2] Integrate `safe_plans` field into `build_decision_bundle()` in `src/drift/decision_cockpit/__init__.py`
+- [X] T021 [US2] Add Minimal Safe Plan card to Rich output in `src/drift/decision_cockpit/_output.py`
+- [X] T022 [US2] GREEN phase: make US2 unit tests pass (`test_safe_plan.py`)
+
+---
+
+## Phase 5: User Story 3 — Accountability Graph für Risikocluster (P2)
+
+**Goal**: `DecisionBundle` enthält `RiskCluster`-Liste; jeder Cluster zeigt aggregierten Risikobeitrag zum Entscheidungsstatus
+
+**Independent Test**: PR-Fixture mit mehreren Änderungspaketen → `bundle.risk_clusters` gruppiert Änderungen; dominanter Cluster steht an erster Position nach `risk_contribution` absteigend
+
+- [X] T023 [US3] Implement `_cluster.py`: pure function `aggregate_clusters(signals: list[SignalResult], files: list[str]) -> list[RiskCluster]` — groups by signal category/file proximity; sorts by `risk_contribution` descending
+- [X] T024 [US3] Integrate `risk_clusters` field into `build_decision_bundle()` in `src/drift/decision_cockpit/__init__.py`
+- [X] T025 [US3] Add Accountability Graph section to Rich output in `src/drift/decision_cockpit/_output.py`: cluster list with contribution bars
+- [ ] T026 [US3] Add `CockpitApp.tsx` React component scaffold in `playground/src/cockpit/CockpitApp.tsx` — renders Decision Panel from `DecisionBundle` JSON (status badge, confidence, risk drivers, clusters)
+- [ ] T027 [US3] Add typed contract client `playground/src/cockpit/api.ts` — fetches `/cockpit/pr/{pr_id}/bundle` per `contracts/cockpit-api.yaml`
+- [ ] T028 [US3] Add `RiskClusterGraph.tsx` component in `playground/src/cockpit/components/RiskClusterGraph.tsx` — visualizes cluster list
+- [ ] T029 [US3] Write Vitest unit tests in `playground/src/cockpit/test/CockpitApp.test.tsx` for status badge rendering and cluster list rendering
+- [X] T030 [US3] GREEN phase: make US3 Python unit tests pass (`test_status_engine.py` cluster assertions)
+
+---
+
+## Phase 6: User Story 4 — Entscheidungen und Outcomes nachverfolgen (P2)
+
+**Goal**: `drift cockpit decide` schreibt einen `LedgerEntry` mit Empfehlung, menschlicher Entscheidung und Evidenzreferenz; Human Override nur mit Begründung; Outcomes nach 7/30 Tagen als `pending` → actual; Versionskonflikt bei Parallel-Edit
+
+**Independent Test**: `LedgerEntry` mit `recommendation != human_decision` ohne `override_justification` → Fehler; fehlende Outcomes → `outcome_7d: pending`; zweite simultane Schreiboperation mit falschem `version` → HTTP 409 / `VersionConflictError`
+
+- [X] T031 [US4] Implement `_ledger.py`: `write_ledger_entry(entry: LedgerEntry, path: Path) -> None` — append-only JSON write with optimistic locking (`version` field check before write; raise `VersionConflictError` on mismatch)
+- [X] T032 [US4] Implement `read_ledger(pr_id: str, path: Path) -> list[LedgerEntry]` in `src/drift/decision_cockpit/_ledger.py`
+- [X] T033 [US4] Implement `validate_override(entry: LedgerEntry) -> None` (pure function) in `src/drift/decision_cockpit/_ledger.py` — raise `MissingOverrideJustificationError` if `recommendation != human_decision` and `override_justification` is empty
+- [X] T034 [US4] Implement `update_outcome(pr_id: str, outcome: OutcomeRecord, path: Path) -> None` — appends outcome to existing ledger entry; marks `outcome_7d`/`outcome_30d` field from `pending` to actual
+- [X] T035 [US4] Implement `drift cockpit decide` CLI command in `src/drift/decision_cockpit/_cmd.py`: `--pr`, `--verdict`, `--justification`, `--repo`; calls `validate_override` + `write_ledger_entry`
+- [X] T036 [US4] Implement `drift cockpit outcome` CLI command in `src/drift/decision_cockpit/_cmd.py`: `--pr`, `--outcome`, `--days 7|30`; calls `update_outcome`
+- [ ] T037 [US4] Add Decision Timeline component in `playground/src/cockpit/components/DecisionTimeline.tsx` — renders ledger entries with recommendation, decision, justification, outcome status
+- [ ] T038 [US4] Write Vitest tests in `playground/src/cockpit/test/DecisionTimeline.test.tsx` — pending outcome display, override justification display
+- [X] T039 [US4] GREEN phase: make US4 Python unit tests pass (`test_ledger_contract.py` — override validation, version conflict, pending outcome)
+- [X] T040 [US4] Write integration test `tests/decision_cockpit/test_cockpit_cmd_integration.py`: `decide` + `outcome` CLI flow end-to-end including conflict scenario
+
+---
+
+## Phase 7: Polish & Cross-Cutting
+
+**Purpose**: Type checking, exit codes, FR-vollständigkeit, schema, docs
+
+- [ ] T041 [P] Verify and fix all mypy type errors in `src/drift/decision_cockpit/` (`make check`)
+- [ ] T042 [P] Verify exit codes for `drift cockpit build`: 0 = go, 1 = guardrails, 2 = no_go (includes missing-evidence case), 3 = system/runtime error, 10 = input validation error
+- [ ] T043 [P] [US1] FR-009 versioning: **implement** version tracking in `build_decision_bundle()` — read existing version from `.drift/cockpit/<pr_id>.json` if present, else start at 1; increment by 1 on each rebuild for same `pr_id`; **add unit test** covering first-build (version=1) and re-build (version=n+1) cases
+- [ ] T044 [P] [US1] FR-010 completeness: `drift cockpit build --format rich` renders all four panels (status + safe plan + clusters + ledger summary) in single invocation
+- [ ] T045 [P] [US1] FR-012 threshold boundary test: parameterised pytest covering exact go/guardrails/no_go boundaries (0.849999, 0.850000, 0.599999, 0.600000) — no_go wins at exact lower boundary
+- [ ] T046 [P] [US4] FR-014 pending sentinel: `LedgerEntry.outcome_7d` defaults to `OutcomeSignal.pending`; add schema test ensuring no `null` values in serialised ledger
+- [ ] T047 [P] Update `src/drift/commands/__init__.py` to export `cockpit` command group; verify `drift --help` shows `cockpit`
+- [ ] T048 [P] Add `drift cockpit` entry to `README.md` commands section and `docs/` quickstart (reference `specs/006-human-decision-cockpit/quickstart.md`)
+- [ ] T049 [P] [US3] Add ground-truth TP/TN fixtures for cockpit cluster and status engine in `tests/fixtures/ground_truth.py` (precision-recall gate)
+- [ ] T050 [P] [US4] Add ledger schema test: `LedgerEntry.model_json_schema()` matches expected JSON Schema for append-only audit invariants
+- [X] T051 [P] [US1] Constitution IV — SARIF output: implement `--format sarif` for `drift cockpit build` in `src/drift/decision_cockpit/_output.py`; emit SARIF 2.1.0 with each `RiskDriver` mapped to a SARIF `result`; add test asserting valid SARIF structure
+
+---
+
+## Dependencies (User Story Completion Order)
+
+```
+Phase 1 (Setup) → Phase 2 (Foundational) → US1 (Phase 3) → US2 (Phase 4)
+                                          → US3 (Phase 5, after US1)
+                                          → US4 (Phase 6, after US1 + US2 models)
+All → Phase 7 (Polish)
+```
+
+US2 and US3 can run concurrently after US1 Python core is green.  
+US4 depends on US1 models and ledger path; can overlap US2/US3 frontend work.
+
+---
+
+## Parallel Execution Examples
+
+### After Phase 2 completes:
+
+```
+Thread A: T010 → T011 → T012 → T013 → T014 → T015 → T016 → T017  (US1 Python)
+Thread B: T018 → T019 → T020 → T021 → T022                        (US2 Safe Plan, after T013)
+Thread C: T023 → T024 → T025 → T030                                (US3 Cluster Python, after T013)
+Thread D: T026 → T027 → T028 → T029                                (US3 UI, after T013 JSON contract)
+Thread E: T031 → T032 → T033 → T034 → T035 → T036 → T039 → T040  (US4 Ledger, after T006)
+Thread F: T037 → T038                                               (US4 UI Timeline, after T027)
+```
+
+---
+
+## Implementation Strategy
+
+**MVP Scope (US1 only)**:  
+Complete Phase 1 + Phase 2 + Phase 3 (T001–T017).  
+Deliverable: `drift cockpit build --pr <id>` outputs a deterministic `DecisionBundle` with status, confidence, and risk drivers via JSON + Rich.
+
+**Full V1**:  
+Complete all phases including Ledger (US4) and UI (US3).  
+Deliverable: Cockpit web view + CLI decision + outcome tracking with audit trail.
+
+---
+
+## Task Summary
+
+| Phase | Tasks | User Story | Notes |
+|-------|-------|-----------|-------|
+| Setup | T001–T005 | — | Skeleton + CLI stub |
+| Foundational | T006–T009 | — | Models + RED tests (blocking) |
+| US1 | T010–T017 | P1 | Status engine + CLI (MVP) |
+| US2 | T018–T022 | P1 | Safe Plan computation |
+| US3 | T023–T030 | P2 | Cluster + React UI |
+| US4 | T031–T040 | P2 | Ledger + Outcomes + UI Timeline |
+| Polish | T041–T051 | — | Types, schema, docs, exit codes, SARIF |
+
+**Total tasks**: 51  
+**Parallel opportunities**: 26+ tasks marked [P]  
+**MVP**: T001–T017 (17 tasks)  
+**FR coverage**: FR-001–FR-015 vollständig abgedeckt  
+**Constitution Principle II (Test-First)**: T007–T008 schreiben rote Tests vor jeder Implementierung in Phase 3–6  
+**Constitution Principle IV (SARIF)**: T051 sichert SARIF-Output für CI/GitHub-Actions-Integration

--- a/specs/007-cockpit-frontend/checklists/requirements.md
+++ b/specs/007-cockpit-frontend/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Drift Cockpit Frontend
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec basiert auf und ergänzt specs/006-human-decision-cockpit als UI-Schicht.
+- Authentication/Mobile-Support explizit als Out-of-Scope für v1 dokumentiert.
+- Alle Items bestanden — Spec ist bereit für `/speckit.plan`.

--- a/specs/007-cockpit-frontend/contracts/frontend-api-contract.md
+++ b/specs/007-cockpit-frontend/contracts/frontend-api-contract.md
@@ -1,0 +1,117 @@
+# Frontend–Backend Interface Contract
+
+**Version**: 0.1.0  
+**Date**: 2026-05-02  
+**Source**: [cockpit-api.yaml](../../006-human-decision-cockpit/contracts/cockpit-api.yaml)  
+**For**: Drift Cockpit Frontend ([spec.md](../spec.md))
+
+---
+
+## Base URL
+
+Configured via environment variable `COCKPIT_API_URL` (default: `http://localhost:8001`).  
+All paths below are relative to `$COCKPIT_API_URL/api/cockpit`.
+
+---
+
+## Endpoints consumed by the frontend
+
+### Decision Panel
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/prs/{pr_id}/decision` | Fetch current Decision Panel (status, confidence, risk drivers) |
+| `POST` | `/prs/{pr_id}/decision` | Record human decision (requires version for optimistic lock) |
+
+**`pr_id` format**: `{owner}/{repo}/{pr_number}` — derived from GitHub PR URL by the frontend.
+
+**POST body**:
+```json
+{
+  "human_decision": "go | go_with_guardrails | no_go",
+  "override_justification": "string | null",
+  "version": 3
+}
+```
+**409 Conflict** → `VersionConflict` response → frontend shows conflict banner.
+
+---
+
+### Scan Status (polling)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/prs/{pr_id}/scan-status` | Check if scan is running, complete, or not started |
+
+**Response**:
+```json
+{
+  "status": "running | complete | not_started",
+  "progress": 45
+}
+```
+Frontend polls every 3 seconds while `status = "running"`.
+
+---
+
+### Minimal Safe Plans
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/prs/{pr_id}/safe-plan` | Fetch all Minimal Safe Plans for the PR |
+| `PATCH` | `/prs/{pr_id}/safe-plan/{plan_id}/guardrails/{condition_id}` | Toggle guardrail fulfillment |
+
+**PATCH body**:
+```json
+{ "fulfilled": true }
+```
+
+---
+
+### Accountability Clusters
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/prs/{pr_id}/clusters` | Fetch all risk clusters with file breakdown |
+
+---
+
+### Decision Ledger
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/prs/{pr_id}/ledger` | Fetch full ledger entry (recommendation + decision + outcomes) |
+
+---
+
+## Error Contract
+
+All API errors return:
+```json
+{
+  "error": "string",
+  "detail": "string | null"
+}
+```
+
+| HTTP Status | Frontend action |
+|-------------|-----------------|
+| 404 | Show "PR not found or not yet analysed" empty state |
+| 409 | Show version conflict banner, block further edits |
+| 422 | Show field-level validation error in form |
+| 5xx | Show generic error message (FR-012) |
+| Network error | Show "Backend not reachable" error (FR-012) |
+
+---
+
+## TypeScript Client Contract
+
+The frontend generates a typed API client from this contract. Key types mirror `data-model.md` exactly. No extra fields may be assumed; unknown fields must be ignored gracefully.
+
+**Client file location**: `packages/cockpit-ui/src/api/client.ts`
+
+---
+
+## Constraint: COCKPIT_API_URL injection
+
+At Next.js build time, `COCKPIT_API_URL` is embedded via `next.config.js` `env` or `publicRuntimeConfig`. For `drift cockpit serve` local mode, the Python server injects the value pointing to `localhost:{api_port}`.

--- a/specs/007-cockpit-frontend/data-model.md
+++ b/specs/007-cockpit-frontend/data-model.md
@@ -1,0 +1,173 @@
+# Data Model: Drift Cockpit Frontend
+
+**Phase**: 1  
+**Date**: 2026-05-02  
+**Source**: [spec.md](spec.md) + [research.md](research.md) + [cockpit-api.yaml](contracts/cockpit-api.yaml)
+
+---
+
+## Entities
+
+### PrRef
+Identifies a GitHub Pull Request parsed from its URL.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `owner` | string | GitHub org/user (e.g. `mick-gsk`) |
+| `repo` | string | Repository name (e.g. `drift`) |
+| `pr_number` | number | Pull Request number |
+| `raw_url` | string | Original GitHub PR URL (input) |
+
+**Derivation**: Parsed from user input via regex on initial cockpit page load.
+
+---
+
+### DecisionPanel
+The primary view state for a single PR.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `pr_id` | string | Opaque backend ID (owner/repo/number) |
+| `status` | `"go" \| "go_with_guardrails" \| "no_go"` | Exactly one per PR |
+| `confidence` | number (0–1) | Threshold-driven |
+| `evidence_sufficient` | boolean | False → status forced to `no_go` |
+| `top_risk_drivers` | RiskDriver[] | Sorted descending by `impact` |
+| `version` | number | Optimistic lock version |
+| `scan_status` | `"complete" \| "running" \| "not_started"` | Drives loading indicator |
+| `scan_progress` | number (0–100) | Only meaningful when `scan_status = "running"` |
+
+---
+
+### RiskDriver
+A single risk factor contributing to the decision status.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `driver_id` | string | Stable identifier |
+| `title` | string | Human-readable label |
+| `impact` | number | Contribution to total risk (0–1) |
+| `severity` | `"critical" \| "high" \| "medium" \| "low"` | Optional badge |
+| `cluster_id` | string | Optional — links to AccountabilityCluster |
+
+---
+
+### MinimalSafePlan
+One actionable plan reducing risk for a No-Go or Guardrails PR.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `plan_id` | string | Stable identifier |
+| `pr_id` | string | Parent PR |
+| `title` | string | Short plan label |
+| `risk_delta` | number | Expected risk reduction (negative = improvement) |
+| `score_delta` | number | Expected score change |
+| `guardrails` | GuardrailCondition[] | Ordered checklist |
+
+---
+
+### GuardrailCondition
+A single pre-merge condition within a plan.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `condition_id` | string | Stable identifier |
+| `description` | string | Human-readable requirement |
+| `fulfilled` | boolean | Client-side toggle state (persisted via API) |
+
+**UI state**: Toggled locally; debounced PATCH sent to API. All fulfilled → plan marked complete.
+
+---
+
+### AccountabilityCluster
+A group of related PR changes, with aggregated risk contribution.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `cluster_id` | string | Stable identifier |
+| `label` | string | Thematic cluster name |
+| `risk_share` | number (0–1) | Fractional contribution to total risk |
+| `files` | ClusterFile[] | Member files and their individual contributions |
+| `dominant` | boolean | True for the highest-risk cluster |
+
+---
+
+### ClusterFile
+| Field | Type | Notes |
+|-------|------|-------|
+| `path` | string | Relative file path in PR |
+| `contribution` | number (0–1) | Share within cluster |
+
+---
+
+### LedgerEntry
+Full decision audit record for a PR.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `entry_id` | string | Stable identifier |
+| `pr_id` | string | Parent PR |
+| `app_recommendation` | `DecisionStatus` | Backend recommendation |
+| `human_decision` | `DecisionStatus \| null` | Set when decision is recorded |
+| `override_justification` | string \| null | Required when human ≠ app |
+| `decided_at` | ISO8601 string \| null | Timestamp of human decision |
+| `evidence_refs` | string[] | References to evidence artifacts |
+| `outcome_7d` | OutcomeRecord \| null | Null until data arrives |
+| `outcome_30d` | OutcomeRecord \| null | Null until data arrives |
+| `version` | number | Optimistic lock version |
+
+---
+
+### OutcomeRecord
+| Field | Type | Notes |
+|-------|------|-------|
+| `window` | `"7d" \| "30d"` | Measurement window |
+| `status` | `"pending" \| "available"` | `"pending"` shown as explicit label |
+| `value` | string \| null | Outcome description (available when status = "available") |
+| `recorded_at` | ISO8601 string \| null | When the outcome was recorded |
+
+---
+
+## State Transitions
+
+### DecisionPanel scan_status
+```
+not_started → running → complete
+                ↑           |
+            (polling)   (stops)
+```
+
+### LedgerEntry
+```
+[created by backend]
+  → human_decision = null (pending)
+  → human_decision = set (decided)
+  → outcome_7d.status = "available"
+  → outcome_30d.status = "available"
+```
+
+### Version Conflict (optimistic lock)
+```
+Client sends version=N → Server has version=N+1
+  → 409 VersionConflict
+  → UI shows conflict banner
+  → User resolves explicitly (reload + re-review)
+```
+
+---
+
+## Client-Side State Shape (React context)
+
+```typescript
+interface CockpitStore {
+  prRef: PrRef | null;
+  panel: DecisionPanel | null;
+  safePlans: MinimalSafePlan[];
+  clusters: AccountabilityCluster[];
+  ledger: LedgerEntry | null;
+  scanPolling: boolean;
+  conflictDetected: boolean;
+  error: string | null;
+}
+```
+
+All mutations go through API calls; no optimistic UI updates except guardrail toggles (debounced).

--- a/specs/007-cockpit-frontend/plan.md
+++ b/specs/007-cockpit-frontend/plan.md
@@ -1,0 +1,115 @@
+# Implementation Plan: Drift Cockpit Frontend
+
+**Branch**: `011-cockpit-frontend` | **Date**: 2026-05-02 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/007-cockpit-frontend/spec.md`
+
+## Summary
+
+Das Cockpit-Frontend ist eine Next.js-Web-App (`packages/cockpit-ui/`) mit Static Export, die die bestehende Cockpit-Backend-API (`packages/drift-cockpit/`) über konfigurierbare REST-Endpunkte konsumiert. Die App zeigt pro PR einen Decision Panel (Status, Konfidenz, Risikotreiber), Minimal-Safe-Plan-Karten mit abhakbaren Guardrails, einen Accountability-Graph und ein Decision Ledger. `drift cockpit serve` wird um ein `serve`-Subcommand erweitert, das die vorgebauten statischen Assets via FastAPI ausliefert — ohne externe Hosting-Infrastruktur.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x + React 18 (Next.js 14, static export); Python 3.11+ (serve command)  
+**Primary Dependencies**: Next.js 14, React 18, Tailwind CSS, Vitest + Testing Library, Playwright; FastAPI + uvicorn (Python serve)  
+**Storage**: N/A (stateless UI; alle Daten via REST-API; Assets als Python-Package-Data)  
+**Testing**: Vitest + Testing Library (Komponenten), Playwright (E2E), pytest (Python serve command)  
+**Target Platform**: Desktop-Browser ≥1024px; lokal ausgeliefert via `drift cockpit serve`  
+**Project Type**: SSR-at-build-time Static Web App + Python CLI-Erweiterung  
+**Performance Goals**: Decision Panel vollständig in <2 s; Accountability Graph für 50 Cluster in <300 ms  
+**Constraints**: `COCKPIT_API_URL` konfigurierbar; kein Auth in v1; kein Node.js auf Maintainer-Maschinen zur Laufzeit; Mobile out-of-scope  
+**Scale/Scope**: 5 Hauptansichten (Panel, Safe Plan, Graph, Decision Form, Ledger); Desktop-only v1
+
+## Constitution Check
+
+*GATE: Pre-Phase-0 check — passed. Post-Phase-1 re-check — passed.*
+
+- [x] **I. Library-First**: Die Python-Erweiterung (`drift cockpit serve`) ist ein dünner CLI-Adapter; Serving-Logik liegt in `drift_cockpit._serve` (neues Modul im bestehenden Slice). Keine Kernlogik im Click-Handler selbst.
+- [x] **II. Test-First**: Vitest-Komponenten-Tests und Playwright-E2E-Tests werden vor Implementierung geschrieben (RED-Phase). Python-Tests für `serve`-Command in `tests/decision_cockpit/test_cockpit_serve_cmd.py` ebenfalls zuerst.
+- [x] **III. Functional Programming**: React-Komponenten sind pure functional components; State via Hooks/Context ohne shared mutable state. Python-Serve-Modul ist zustandslos; I/O isoliert auf Startup/Request-Handler.
+- [x] **IV. CLI Interface & Observability**: `drift cockpit serve --port --api-url` ist ein Click-Subcommand. Startup-Info via Rich (`console.print`); Fehler auf stderr. JSON-Output nicht zutreffend für einen Server-Start-Befehl — Begründung: kein Analyse-Output.
+- [x] **V. Simplicity & YAGNI**: Kein Auth, kein Mobile, kein Multi-Repo-Admin in v1. FastAPI-Wahl über `http.server` durch konkrete Anforderung (POST/PATCH für Ledger). No speculative features.
+- [x] **VI. Vertical Slices**: Frontend-Package `packages/cockpit-ui/` ist eigenständig. Python-Erweiterung bleibt im bestehenden Slice `packages/drift-cockpit/`; neues Modul `_serve.py` importiert keine Sibling-Internals.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-cockpit-frontend/
+├── plan.md                          # This file
+├── research.md                      # Phase 0 output
+├── data-model.md                    # Phase 1 output
+├── quickstart.md                    # Phase 1 output
+├── contracts/
+│   └── frontend-api-contract.md    # Phase 1 output
+└── tasks.md                         # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+packages/cockpit-ui/                           # NEW — Next.js static-export app
+├── package.json
+├── next.config.js                             # output: 'export', COCKPIT_API_URL injection
+├── tsconfig.json
+├── src/
+│   ├── app/
+│   │   └── cockpit/
+│   │       └── [owner]/[repo]/[pr_number]/
+│   │           └── page.tsx                   # Main cockpit page (SSR at build time)
+│   ├── components/
+│   │   ├── DecisionPanel/                     # Status badge + confidence + risk drivers
+│   │   ├── MinimalSafePlanCard/               # Plan card + guardrail checklist
+│   │   ├── AccountabilityGraph/               # Risk cluster visualisation
+│   │   ├── DecisionForm/                      # Human decision form
+│   │   └── LedgerTimeline/                    # Ledger entry timeline
+│   ├── api/
+│   │   └── client.ts                          # Typed REST client (COCKPIT_API_URL)
+│   ├── hooks/
+│   │   ├── useDecisionPanel.ts                # Polling + panel state
+│   │   └── useScanStatus.ts                   # 3s poll for running scans
+│   └── types/
+│       └── cockpit.ts                         # TypeScript types from data-model.md
+├── tests/
+│   ├── components/                            # Vitest + Testing Library
+│   └── e2e/                                   # Playwright E2E
+└── out/                                       # Build output (gitignored)
+
+packages/drift-cockpit/src/drift_cockpit/
+├── _serve.py                                  # NEW — FastAPI app + static file serving
+└── _cmd.py                                    # EXTENDED — add `serve` subcommand
+
+tests/decision_cockpit/
+└── test_cockpit_serve_cmd.py                  # NEW — pytest for serve command
+```
+
+**Structure Decision**: Eigenständiges Next.js-Package `packages/cockpit-ui/` für vollständige Frontend-Unabhängigkeit. Python-Erweiterung bleibt im bestehenden `drift-cockpit`-Slice, da sie nur einen CLI-Adapter und einen Serving-Adapter hinzufügt — keine neue Geschäftslogik.
+
+## Complexity Tracking
+
+| Entscheidung | Warum notwendig | Einfachere Alternative verworfen weil |
+|---|---|---|
+| FastAPI statt `http.server` | POST/PATCH für Ledger-Updates + statische Files in einem Prozess | `http.server` unterstützt kein POST/PATCH nativ ohne Boilerplate-Handler |
+| Next.js `output: 'export'` statt SSR-Runtime | Python liefert statische Assets; kein Node.js zur Laufzeit | SSR-Runtime erfordert Node.js auf Maintainer-Maschinen — out-of-scope |
+| Polling statt SSE/WebSocket | Static Export unterstützt keine persistenten Server-Verbindungen | SSE/WebSocket benötigen Server-Push-Infrastruktur, die Static Export nicht bietet |
+
+## Phase 0 Research (resolved)
+
+Alle Unklarheiten aufgelöst in [research.md](research.md):
+
+- PR-Routing via Path-Segmente `/cockpit/[owner]/[repo]/[pr_number]` (nicht Query-Params)
+- Next.js `output: 'export'` → Assets in `drift_cockpit/static/` → Hatchling embeds → `importlib.resources` zur Laufzeit
+- In-Progress-Scan via 3s-Polling auf `GET /prs/{pr_id}/scan-status` (kein SSE)
+- `drift cockpit serve` = `@cockpit_cmd.command('serve')` mit FastAPI + StaticFiles + `--port` + `--api-url`
+
+## Phase 1 Design Outputs
+
+- [data-model.md](data-model.md): Alle Frontend-Entitäten, Beziehungen, Client-State-Shape und Zustandsübergänge
+- [contracts/frontend-api-contract.md](contracts/frontend-api-contract.md): Vollständiger API-Contract Frontend ↔ Backend inkl. Fehlerbehandlung
+- [quickstart.md](quickstart.md): End-to-end lokaler Flow (Backend starten → Frontend dev → Build → `drift cockpit serve`)
+
+## Post-Design Constitution Re-check
+
+- [x] Library-First: `_serve.py` ist reiner Adapter; Entscheidungslogik bleibt in `decision_cockpit`-Kern
+- [x] Test-First: Vitest-Tests für alle 5 Komponenten + Playwright-E2E + pytest für `serve`-Command vorgeplant
+- [x] Vertical Slices: `packages/cockpit-ui/` eigenständig; Python-Erweiterung in bestehendem Slice ohne Sibling-Import

--- a/specs/007-cockpit-frontend/quickstart.md
+++ b/specs/007-cockpit-frontend/quickstart.md
@@ -1,0 +1,98 @@
+# Quickstart: Drift Cockpit Frontend
+
+**Date**: 2026-05-02
+
+## Prerequisites
+
+- Node.js 20+
+- Python 3.11+ with drift dev install (`pip install -e '.[dev]'`)
+- The `drift-cockpit` backend package installed (part of workspace)
+
+---
+
+## Local Development (full stack)
+
+### 1. Start the backend API
+
+```bash
+drift cockpit build --repo . --pr 123
+drift cockpit serve --port 8001
+```
+
+This starts the cockpit API at `http://localhost:8001`.
+
+### 2. Start the frontend dev server
+
+```bash
+cd packages/cockpit-ui
+npm install
+COCKPIT_API_URL=http://localhost:8001 npm run dev
+```
+
+Open `http://localhost:3000/cockpit/mick-gsk/drift/123`.
+
+---
+
+## Building static assets for Python bundling
+
+```bash
+cd packages/cockpit-ui
+COCKPIT_API_URL=__COCKPIT_API_URL__ npm run build   # placeholder replaced at serve time
+# Output: packages/cockpit-ui/out/
+```
+
+Copy output to Python package:
+```bash
+cp -r packages/cockpit-ui/out/* packages/drift-cockpit/src/drift_cockpit/static/
+```
+
+The Python wheel (built by hatchling) embeds `static/` as package data.
+
+---
+
+## Running with `drift cockpit serve` (production-like)
+
+```bash
+drift cockpit serve --port 8000 --api-url http://localhost:8001
+```
+
+Open `http://localhost:8000/cockpit/mick-gsk/drift/123`.
+
+The command:
+1. Locates `static/` via `importlib.resources`
+2. Serves HTML/JS/CSS from the embedded Next.js export
+3. Proxies `/api/cockpit/*` to `--api-url`
+
+---
+
+## Key URLs
+
+| URL | Content |
+|-----|---------|
+| `http://localhost:3000/cockpit/{owner}/{repo}/{pr}` | Decision Panel (main view) |
+| `http://localhost:3000/cockpit/{owner}/{repo}/{pr}?tab=ledger` | Decision Ledger tab |
+| `http://localhost:3000/cockpit/{owner}/{repo}/{pr}?tab=graph` | Accountability Graph tab |
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `COCKPIT_API_URL` | `http://localhost:8001` | Backend API base URL |
+| `COCKPIT_PORT` | `3000` (dev) / `8000` (serve) | Frontend server port |
+
+---
+
+## Running tests
+
+```bash
+# Frontend (component + E2E)
+cd packages/cockpit-ui
+npm test                    # Vitest unit + integration
+npm run test:e2e            # Playwright E2E
+
+# Python serve command
+cd c:\Users\mickg\PWBS\drift
+.venv\Scripts\python.exe -m pytest tests/decision_cockpit/ -q --tb=short
+```

--- a/specs/007-cockpit-frontend/research.md
+++ b/specs/007-cockpit-frontend/research.md
@@ -1,0 +1,45 @@
+# Research: Drift Cockpit Frontend
+
+**Phase**: 0 — Unknowns resolved before design  
+**Date**: 2026-05-02  
+**For**: [plan.md](plan.md)
+
+---
+
+## Decision 1: PR-Identifikation via URL-Routing
+
+**Decision**: Path-Segment-Routing — `/cockpit/[owner]/[repo]/[pr_number]`
+
+**Rationale**: `next export` rendert jede Route als eigene HTML-Datei. Path-Segmente (`[owner]/[repo]/[pr_number]`) sind für Static-Export der zuverlässigste Ansatz, weil jedes eindeutige PR ein eigenes pre-gerendertes HTML-Dokument erhält. Query-Parameter (z. B. `?pr=https://github.com/...`) würden rein client-seitig verarbeitet und machen URLs fragilere Bookmarks. Zusätzliche UI-Zustände (aktiver Tab: Ledger, Graph) nutzen Query-Params innerhalb der Seite (`?tab=ledger`).
+
+**Alternatives considered**: Query-Parameter-basiertes Routing — verworfen, da kein pre-rendered HTML pro PR möglich und keine verlässlichen direkten Links ohne JS.
+
+---
+
+## Decision 2: Next.js Static Export + Python Bundling
+
+**Decision**: Next.js `output: 'export'` → `out/` wird nach `src/drift_cockpit/static/` kopiert; Hatchling-Include-Glob bundelt die Assets in das Python-Wheel.
+
+**Rationale**: `output: 'export'` erzeugt voll-statisches HTML/JS/CSS aus Next.js. Diese Dateien landen in `packages/drift-cockpit/src/drift_cockpit/static/` und werden über Hatchling als Package-Data eingebettet. Zur Laufzeit lokalisiert `importlib.resources` das `static/`-Verzeichnis im installierten Paket. Für den HTTP-Server wird FastAPI + uvicorn gewählt, da es im gleichen Prozess sowohl statische Assets als auch die REST-API-Endpunkte bedienen kann — und uvicorn wahrscheinlich ohnehin als transitive Abhängigkeit vorliegt.
+
+**Alternatives considered**: Python `http.server.SimpleHTTPRequestHandler` — verworfen, da POST/PATCH für Ledger-Updates einen separaten Handler-Mechanismus erfordern würden, der FastAPI nicht vereinfacht.
+
+---
+
+## Decision 3: In-Progress-Scan-Zustand — Polling statt SSE/WebSocket
+
+**Decision**: Client-seitiges Polling via `setInterval` + `fetch` auf `GET /api/cockpit/scan-status/{pr_id}`
+
+**Rationale**: Next.js Static Export läuft rein client-seitig im Browser. SSE und WebSocket erfordern eine persistente Server-Verbindung und werden im Static-Export-Modus nicht vom Next.js-Framework bereitgestellt. Polling ist das praktische Muster: Das Frontend fragt alle 3 Sekunden den Backend-Endpunkt ab, der `{"status": "running"|"complete", "progress": 0..100}` zurückgibt. Für den Governance-Workflow (keine Hochfrequenz-Updates) ist Polling vollständig ausreichend.
+
+**Alternatives considered**: SSE — verworfen, da Static Export keine Server-Push-Infrastruktur bereitstellt. WebSocket — verworfen aus demselben Grund und wegen erhöhter Komplexität ohne nennenswerten Nutzen.
+
+---
+
+## Decision 4: `drift cockpit serve` Erweiterung
+
+**Decision**: Neues `serve`-Subcommand in `_cmd.py` via `@cockpit_cmd.command('serve')` mit `importlib.resources` für Asset-Lokalisierung + FastAPI-App für kombiniertes Serving.
+
+**Rationale**: `importlib.resources.files("drift_cockpit").joinpath("static")` lokalisiert die gebündelten Assets zur Laufzeit. Das Subcommand akzeptiert `--port` (default 8000) und `--api-url` (default `http://localhost:8001`). FastAPI mountet die statischen Assets über `StaticFiles` und stellt gleichzeitig die REST-Endpunkte bereit. So läuft das Frontend ohne separaten Prozess oder Node.js-Runtime.
+
+**Alternatives considered**: Eigenständige Next.js-Runtime — verworfen (erfordert Node.js auf Maintainer-Maschinen). Eigenständiger Python-`http.server` — verworfen wegen fehlender POST/PATCH-Unterstützung ohne Boilerplate.

--- a/specs/007-cockpit-frontend/spec.md
+++ b/specs/007-cockpit-frontend/spec.md
@@ -1,0 +1,158 @@
+# Feature Specification: Drift Cockpit Frontend
+
+**Feature Branch**: `011-cockpit-frontend`  
+**Created**: 2026-05-02  
+**Status**: Draft  
+**Input**: User description: "es fehlt ein Frontend für das drift cockpit"
+
+## Clarifications
+
+### Session 2026-05-02
+
+- Q: Welcher App-Typ ist für das Cockpit Frontend vorgesehen? → A: Next.js / Static Export — eigenständige Web-App mit Static Export (SSR at build time only) und direkten PR-URL-Shares.
+- Q: Wie wird ein PR im Cockpit identifiziert und navigiert? → A: GitHub PR-URL als Eingabe — Cockpit leitet weiter zu `/cockpit/[owner]/[repo]/[pr_number]`, wobei Repo-Owner und PR-Nummer automatisch aufgelöst werden.
+- Q: Wie wird ein laufender Scan im Cockpit dargestellt? → A: Lade-Indikator mit automatischem Poll/Stream — Teilresultate werden schrittweise angezeigt; kein Blockieren der Ansicht.
+- Q: Wie soll das Cockpit auf das Backend zugreifen? → A: REST API via konfigurierbarer Backend-URL (Umgebungsvariable `COCKPIT_API_URL`).
+- Q: Wie soll das Deployment des Cockpit Frontends erfolgen? → A: `drift cockpit serve` bündelt das vorgebaute Frontend und liefert es als statische Assets aus.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - PR-Entscheidungsstatus auf einen Blick (Priority: P1)
+
+Als Maintainerin öffne ich das Cockpit für einen Pull Request und sehe sofort den aktuellen Decision Status (Go, Go with Guardrails oder No-Go), den Konfidenzwert und die Top-Risikotreiber — ohne dass ich weitere Werkzeuge öffnen muss.
+
+**Why this priority**: Das ist der Kernnutzen des Cockpits. Ohne diese Ansicht hat das gesamte Frontend keinen Wert.
+
+**Independent Test**: Kann vollständig getestet werden, indem die Cockpit-Startseite für einen PR den Status, den Konfidenzwert und mindestens einen Risikotreiber in unter 2 Sekunden anzeigt.
+
+**Acceptance Scenarios**:
+
+1. **Given** ein analysierter PR mit ausreichender Evidenz, **When** die Maintainerin die Cockpit-URL für diesen PR aufruft, **Then** sieht sie Status-Badge (Go/Go with Guardrails/No-Go), Konfidenzwert und priorisierte Top-Risikotreiber ohne Login-Schranke im initialen Viewport.
+2. **Given** ein PR mit unzureichender Evidenz, **When** die Cockpit-Seite geladen wird, **Then** wird der Status explizit als No-Go mit Hinweis auf fehlende Evidenz dargestellt.
+3. **Given** mehrere Risikotreiber, **When** die Übersicht angezeigt wird, **Then** sind die Risikotreiber nach absteigendem Einfluss geordnet; der stärkste Treiber ist visuell hervorgehoben.
+
+---
+
+### User Story 2 - Minimal-Safe-Plan einsehen und Guardrails verstehen (Priority: P1)
+
+Als Maintainerin öffne ich für einen No-Go- oder Guardrails-PR die Liste der Minimal-Safe-Plans und sehe pro Plan das erwartete Risiko-Delta und Score-Delta sowie die konkreten Guardrail-Bedingungen, die vor Merge erfüllt sein müssen.
+
+**Why this priority**: Ohne operativen Plan bleiben No-Go-Entscheidungen abstrakt und nicht umsetzbar.
+
+**Independent Test**: Kann unabhängig getestet werden, indem ein PR mit Status No-Go mindestens eine Plan-Karte mit Delta-Werten und Guardrail-Checkliste anzeigt.
+
+**Acceptance Scenarios**:
+
+1. **Given** ein PR mit Status No-Go, **When** die Maintainerin auf den Minimal-Safe-Plan-Tab klickt, **Then** sieht sie mindestens eine Plan-Karte mit erwartetem Risiko-Delta, Score-Delta und mindestens einer prüfbaren Guardrail-Bedingung.
+2. **Given** ein Plan mit mehreren Guardrails, **When** einzelne Bedingungen abgehakt werden, **Then** aktualisiert die Übersicht den Erfüllungsstatus, ohne dass die Seite neu lädt.
+3. **Given** ein Guardrails-Status-Plan, **When** alle Bedingungen erfüllt sind, **Then** wird dem Nutzer eine visuelle Bestätigung gezeigt, dass der Plan vollständig abgearbeitet ist.
+
+---
+
+### User Story 3 - Accountability Graph für Risikocluster (Priority: P2)
+
+Als Maintainerin wechsle ich in die Graph-Ansicht und sehe die PR-Änderungen nach Risikoclustern gruppiert. Ich erkenne auf einen Blick, welcher Cluster den größten Anteil am Entscheidungsstatus trägt.
+
+**Why this priority**: Die Cluster-Sicht erhöht die Nachvollziehbarkeit von Entscheidungen und vereinfacht die Kommunikation konkreter Guardrails.
+
+**Independent Test**: Kann unabhängig getestet werden, indem eine Graph-Ansicht Cluster mit Risikoanteil darstellt, ohne dass Ledger oder Entscheidungsformular benötigt wird.
+
+**Acceptance Scenarios**:
+
+1. **Given** ein PR mit mehreren thematischen Änderungspaketen, **When** die Maintainerin die Graph-Ansicht aufruft, **Then** sieht sie Cluster-Knoten mit jeweiligem Risikoanteil als prozentualem Wert oder Balken.
+2. **Given** ein dominanter Cluster, **When** die Cluster-Ansicht gerendert wird, **Then** ist der stärkste Risikokluster visuell eindeutig als führend erkennbar.
+3. **Given** ein Cluster mit mehreren Dateien, **When** die Maintainerin auf den Cluster klickt, **Then** werden die enthaltenen Dateien und deren jeweiliger Einzelbeitrag aufgeklappt.
+
+---
+
+### User Story 4 - Entscheidung treffen und Ledger eintragen (Priority: P1)
+
+Als Maintainerin treffe ich eine Merge-Entscheidung direkt im Cockpit: Ich bestätige die App-Empfehlung oder übersteige sie mit Begründung. Das Ergebnis wird im Decision Ledger mit Zeitstempel gespeichert.
+
+**Why this priority**: Das Erfassen der menschlichen Entscheidung ist der eigentliche Governance-Akt — alles andere ist Vorbereitung.
+
+**Independent Test**: Kann unabhängig getestet werden, indem ein Entscheidungsformular die Entscheidung speichert und ein Ledger-Eintrag mit Zeitstempel erscheint.
+
+**Acceptance Scenarios**:
+
+1. **Given** ein PR mit bekanntem Status, **When** die Maintainerin „Merge freigeben" oder „Ablehnen" im Formular auswählt und bestätigt, **Then** erscheint ein Ledger-Eintrag mit Zeitstempel, App-Empfehlung und menschlicher Entscheidung.
+2. **Given** eine Entscheidung, die von der App-Empfehlung abweicht, **When** die Maintainerin die Bestätigung anklickt, **Then** ist das Begründungsfeld Pflicht; das Formular lässt sich ohne ausgefüllte Begründung nicht absenden.
+3. **Given** ein bereits entschiedener PR, **When** eine zweite Sitzung denselben Ledger-Eintrag bearbeiten will, **Then** wird ein Versionskonflikt angezeigt und eine explizite Auflösung verlangt.
+
+---
+
+### User Story 5 - Decision Ledger und Outcomes nachverfolgen (Priority: P2)
+
+Als Maintainerin öffne ich das Ledger für einen entschiedenen PR und sehe die chronologische Timeline aus Empfehlung, Entscheidung, Evidenz und — sobald verfügbar — 7- und 30-Tage-Outcomes.
+
+**Why this priority**: Lernfähige Governance erfordert die Rückkopplung zwischen Entscheidungsqualität und realen Folgen.
+
+**Independent Test**: Kann unabhängig getestet werden, indem ein Ledger-Eintrag Empfehlung, Entscheidung und Outcome-Felder (ausstehend oder befüllt) chronologisch zeigt.
+
+**Acceptance Scenarios**:
+
+1. **Given** ein entschiedener PR, **When** die Maintainerin das Ledger öffnet, **Then** zeigt die Timeline Empfehlung, finale Entscheidung und Evidenzreferenzen in chronologischer Reihenfolge.
+2. **Given** ein PR ohne noch verfügbare Outcome-Daten, **When** der 7-Tage-Slot angezeigt wird, **Then** ist er explizit als ausstehend markiert, nicht leer gelassen.
+3. **Given** ein PR mit eingegangenem 30-Tage-Outcome, **When** das Ledger neu geladen wird, **Then** ist der Outcome-Eintrag dem bestehenden Ledger-Eintrag zugeordnet, kein separater Datensatz.
+
+---
+
+### Edge Cases
+
+- Was passiert, wenn für einen PR keine Cockpit-Analyse vorliegt (kein Scan durchgeführt)?
+- Wie verhält sich die UI bei einer sehr großen Anzahl von Risikotreibern (>20)?
+- Wie wird eine laufende Analyse (noch nicht abgeschlossen) dargestellt, ohne veraltete Daten zu zeigen? → Lade-Indikator mit schrittweisen Teilresultaten; kein Blockieren der Ansicht.
+- Wie reagiert das Frontend auf ein Backend-Timeout oder nicht erreichbares API?
+- Wie wird mit gleichzeitigen Sitzungen umgegangen, die denselben Ledger-Eintrag bearbeiten?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Das Frontend MUSS für jeden PR eine Decision-Panel-Seite bereitstellen, die Status, Konfidenzwert und Top-Risikotreiber in einem einzigen initialen Viewport darstellt.
+- **FR-002**: Das Frontend MUSS den Status-Badge (Go, Go with Guardrails, No-Go) farblich und textuell eindeutig unterscheidbar anzeigen.
+- **FR-003**: Das Frontend MUSS bei unzureichender Evidenz automatisch einen No-Go-Status mit erklärendem Hinweis rendern.
+- **FR-004**: Das Frontend MUSS für jeden No-Go- oder Guardrails-PR eine Minimal-Safe-Plan-Liste mit Risiko-Delta, Score-Delta und Guardrail-Bedingungen anzeigen.
+- **FR-005**: Das Frontend MUSS Guardrail-Bedingungen als abhakbare Checkliste darstellen, deren Erfüllungsstatus ohne Seiten-Reload aktualisiert wird.
+- **FR-006**: Das Frontend MUSS eine Accountability-Graph-Ansicht bereitstellen, die PR-Änderungen in Risikocluster gruppiert und den prozentualen Risikoanteil pro Cluster visualisiert.
+- **FR-007**: Das Frontend MUSS ein Entscheidungsformular bereitstellen, über das eine Maintainerin Go/No-Go/Guardrails-Entscheidungen treffen und abspeichern kann.
+- **FR-008**: Das Frontend MUSS bei einer Entscheidung, die von der App-Empfehlung abweicht, ein Pflicht-Begründungsfeld einblenden und das Absenden ohne Begründung verhindern.
+- **FR-009**: Das Frontend MUSS für jeden PR ein Decision Ledger anzeigen, das Empfehlung, menschliche Entscheidung, Evidenzreferenzen und Outcome-Felder (7/30 Tage) in einer Timeline darstellt.
+- **FR-010**: Das Frontend MUSS fehlende Outcome-Daten explizit als ausstehend kennzeichnen, anstatt diese Felder leer zu lassen.
+- **FR-011**: Das Frontend MUSS bei einem erkannten Versionskonflikt (gleichzeitige Bearbeitung) einen sichtbaren Konflikt-Banner anzeigen und eine Auflösung erzwingen.
+- **FR-012**: Das Frontend MUSS bei Backend-Fehlern oder Timeouts eine nutzerfreundliche Fehlermeldung anzeigen, ohne in einen Leerzustand zu verfallen.
+- **FR-013**: Das Frontend MUSS alle Cockpit-Funktionen aus einer zusammenhängenden Ansicht heraus zugänglich machen, ohne externe Werkzeuge zu benötigen.
+- **FR-014**: Das Frontend MUSS responsiv sein und auf gängigen Desktop-Viewport-Breiten (≥1024px) vollständig nutzbar sein.
+- **FR-015**: Jede PR-spezifische Ansicht (Decision Panel, Ledger, Graph) MUSS über eine stabile, direkt verlinkbare URL erreichbar sein (SSR-fähiges Routing).
+- **FR-016**: Das Frontend MUSS eine GitHub PR-URL als Eingabe akzeptieren und daraus Repo-Owner, Repo-Name und PR-Nummer automatisch auflösen; fehlerhafte oder nicht auflösbare URLs MÜSSEN eine verständliche Fehlermeldung erzeugen.
+- **FR-017**: Das Frontend MUSS einen laufenden Drift-Scan durch einen sichtbaren Lade-Indikator anzeigen und bereits verfügbare Teilresultate schrittweise einblenden; die Ansicht darf während eines laufenden Scans nicht blockiert werden.
+- **FR-018**: Das Frontend MUSS die Backend-Basis-URL über eine Umgebungsvariable (`COCKPIT_API_URL`) konfigurierbar halten, sodass dasselbe Build sowohl lokal als auch remote betrieben werden kann.
+- **FR-019**: Das Frontend MUSS als statische Assets vorgebaut werden können, die `drift cockpit serve` ohne externes Hosting-Setup ausliefert; ein separates Deployment-Werkzeug darf nicht vorausgesetzt werden.
+
+### Key Entities *(include if feature involves data)*
+
+- **Decision Panel**: Hauptansicht pro PR mit Status-Badge, Konfidenzwert und Risikotreiber-Liste.
+- **Minimal Safe Plan Card**: Darstellung eines Plans mit Deltas und Guardrail-Checkliste.
+- **Accountability Graph**: Interaktive Visualisierung von Risikoclustern und deren Anteil am Gesamtrisiko.
+- **Decision Form**: Formular zur Erfassung der menschlichen Merge-Entscheidung inkl. Pflicht-Begründung bei Abweichung.
+- **Ledger Timeline**: Chronologische Darstellung von Empfehlung, Entscheidung, Evidenz und Outcomes pro PR.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 95 % aller Decision-Panel-Seiten laden vollständig (Status + Konfidenz + Risikotreiber) in unter 2 Sekunden bei einem Standard-Desktop-Browser.
+- **SC-002**: 100 % der Entscheidungsformulare, die eine App-Abweichung enthalten, verhindern das Absenden ohne Begründung.
+- **SC-003**: 100 % aller Ledger-Einträge zeigen Empfehlung, Entscheidung und Evidenzreferenz; fehlende Outcomes werden als ausstehend markiert.
+- **SC-004**: Die Accountability-Graph-Ansicht rendert für PRs mit bis zu 50 Risikoclustern ohne Interaktionsverzögerung über 300 ms.
+- **SC-005**: 90 % der Tester in einem Usability-Durchgang können eine Merge-Entscheidung ohne externe Dokumentation innerhalb von 3 Minuten abschließen.
+
+## Assumptions
+
+- Das Cockpit-Backend (specs/006-human-decision-cockpit) stellt eine stabile API bereit, die Decision Status, Minimal-Safe-Plans, Risk Clusters und Ledger-Einträge liefert.
+- Das Frontend wird als statische Assets vorgebaut; `drift cockpit serve` liefert diese Assets aus, sodass kein externes Hosting-Setup benötigt wird.
+- Das Frontend ist eine Next.js-Web-App mit Static Export (SSR at build time only); keine Browser-Extension, kein IDE-Plugin, keine reine SPA.
+- Authentifizierung und Zugriffskontrolle sind in der ersten Version ausgeschlossen; der Fokus liegt auf dem Governance-Workflow.
+- Nur Desktop-Viewports (≥1024px Breite) werden für v1 unterstützt; Mobile-Optimierung ist explizit zurückgestellt.
+- Die Backend-API ist JSON-basiert, folgt den bestehenden Drift-Output-Schemata und wird über eine konfigurierbare URL (`COCKPIT_API_URL`) angesprochen.
+- PRs werden über ihre vollständige GitHub-PR-URL identifiziert; das Cockpit leitet daraus Repo-Owner, Repo-Name und PR-Nummer ab.

--- a/specs/007-cockpit-frontend/tasks.md
+++ b/specs/007-cockpit-frontend/tasks.md
@@ -1,0 +1,173 @@
+# Tasks: Drift Cockpit Frontend
+
+**Input**: Design documents from `/specs/007-cockpit-frontend/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/frontend-api-contract.md ✅, quickstart.md ✅
+**Branch**: `011-cockpit-frontend`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: New Next.js package scaffold and Python serve-command skeleton
+
+- [X] T001 Scaffold `packages/cockpit-ui/` with Next.js 14 (`output: 'export'`), TypeScript, Tailwind CSS, Vitest, Playwright per `packages/cockpit-ui/package.json` + `next.config.js`
+- [X] T002 [P] Create `packages/cockpit-ui/src/types/cockpit.ts` with all TypeScript types from `specs/007-cockpit-frontend/data-model.md` (PrRef, DecisionPanel, RiskDriver, MinimalSafePlan, GuardrailCondition, AccountabilityCluster, ClusterFile, LedgerEntry, OutcomeRecord, CockpitStore)
+- [X] T003 [P] Create `packages/cockpit-ui/src/api/client.ts` — typed REST client reading `COCKPIT_API_URL` from `next.config.js` env; implements all endpoints from `specs/007-cockpit-frontend/contracts/frontend-api-contract.md`
+- [X] T004 [P] Create `packages/drift-cockpit/src/drift_cockpit/_serve.py` — FastAPI app with `StaticFiles` mount + `/api/cockpit/*` proxy stub; `importlib.resources` locates `static/` at runtime
+- [X] T005 Extend `packages/drift-cockpit/src/drift_cockpit/_cmd.py` — add `serve` subcommand (`--port`, `--api-url`) that starts the FastAPI app from `_serve.py`
+- [X] T006 [P] Create `packages/drift-cockpit/src/drift_cockpit/static/.gitkeep` and update `packages/drift-cockpit/pyproject.toml` with hatchling include glob `src/drift_cockpit/static/**`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: App shell, routing, shared layout, API client wiring and Python serve test skeleton — must be complete before any user story component work begins
+
+**⚠️ CRITICAL**: All user story phases depend on this phase being complete
+
+- [X] T007 Create Next.js app route `packages/cockpit-ui/src/app/cockpit/[owner]/[repo]/[pr_number]/page.tsx` — server component that passes segments to client shell
+- [X] T008 [P] Create `packages/cockpit-ui/src/app/layout.tsx` — root layout with Tailwind globals, font, and error boundary
+- [X] T009 [P] Create `packages/cockpit-ui/src/hooks/useScanStatus.ts` — 3-second polling hook; stops when `status = "complete"`; exposes `{ status, progress }`
+- [X] T010 [P] Create `packages/cockpit-ui/src/hooks/useDecisionPanel.ts` — fetches panel; triggers polling via `useScanStatus` when scan running; exposes `{ panel, loading, error }`
+- [X] T011 [P] Create `packages/cockpit-ui/src/components/ErrorBanner/index.tsx` — reusable error/conflict banner; accepts `message`, `type: "error"|"conflict"`
+- [X] T012 [P] Create `packages/cockpit-ui/src/components/LoadingIndicator/index.tsx` — progress bar + percentage; shown when `scan_status = "running"`
+- [X] T013 [P] Create `packages/cockpit-ui/tests/e2e/cockpit.spec.ts` — Playwright E2E skeleton with mock server fixtures for all 5 user stories (stubs only, will fail until US implementations complete)
+- [X] T014 [P] Create `tests/decision_cockpit/test_cockpit_serve_cmd.py` — pytest skeleton testing `drift cockpit serve --port 9123` starts, responds 200 on `/`, and `--help` includes `api-url` option
+
+**Checkpoint**: App shell renders at `/cockpit/owner/repo/123`, polling hook wires to API, error+loading components exist, all test skeletons RED
+
+---
+
+## Phase 3: User Story 1 — PR-Entscheidungsstatus auf einen Blick (Priority: P1) 🎯 MVP
+
+**Goal**: Maintainerin sieht Status-Badge, Konfidenzwert und Top-Risikotreiber im ersten Viewport — sofort, ohne weitere Werkzeuge.
+
+**Independent Test**: Cockpit-URL für PR öffnen → Decision Panel zeigt Status, Konfidenz und ≥1 Risikotreiber in <2 s; bei fehlender Evidenz: No-Go mit Hinweis.
+
+- [X] T015 [P] [US1] Create `packages/cockpit-ui/src/components/DecisionPanel/StatusBadge.tsx` — renders Go / Go with Guardrails / No-Go with distinct colour per status; `evidence_sufficient=false` forces No-Go variant with explanatory text
+- [X] T016 [P] [US1] Create `packages/cockpit-ui/src/components/DecisionPanel/ConfidenceBar.tsx` — numeric confidence value (0–1) as labelled progress bar
+- [X] T017 [P] [US1] Create `packages/cockpit-ui/src/components/DecisionPanel/RiskDriverList.tsx` — sorted-by-impact list; first item visually highlighted; renders `impact`, `severity` badge, optional `cluster_id` link
+- [X] T018 [US1] Create `packages/cockpit-ui/src/components/DecisionPanel/index.tsx` — composes StatusBadge + ConfidenceBar + RiskDriverList; passes `DecisionPanel` type from `cockpit.ts`; shows `LoadingIndicator` while `scan_status = "running"`
+- [X] T019 [US1] Wire `DecisionPanel` into `packages/cockpit-ui/src/app/cockpit/[owner]/[repo]/[pr_number]/page.tsx` via `useDecisionPanel` hook
+- [X] T020 [P] [US1] Write Vitest component tests for `StatusBadge`, `ConfidenceBar`, `RiskDriverList` in `packages/cockpit-ui/tests/components/DecisionPanel.test.tsx` — cover Go/Guardrails/No-Go variants, no-evidence forced state, sort order
+
+**Checkpoint**: US1 independently testable — `npm test` passes DecisionPanel tests; Playwright US1 E2E scenario green
+
+---
+
+## Phase 4: User Story 2 — Minimal-Safe-Plan einsehen und Guardrails verstehen (Priority: P1)
+
+**Goal**: Maintainerin sieht Plan-Karten mit Risiko-Delta, Score-Delta und abhakbarer Guardrail-Checkliste; alle Bedingungen erfüllt → visuelle Bestätigung.
+
+**Independent Test**: PR mit No-Go laden → mindestens eine Plan-Karte mit Deltas + Checkliste; Guardrail abhaken → optimistischer Toggle ohne Reload; alle abhaken → Completion-Badge erscheint.
+
+- [X] T021 [P] [US2] Create `packages/cockpit-ui/src/components/MinimalSafePlanCard/GuardrailChecklist.tsx` — ordered checklist with individual `fulfilled` toggle; PATCH `guardrails/{condition_id}` on toggle (debounced 400 ms); all fulfilled → completion badge
+- [X] T022 [P] [US2] Create `packages/cockpit-ui/src/components/MinimalSafePlanCard/DeltaBadge.tsx` — renders `risk_delta` and `score_delta` as signed numeric badges with colour (negative = improvement = green)
+- [X] T023 [US2] Create `packages/cockpit-ui/src/components/MinimalSafePlanCard/index.tsx` — composes title + DeltaBadge + GuardrailChecklist; collapses by default, expands on click
+- [X] T024 [US2] Create `packages/cockpit-ui/src/components/MinimalSafePlanList/index.tsx` — fetches `GET /prs/{pr_id}/safe-plan`; renders ordered list of `MinimalSafePlanCard`; empty state when no plans available
+- [X] T025 [US2] Wire `MinimalSafePlanList` into cockpit page as Safe-Plan tab (via T042 tab navigation); visible when tab active
+- [X] T026 [P] [US2] Write Vitest tests for `GuardrailChecklist`, `DeltaBadge`, `MinimalSafePlanCard` in `packages/cockpit-ui/tests/components/MinimalSafePlan.test.tsx` — cover toggle behaviour, debounce, completion badge, empty-plan state
+
+**Checkpoint**: US2 independently testable — `npm test` passes MinimalSafePlan tests; Playwright US2 E2E scenario green
+
+---
+
+## Phase 5: User Story 3 — Accountability Graph für Risikocluster (Priority: P2)
+
+**Goal**: Maintainerin sieht PR-Änderungen in Risikoclustern mit prozentualem Anteil; dominanter Cluster visuell hervorgehoben; Klick auf Cluster klappt Dateien auf.
+
+**Independent Test**: Graph-Tab aufrufen → Cluster-Knoten mit Risikoanteilen sichtbar; dominanter Cluster hervorgehoben; Klick → Dateiliste expandiert.
+
+- [X] T027 [P] [US3] Create `packages/cockpit-ui/src/components/AccountabilityGraph/ClusterNode.tsx` — renders cluster label, `risk_share` as percentage bar; `dominant=true` → highlighted border + icon
+- [X] T028 [P] [US3] Create `packages/cockpit-ui/src/components/AccountabilityGraph/ClusterFileList.tsx` — expandable list of `ClusterFile[]` with individual `contribution` percentage; toggled by click on parent
+- [X] T029 [US3] Create `packages/cockpit-ui/src/components/AccountabilityGraph/index.tsx` — fetches `GET /prs/{pr_id}/clusters`; renders sorted `ClusterNode` list (descending `risk_share`); wires expand/collapse per cluster
+- [X] T030 [US3] Add `?tab=graph` routing to cockpit page — renders `AccountabilityGraph` when tab active; default tab is `panel`
+- [X] T031 [P] [US3] Write Vitest tests for `ClusterNode`, `ClusterFileList`, `AccountabilityGraph` in `packages/cockpit-ui/tests/components/AccountabilityGraph.test.tsx` — cover dominant highlight, sort order, expand/collapse, ≤50 clusters render performance
+
+**Checkpoint**: US3 independently testable — `npm test` passes AccountabilityGraph tests; Playwright US3 E2E scenario green
+
+---
+
+## Phase 6: User Story 4 — Entscheidung treffen und Ledger eintragen (Priority: P1)
+
+**Goal**: Maintainerin erfasst Go/No-Go/Guardrails direkt im Formular; Abweichung von App-Empfehlung erfordert Pflicht-Begründung; Versionskonflikt wird angezeigt.
+
+**Independent Test**: Formular absenden → Ledger-Eintrag mit Zeitstempel erscheint; Abweichung ohne Begründung → Formular blockiert; Versionskonflikt → Conflict-Banner.
+
+- [X] T032 [P] [US4] Create `packages/cockpit-ui/src/components/DecisionForm/DecisionSelector.tsx` — radio group for Go / Go with Guardrails / No-Go; highlights app recommendation
+- [X] T033 [P] [US4] Create `packages/cockpit-ui/src/components/DecisionForm/JustificationField.tsx` — textarea; required (non-empty) when human choice differs from `app_recommendation`; shows validation message if empty on submit
+- [X] T034 [US4] Create `packages/cockpit-ui/src/components/DecisionForm/index.tsx` — composes DecisionSelector + JustificationField + submit button; POSTs `DecisionWriteRequest` with current `version`; on 409 → renders `ErrorBanner` with `type="conflict"` and blocks further edits; on success → triggers ledger refresh
+- [X] T035 [US4] Wire `DecisionForm` into cockpit page below `DecisionPanel`; hidden once `human_decision` already recorded
+- [X] T036 [P] [US4] Write Vitest tests for `DecisionForm` in `packages/cockpit-ui/tests/components/DecisionForm.test.tsx` — cover justification required when overriding, submit blocked without justification, 409 conflict banner, success → form hidden
+
+**Checkpoint**: US4 independently testable — `npm test` passes DecisionForm tests; Playwright US4 E2E scenario green
+
+---
+
+## Phase 7: User Story 5 — Decision Ledger und Outcomes nachverfolgen (Priority: P2)
+
+**Goal**: Maintainerin sieht chronologische Timeline aus Empfehlung, Entscheidung, Evidenzreferenzen und 7/30-Tage-Outcomes; fehlende Outcomes explizit als ausstehend markiert.
+
+**Independent Test**: Ledger-Tab aufrufen → Timeline mit allen Feldern; `outcome_7d.status = "pending"` → Label "ausstehend", kein leeres Feld; 30d-Outcome eingetragen → im selben Eintrag sichtbar.
+
+- [X] T037 [P] [US5] Create `packages/cockpit-ui/src/components/LedgerTimeline/TimelineEntry.tsx` — renders app recommendation, human decision (or "pending"), evidence refs as links, outcome slots
+- [X] T038 [P] [US5] Create `packages/cockpit-ui/src/components/LedgerTimeline/OutcomeSlot.tsx` — renders `OutcomeRecord`; `status = "pending"` → explicit "ausstehend" badge; `status = "available"` → outcome value + `recorded_at`
+- [X] T039 [US5] Create `packages/cockpit-ui/src/components/LedgerTimeline/index.tsx` — fetches `GET /prs/{pr_id}/ledger`; renders `TimelineEntry` with 7d and 30d `OutcomeSlot`; refreshes after DecisionForm submit
+- [X] T040 [US5] Add `?tab=ledger` routing to cockpit page — renders `LedgerTimeline` when tab active
+- [X] T041 [P] [US5] Write Vitest tests for `LedgerTimeline`, `TimelineEntry`, `OutcomeSlot` in `packages/cockpit-ui/tests/components/LedgerTimeline.test.tsx` — cover pending outcome label, available outcome display, evidence refs, timeline order
+
+**Checkpoint**: US5 independently testable — `npm test` passes LedgerTimeline tests; Playwright US5 E2E scenario green
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Build pipeline, Python serve integration, tab navigation, error states, performance validation
+
+- [X] T042 Add tab navigation bar to cockpit page — Panel (default) / Safe Plan / Graph / Ledger; active tab from `?tab=` query param; keyboard-accessible
+- [X] T043 Implement global error boundary in `packages/cockpit-ui/src/app/cockpit/[owner]/[repo]/[pr_number]/page.tsx` — renders `ErrorBanner` on fetch errors, timeouts, 5xx; never blank page (FR-012)
+- [X] T044 [P] Implement `parsePrUrl(url: string): PrRef | null` in `packages/cockpit-ui/src/api/client.ts` — regex extracts owner/repo/pr_number from GitHub PR URL; invalid input returns null with user-friendly error (FR-016)
+- [X] T045 [P] Add landing page `packages/cockpit-ui/src/app/page.tsx` — GitHub PR-URL input field; on submit navigates to `/cockpit/[owner]/[repo]/[pr_number]` using `parsePrUrl`; invalid URL → inline error
+- [X] T046 Build Next.js static export and copy `out/` to `packages/drift-cockpit/src/drift_cockpit/static/` — document in `Makefile` as `make cockpit-build`
+- [X] T047 [P] Implement `packages/drift-cockpit/src/drift_cockpit/_serve.py` fully — FastAPI mounts `StaticFiles` from `importlib.resources`; proxies `/api/cockpit/*` to `COCKPIT_API_URL`; handles startup error when static dir empty with clear message
+- [X] T048 Complete `tests/decision_cockpit/test_cockpit_serve_cmd.py` — assert serve starts on `--port`, responds 200 on `/`, validates `--api-url` is passed to proxy, empty static dir produces informative error
+- [X] T049 [P] Write Vitest tests for `parsePrUrl` and landing page in `packages/cockpit-ui/tests/components/LandingPage.test.tsx` — valid URLs, invalid URLs, navigation trigger
+- [X] T050 [P] Write Playwright viewport tests for ≥1024px Desktop responsiveness in `packages/cockpit-ui/tests/e2e/viewport.spec.ts` — confirm all panels/tabs layout correctly at 1024px, 1280px, 1920px viewports (FR-014 coverage)
+- [X] T051 Run full Playwright E2E suite against mock backend; confirm all 5 US scenarios green; confirm SC-001 (<2 s panel load) with Playwright `page.metrics()`
+
+---
+
+## Dependencies
+
+```
+Phase 1 (Setup)
+  └── Phase 2 (Foundational: app shell, hooks, skeletons)
+        ├── Phase 3 (US1 Decision Panel) ← MVP — deliver first
+        ├── Phase 4 (US2 Safe Plans)     ← depends on Phase 3 tab shell
+        ├── Phase 5 (US3 Graph)          ← parallel with US2 after Phase 2
+        ├── Phase 6 (US4 Decision Form)  ← depends on Phase 3 (panel data)
+        └── Phase 7 (US5 Ledger)         ← depends on Phase 6 (decision write)
+              └── Phase 8 (Polish)       ← all US complete
+```
+
+## Parallel Execution per Story
+
+Each story phase is independently executable after Phase 2 completes:
+
+| Phase | Parallelisable tasks |
+|-------|---------------------|
+| 3 | T015, T016, T017, T020 in parallel |
+| 4 | T021, T022, T026 in parallel; T023→T024 sequential |
+| 5 | T027, T028, T031 in parallel; T029→T030 sequential |
+| 6 | T032, T033, T036 in parallel; T034→T035 sequential |
+| 7 | T037, T038, T041 in parallel; T039→T040 sequential |
+
+## MVP Scope
+
+Implement **Phase 1 + Phase 2 + Phase 3** first. This delivers US1 (Decision Panel), which is the single highest-value increment: a working cockpit URL showing status, confidence and risk drivers for any analysed PR.
+
+| Phase | Tasks | US |
+|-------|-------|----|
+| Phase 1 | T001–T006 | — |
+| Phase 2 | T007–T014 | — |
+| Phase 3 | T015–T020 | US1 ✅ |

--- a/specs/008-cli-load-reduction/checklists/requirements.md
+++ b/specs/008-cli-load-reduction/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: CLI Load Reduction
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-02  
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation run completed in one iteration; no blockers identified for planning handoff.

--- a/specs/008-cli-load-reduction/contracts/cli-help-navigation.contract.md
+++ b/specs/008-cli-load-reduction/contracts/cli-help-navigation.contract.md
@@ -1,0 +1,33 @@
+# Contract: CLI Help Navigation
+
+## Scope
+Oeffentliche CLI-Hilfeoberflaeche fuer `drift --help` im Rahmen der kognitiven Lastreduktion.
+
+## Public Contract
+
+### C-001 Start-Section
+- `drift --help` MUSS eine prominente Einstiegsektion enthalten.
+- Die Sektion MUSS mindestens einen klaren, ausfuehrbaren Startpfad zeigen.
+
+### C-002 Capability Grouping
+- Kommandos MUESSEN in nachvollziehbaren Aufgabenbereichen dargestellt werden.
+- Jeder Bereich MUSS eine kurze Zweckbeschreibung in nutzerorientierter Sprache enthalten.
+
+### C-003 Navigation Hand-off
+- Die Uebersicht MUSS einen expliziten Weg in tiefere Hilfe bieten (z. B. Bereich -> Detailhilfe).
+
+### C-004 Backward Compatibility
+- Bestehende CLI-Aufrufe bleiben funktional erhalten.
+- Neue Help-Struktur darf bestehende Automationen nicht brechen.
+
+### C-005 Stability for Testing
+- Reihenfolge und Benennung der Hauptsektionen MUESSEN stabil genug fuer Contract-Tests sein.
+
+## Verification Mapping
+- C-001, C-002, C-003: `tests/help_nav/test_help_nav_contract.py`
+- C-004: `tests/help_nav/test_help_nav_integration.py`
+- C-005: `tests/help_nav/test_help_nav_contract.py` (section-order assertions)
+
+## Non-goals
+- Keine Umbenennung/Entfernung bestehender Kommandos in dieser Phase.
+- Keine adaptive, telemetry-gesteuerte Personalisierung der Help-Reihenfolge.

--- a/specs/008-cli-load-reduction/data-model.md
+++ b/specs/008-cli-load-reduction/data-model.md
@@ -1,0 +1,56 @@
+# Data Model: CLI Load Reduction
+
+## Entity: CommandCapabilityArea
+- Purpose: Gruppiert thematisch zusammengehoerige CLI-Kommandos fuer zielorientierte Navigation.
+- Fields:
+  - id (string, stable, machine-friendly)
+  - title (string, user-facing)
+  - purpose (string, kurze Erkllaerung in Nicht-Entwickler-Sprache)
+  - command_refs (list[string], referenziert bestehende Commands)
+  - priority (int, steuert Reihenfolge in Help-Ausgabe)
+- Validation Rules:
+  - id muss eindeutig sein
+  - command_refs darf nicht leer sein
+  - priority muss >= 0 sein
+
+## Entity: EntryPath
+- Purpose: Definiert einen empfohlenen Einstieg fuer ein konkretes Nutzerziel.
+- Fields:
+  - id (string)
+  - goal_text (string)
+  - steps (list[EntryStep])
+  - audience (enum: new_user, returning_user)
+- Validation Rules:
+  - mind. 1 Schritt vorhanden
+  - jeder Schritt referenziert gueltigen Command oder Subcommand
+
+## Entity: EntryStep
+- Purpose: Einzelner Schritt in einem Einstiegspfad.
+- Fields:
+  - order (int)
+  - action_text (string)
+  - command_example (string)
+- Validation Rules:
+  - Reihenfolge innerhalb eines EntryPath eindeutig
+  - command_example darf nicht leer sein
+
+## Entity: HelpSection
+- Purpose: Renderbare Sektion in CLI-Help (Uebersicht, Kategorien, Deep-Dive-Hinweise).
+- Fields:
+  - key (string)
+  - heading (string)
+  - body_lines (list[string])
+  - next_hint (string | null)
+- Validation Rules:
+  - heading nicht leer
+  - body_lines nicht leer
+
+## Relationships
+- Ein CommandCapabilityArea enthaelt viele Command-Referenzen.
+- Ein EntryPath enthaelt viele EntrySteps.
+- HelpSection kann EntryPath- und CommandCapabilityArea-Informationen verdichten.
+
+## State Transitions
+- Draft Design -> Reviewed Design: Validierungsregeln und Mapping vollstaendig.
+- Reviewed Design -> Implemented Rendering: Help-Ausgabe wird aus Modellen generiert.
+- Implemented Rendering -> Contract Verified: CLI-Contract-Tests bestehen fuer Struktur und Kompatibilitaet.

--- a/specs/008-cli-load-reduction/plan.md
+++ b/specs/008-cli-load-reduction/plan.md
@@ -1,0 +1,86 @@
+# Implementation Plan: CLI Load Reduction
+
+**Branch**: `010-before-specify-hook` | **Date**: 2026-05-02 | **Spec**: [specs/008-cli-load-reduction/spec.md](specs/008-cli-load-reduction/spec.md)
+**Input**: Feature specification from `specs/008-cli-load-reduction/spec.md`
+
+## Summary
+
+Das Feature reduziert die kognitive Last in `drift --help`, indem die flache Liste der Top-Level-Commands in nutzerorientierte Aufgabenbereiche und klare Einstiegspfade ueberfuehrt wird. Bestehende Aufrufe bleiben kompatibel; neu ist primär die Orientierungsschicht (strukturierte Help-Ausgabe plus Fuehrung von Uebersicht zu Details).
+
+## Technical Context
+
+**Language/Version**: Python 3.11+  
+**Primary Dependencies**: Click, Rich, Pydantic (fuer strukturierte Help-Modelle)  
+**Storage**: N/A (rein prozessuale CLI-Ausgabe)  
+**Testing**: pytest (unit, integration, CLI-contract tests)  
+**Target Platform**: Cross-platform terminal usage (Windows/Linux/macOS)
+**Project Type**: CLI + library slice in `packages/drift-cli/src/drift_cli/`  
+**Performance Goals**: `drift --help` bleibt gefuehlt instantan; keine merkliche Zusatzlatenz durch Strukturierung  
+**Constraints**: Keine Breaking Changes fuer bestehende Befehlsaufrufe; JSON/Rich-Ausgabe muss konsistent bleiben  
+**Scale/Scope**: Reorganisation fuer aktuell 48 Top-Level-Kommandos mit Fokus auf Einstieg und Navigation
+
+## Constitution Check
+
+*GATE: Passed before Phase 0 research; re-checked after Phase 1 design.*
+
+### Pre-Research Gate
+
+- [x] **I. Library-First**: Help-Navigation wird als eigene Slice-Library unter `packages/drift-cli/src/drift_cli/help_nav/` modelliert; Command-Module enthalten nur Wiring.
+- [x] **II. Test-First**: Umsetzung wird mit zuerst scheiternden CLI/Contract-Tests geplant; keine Implementierung in dieser Plan-Phase.
+- [x] **III. Functional Programming**: Mapping von Commands zu Capability-Areas erfolgt ueber pure Funktionen und immutable Modelle.
+- [x] **IV. CLI Interface & Observability**: Ausgabe bleibt ueber Click integriert und muss Rich + JSON-Pfade abdecken; zusaetzlich wird ein expliziter Slice-Subcommandpfad fuer Help-Navigation bereitgestellt und in die Root-Help-Uebersicht eingebunden.
+- [x] **V. Simplicity & YAGNI**: Kein neues Persistenzsystem, keine dynamische Plugin-Engine; nur notwendige Struktur-/Navigationslogik.
+- [x] **VI. Vertical Slices**: Eigenstaendige Slice geplant, keine Querschnittslogik in Fremdmodulen.
+
+### Post-Design Re-Check
+
+- [x] Design-Artefakte (`research.md`, `data-model.md`, `contracts/`, `quickstart.md`) halten die Slice-Grenzen ein.
+- [x] Schnittstellenvertrag zeigt additive Navigation statt Verhaltensbruch bei Legacy-Aufrufen.
+- [x] Testplan priorisiert Nutzerfluss (Entry Path) und Kompatibilitaet in getrennten, unabhaengig testbaren Szenarien.
+- [x] CLI-Vertrag erfasst explizit Root-Help-Integration plus dedizierten Help-Nav-Subcommandpfad zur Erfuellung von Principle IV.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-cli-load-reduction/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── cli-help-navigation.contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+packages/drift-cli/src/drift_cli/help_nav/
+├── __init__.py
+├── _models.py
+├── _grouping.py
+├── _render.py
+└── _compat.py
+
+packages/drift-cli/src/drift_cli/cli.py
+
+tests/help_nav/
+├── test_help_nav_unit.py
+├── test_help_nav_contract.py
+└── test_help_nav_integration.py
+```
+
+**Structure Decision**: Option 1 (Vertical Slice). Die neue Orientierungsschicht wurde als Slice `packages/drift-cli/src/drift_cli/help_nav/` umgesetzt und in `packages/drift-cli/src/drift_cli/cli.py` verdrahtet. Keine Multi-Layer-Ausweitung noetig.
+
+## Complexity Tracking
+
+Keine Constitution-Verletzung identifiziert; keine Ausnahmen erforderlich.
+
+## Implementation Snapshot
+
+- Implementiert: `packages/drift-cli/src/drift_cli/help_nav/` (`_models.py`, `_grouping.py`, `_render.py`, `_compat.py`, `__init__.py`)
+- CLI-Wiring: `packages/drift-cli/src/drift_cli/cli.py` nutzt jetzt modellbasierte Help-Sektionen plus `help-nav` Subcommand
+- Tests: `tests/help_nav/test_help_nav_unit.py`, `tests/help_nav/test_help_nav_contract.py`, `tests/help_nav/test_help_nav_integration.py` sind ergänzt
+- Regression: bestehende Runtime-CLI-Tests bleiben gruen (`tests/test_cli_runtime.py`)

--- a/specs/008-cli-load-reduction/quickstart.md
+++ b/specs/008-cli-load-reduction/quickstart.md
@@ -1,0 +1,68 @@
+# Quickstart: CLI Load Reduction
+
+## Purpose
+Diese Anleitung validiert die implementierte Help-Navigation im `packages/drift-cli`-Pfad.
+
+## 1. Projekt vorbereiten
+```powershell
+pip install -e '.[dev]'
+```
+
+## 2. Feature-Tests ausfuehren (T035)
+```powershell
+.venv\Scripts\python.exe -m pytest tests/help_nav -q --tb=short
+.venv\Scripts\python.exe -m pytest tests/test_cli_runtime.py -q --tb=short
+```
+Ergebnis in dieser Implementierung:
+- `tests/help_nav`: 8 passed
+- `tests/test_cli_runtime.py`: 18 passed
+
+## 3. CLI-Vertrag pruefen (Root Help + Subcommand)
+```powershell
+.venv\Scripts\python.exe -m drift --help
+.venv\Scripts\python.exe -m drift help-nav
+.venv\Scripts\python.exe -m drift help-nav --area investigation
+```
+Erwartung:
+- Sichtbarer `Start Here (80% Path)`-Block als erste Sektion
+- Stabile Sektionen: `Investigation`, `Agent & MCP`, `CI & Automation`, `Configuration`, `Measurement`
+- Additiver Navigationspfad ueber `help-nav`
+
+## 4. Legacy-Kompatibilitaet stichprobenartig pruefen
+```powershell
+.venv\Scripts\python.exe -m drift status --help
+.venv\Scripts\python.exe -m drift analyze --help
+.venv\Scripts\python.exe -m drift scan --help
+.venv\Scripts\python.exe -m drift diff --help
+```
+Erwartung:
+- Bestehende Kommandos bleiben aufrufbar
+- Keine Umbenennung/Entfernung durch die Orientierungsschicht
+
+## 5. SC-Messprotokolle
+
+### SC-001 Findability (T040)
+- Probe: 10 Erstnutzer-Szenarien, jeweils Start bei `drift --help`
+- Erfolgsregel: pass, wenn >= 85% in <= 60s den ersten Analysebefehl identifizieren
+- Messartefakt: Zeit je Durchlauf + Zielbefehl
+
+### SC-002 Time-to-first-analysis (T038, T039)
+- Baseline-Protokoll (vorher): Zeit von erstem `drift --help` bis erstem erfolgreichen `drift analyze --repo .`
+- Post-Change-Protokoll (nachher): identische Messmethode
+- Erfolgsregel: pass bei mindestens 40% Reduktion gegen Baseline
+
+### SC-004 Clarity-Rating (T041)
+- Probe: Nutzerfeedback auf 5er-Skala (`sehr unklar` bis `sehr klar`)
+- Erfolgsregel: pass, wenn >= 80% `klar` oder `sehr klar` bewerten
+
+## 6. Repo-weite Pflichtchecks vor Abschluss
+```powershell
+pre-commit run --all-files
+make check
+make gate-check COMMIT_TYPE=feat
+```
+
+## Done-Kriterien
+- SC-001 bis SC-004 sind mit testbaren Protokollen abgedeckt
+- Keine Breaking Changes fuer bestehende Befehlspfade
+- Help-Navigation ist additiv, stabil und aufgabenorientiert

--- a/specs/008-cli-load-reduction/research.md
+++ b/specs/008-cli-load-reduction/research.md
@@ -1,0 +1,26 @@
+# Research: CLI Load Reduction
+
+## Decision 1: Help-Struktur nach Capability-Areas statt flacher Top-Level-Liste
+- Decision: Die Help-Ausgabe wird in Aufgabenbereiche gegliedert (z. B. Einstieg, Analyse, Qualitaet, Reports, Wartung).
+- Rationale: Nutzer suchen nach Intention, nicht nach internem Command-Namen; strukturierte Gruppen reduzieren Suchaufwand und kognitive Last.
+- Alternatives considered: Rein alphabetische Liste mit kuerzeren Beschreibungen; verworfen, weil weiterhin keine Zielnavigation entsteht.
+
+## Decision 2: Gefuehrter Entry-Path als erste Sektion in `drift --help`
+- Decision: Oberste Help-Sektion zeigt einen klaren "Start hier"-Pfad mit wenigen empfohlenen Erstschritten.
+- Rationale: Erstnutzer brauchen in den ersten Sekunden handlungsfaehige Orientierung; ein fokussierter Einstieg verbessert Aktivierungsrate.
+- Alternatives considered: Nur Verweis auf externe Doku; verworfen, weil der CLI-Einstieg ohne Kontextwechsel funktionieren muss.
+
+## Decision 3: Additive Migration ohne Breaking Changes
+- Decision: Bestehende Command-Aufrufe bleiben unveraendert; nur Darstellung und Navigationspfade werden neu strukturiert.
+- Rationale: Akzeptanz steigt, wenn etablierte Skripte stabil bleiben und dennoch bessere Orientierung verfuegbar ist.
+- Alternatives considered: Renaming/Entfernen alter Top-Level-Kommandos; verworfen wegen hohem Migrationsrisiko.
+
+## Decision 4: Contract-Tests fuer Help-Navigation und Legacy-Kompatibilitaet
+- Decision: Neben Unit-Tests werden CLI-Contract-Tests fuer sichtbare Help-Struktur und Legacy-Aufrufstabilitaet definiert.
+- Rationale: Das Feature ist UX-getrieben; daher muss die oeffentliche CLI-Oberflaeche als Vertrag abgesichert sein.
+- Alternatives considered: Nur Snapshot-Tests einzelner Help-Strings; verworfen, da zu fragil und semantisch zu schwach.
+
+## Decision 5: Keine neue Persistenz oder Telemetrie als Teil von v1
+- Decision: Scope bleibt auf statischer, zur Laufzeit berechneter Help-Navigation ohne neue Datenspeicher.
+- Rationale: Erfuellt YAGNI, minimiert Komplexitaet und liefert schnellen, risikoarmen Nutzen.
+- Alternatives considered: Nutzungsbasierte adaptive Reihenfolge; vertagt auf spaeteres Inkrement mit gesonderter Evidenz.

--- a/specs/008-cli-load-reduction/spec.md
+++ b/specs/008-cli-load-reduction/spec.md
@@ -1,0 +1,91 @@
+# Feature Specification: CLI Load Reduction
+
+**Feature Branch**: `010-before-specify-hook`  
+**Created**: 2026-05-02  
+**Status**: Draft  
+**Input**: User description: "Vorhaben: CLI Cognitive Load Reduction. Das drift CLI exponiert aktuell 48 flache Top-Level-Commands. Fuer neue Nutzer ist drift --help damit unlesbar; der Einstieg scheitert an Orientierungslosigkeit."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Schneller Einstieg ueber klares Help (Priority: P1)
+
+Neue Nutzer wollen in den ersten Minuten verstehen, womit sie anfangen sollen, ohne durch eine lange, unstrukturierte Befehlsliste zu scrollen.
+
+**Why this priority**: Der erste Kontakt mit `drift --help` entscheidet, ob Nutzer das Tool weiterverwenden oder abbrechen.
+
+**Independent Test**: Kann unabhaengig getestet werden, indem Erstnutzer nur mit `drift --help` und den Einstiegsbefehlen eine erste Analyse erfolgreich starten.
+
+**Acceptance Scenarios**:
+
+1. **Given** ein neuer Nutzer ohne Drift-Vorkenntnisse, **When** der Nutzer `drift --help` aufruft, **Then** erkennt der Nutzer klar die empfohlenen Einstiegswege und ihren Zweck.
+2. **Given** ein neuer Nutzer mit konkretem Ziel, **When** der Nutzer den Help-Text liest, **Then** findet der Nutzer den passenden Befehlspfad in unter 60 Sekunden.
+
+---
+
+### User Story 2 - Zielorientierte Navigation statt Befehlssuche (Priority: P2)
+
+Fortgeschrittene Nutzer wollen von einem Ziel (z. B. Analyse, Reparatur, Reporting) aus navigieren und nicht jede Top-Level-Option einzeln pruefen.
+
+**Why this priority**: Die Auffindbarkeit steigt, wenn das CLI nach Nutzungsintention statt alphabetischer Flut strukturiert ist.
+
+**Independent Test**: Kann unabhaengig getestet werden, indem Nutzer typische Aufgaben ohne externe Dokumentation durch die Help-Navigation abschliessen.
+
+**Acceptance Scenarios**:
+
+1. **Given** ein Nutzer mit dem Ziel "Codebasis analysieren", **When** der Nutzer die Help-Ausgabe nutzt, **Then** gelangt der Nutzer direkt zu den relevanten Analyse-Kommandos ohne irrelevante Umwege.
+2. **Given** ein Nutzer mit dem Ziel "Ergebnisse exportieren", **When** der Nutzer die Help-Ausgabe nutzt, **Then** findet der Nutzer die Export-Optionen in einer logisch passenden Kategorie.
+
+---
+
+### User Story 3 - Stabiler Betrieb fuer bestehende Workflows (Priority: P3)
+
+Bestehende Nutzer wollen ihre etablierten Skripte und Kommandonutzung weiterverwenden koennen, waehrend neue Orientierungshilfen eingefuehrt werden.
+
+**Why this priority**: Adoption scheitert, wenn die UX verbessert wird, aber bestehende Nutzungen regressieren.
+
+**Independent Test**: Kann unabhaengig getestet werden, indem bekannte Kommandopfad-Aufrufe weiterhin erfolgreich ausfuehrbar sind und die neuen Orientierungshilfen parallel funktionieren.
+
+**Acceptance Scenarios**:
+
+1. **Given** ein bestehender Nutzer mit gespeichertem CLI-Workflow, **When** der Nutzer denselben Befehl aufruft, **Then** bleibt das erwartete Verhalten unveraendert.
+2. **Given** ein bestehender Nutzer, **When** der Nutzer die neue Help-Ausgabe aufruft, **Then** erhaelt der Nutzer zusaetzliche Orientierung ohne Verlust bestehender Funktionalitaet.
+
+### Edge Cases
+
+- Was passiert, wenn Nutzer direkt nach einem konkreten Legacy-Befehl suchen, der nicht in den bevorzugten Einstiegswegen liegt?
+- Wie wird verhindert, dass ein Nutzer durch mehrere gleich plausible Einstiegspfade wieder unklar orientiert ist?
+- Wie verhaelt sich die Orientierung bei sehr schmalen Terminalbreiten, wenn weniger Inhalt gleichzeitig sichtbar ist?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Das System MUSS die CLI-Help-Ausgabe so strukturieren, dass Erstnutzer mindestens einen klaren "Start hier"-Pfad sehen.
+- **FR-002**: Das System MUSS Befehle in fuer Nutzer verstaendliche Aufgabenbereiche gruppieren, statt nur als flache Gesamtliste zu praesentieren.
+- **FR-003**: Das System MUSS pro Aufgabenbereich den Zweck in kurzer, nicht-technischer Sprache erklaeren.
+- **FR-004**: Das System MUSS einen direkten Weg anbieten, von einer Aufgabenbeschreibung zum passenden Befehl zu gelangen.
+- **FR-005**: Das System MUSS bestehende, bereits verwendete Befehlspfade weiterhin unterstuetzen.
+- **FR-006**: Das System MUSS bei Help-Ausgaben die visuelle Ueberlast reduzieren, indem im initial sichtbaren Bereich maximal 3 Primaersektionen erscheinen (Start hier, Capability-Uebersicht, Naechster Schritt) und jede Primaersektion hoechstens 7 Zeilen umfasst.
+- **FR-007**: Das System MUSS fuer Nutzer erkennbar machen, wie sie von einer globalen Uebersicht in detailliertere Hilfe wechseln.
+
+### Key Entities *(include if feature involves data)*
+
+- **Command Capability Area**: Ein nutzerorientierter Aufgabenbereich (z. B. analysieren, reparieren, berichten), der mehrere CLI-Befehle zusammenfasst.
+- **Entry Path**: Ein empfohlener Startpfad fuer typische Nutzerziele mit kurzer Handlungsanleitung.
+- **Help Section**: Ein klar abgegrenzter Teil der Hilfeausgabe mit Zweckbeschreibung, zugeordneten Befehlen und Navigationshinweisen.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Mindestens 85% neuer Nutzer identifizieren innerhalb von 60 Sekunden den passenden Einstiegsbefehl fuer eine vorgegebene Standardaufgabe.
+- **SC-002**: Die durchschnittliche Zeit vom ersten `drift --help` bis zum erfolgreichen Start einer ersten Analyse sinkt um mindestens 40% gegenueber dem aktuellen Zustand.
+- **SC-003**: Mindestens 90% der in internen Regressionstests abgedeckten bestehenden CLI-Aufrufe bleiben unveraendert erfolgreich.
+- **SC-004**: Mindestens 80% der befragten Nutzer bewerten die Help-Navigation als "klar" oder "sehr klar".
+
+## Assumptions
+
+- Die primaere Schmerzstelle liegt in Orientierung und Informationsdichte, nicht in fehlenden Kernfunktionen.
+- Nutzer kommen mit unterschiedlichen Erfahrungsniveaus; der Einstieg muss ohne Vorwissen funktionieren.
+- Verbesserte Orientierung soll additive Fuehrung bieten und bestehende Nutzungspfade nicht entfernen.
+- Der Schwerpunkt liegt auf CLI-internen Orientierungshilfen; externe Dokumentation bleibt ergaenzend, aber nicht Voraussetzung fuer den Einstieg.

--- a/specs/008-cli-load-reduction/tasks.md
+++ b/specs/008-cli-load-reduction/tasks.md
@@ -1,0 +1,198 @@
+# Tasks: CLI Load Reduction
+
+**Input**: Design documents from [specs/008-cli-load-reduction](specs/008-cli-load-reduction)
+**Prerequisites**: [specs/008-cli-load-reduction/plan.md](specs/008-cli-load-reduction/plan.md), [specs/008-cli-load-reduction/spec.md](specs/008-cli-load-reduction/spec.md), [specs/008-cli-load-reduction/research.md](specs/008-cli-load-reduction/research.md), [specs/008-cli-load-reduction/data-model.md](specs/008-cli-load-reduction/data-model.md), [specs/008-cli-load-reduction/contracts/cli-help-navigation.contract.md](specs/008-cli-load-reduction/contracts/cli-help-navigation.contract.md), [specs/008-cli-load-reduction/quickstart.md](specs/008-cli-load-reduction/quickstart.md)
+
+**Tests**: Enthalten, da der Plan explizit Test-First sowie Contract- und Integrationstests fordert.
+
+**Organization**: Tasks sind nach User Story organisiert, damit jede Story unabhängig implementierbar und testbar bleibt.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Arbeitsrahmen und Zielstruktur fuer die neue Help-Navigation vorbereiten
+
+- [x] T001 Create vertical slice package scaffold in packages/drift-cli/src/drift_cli/help_nav/__init__.py
+- [x] T002 [P] Create feature test package scaffold in tests/help_nav/__init__.py
+- [x] T003 [P] Add help-nav test map entry in tests/TESTMAP.toml
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Kerninfrastruktur, die vor allen User Stories fertig sein muss
+
+**Critical**: Keine Story-Implementierung vor Abschluss dieser Phase
+
+- [x] T004 Define immutable data models CommandCapabilityArea, EntryPath, EntryStep, HelpSection in packages/drift-cli/src/drift_cli/help_nav/_models.py
+- [x] T005 [P] Implement command-to-capability grouping primitives in packages/drift-cli/src/drift_cli/help_nav/_grouping.py
+- [x] T006 [P] Implement help section rendering primitives for Rich and plain help content in packages/drift-cli/src/drift_cli/help_nav/_render.py
+- [x] T007 [P] Implement compatibility guard helpers for legacy command paths in packages/drift-cli/src/drift_cli/help_nav/_compat.py
+- [x] T008 Export public slice API only in packages/drift-cli/src/drift_cli/help_nav/__init__.py
+- [x] T009 Add failing baseline unit tests for model and grouping invariants in tests/help_nav/test_help_nav_unit.py
+- [x] T010 [P] Add failing baseline contract tests for help section presence/order in tests/help_nav/test_help_nav_contract.py
+- [x] T011 [P] Add failing baseline integration tests for legacy command compatibility in tests/help_nav/test_help_nav_integration.py
+- [x] T012 Wire help navigation entrypoint in root CLI registration in packages/drift-cli/src/drift_cli/cli.py
+- [x] T036 Register explicit help-nav subcommand surface in packages/drift-cli/src/drift_cli/cli.py
+- [x] T037 [P] Add contract test for help-nav subcommand exposure in tests/help_nav/test_help_nav_contract.py
+
+**Checkpoint**: Foundation complete; all baseline tests exist and fail before story implementations
+
+---
+
+## Phase 3: User Story 1 - Schneller Einstieg ueber klares Help (Priority: P1) MVP
+
+**Goal**: Ein klarer Start-hier-Pfad macht den Erstkontakt mit drift --help handlungsfaehig
+
+**Independent Test**: Ein Erstnutzer kann nur mit drift --help den ersten Analyseweg finden und starten
+
+### Tests for User Story 1
+
+- [x] T013 [P] [US1] Add contract test for prominent start section visibility in tests/help_nav/test_help_nav_contract.py
+- [x] T014 [P] [US1] Add contract test for minimal executable entry path steps in tests/help_nav/test_help_nav_contract.py
+- [x] T015 [US1] Add integration test for first-run navigation flow from drift --help in tests/help_nav/test_help_nav_integration.py
+
+### Implementation for User Story 1
+
+- [x] T016 [US1] Implement Start-hier entry path builder for new users in packages/drift-cli/src/drift_cli/help_nav/_grouping.py
+- [x] T017 [US1] Render Start-hier section as first help block in packages/drift-cli/src/drift_cli/help_nav/_render.py
+- [x] T018 [US1] Integrate Start-hier section into CLI help composition in packages/drift-cli/src/drift_cli/cli.py
+- [x] T019 [US1] Ensure user-facing wording for start guidance is concise and non-technical in packages/drift-cli/src/drift_cli/help_nav/_render.py
+
+**Checkpoint**: User Story 1 ist eigenstaendig funktionsfaehig und testbar
+
+---
+
+## Phase 4: User Story 2 - Zielorientierte Navigation statt Befehlssuche (Priority: P2)
+
+**Goal**: Nutzer navigieren ueber Aufgabenbereiche direkt zum passenden Command
+
+**Independent Test**: Ein Nutzer findet Analyse- und Exportpfade ohne externe Doku nur ueber die Help-Struktur
+
+### Tests for User Story 2
+
+- [x] T020 [P] [US2] Add contract test for capability-area grouping presence in tests/help_nav/test_help_nav_contract.py
+- [x] T021 [P] [US2] Add contract test for area purpose descriptions readability in tests/help_nav/test_help_nav_contract.py
+- [x] T022 [US2] Add integration test for goal-to-command navigation hand-off in tests/help_nav/test_help_nav_integration.py
+- [x] T042 [P] [US2] Add integration tests for narrow terminal widths (80/60/40 columns) in tests/help_nav/test_help_nav_integration.py
+- [x] T044 [US2] Add contract assertions for initial-view section count and line caps in tests/help_nav/test_help_nav_contract.py
+
+### Implementation for User Story 2
+
+- [x] T023 [US2] Implement capability-area catalog and ordering rules in packages/drift-cli/src/drift_cli/help_nav/_grouping.py
+- [x] T024 [US2] Implement navigation hand-off hints from overview to detail help in packages/drift-cli/src/drift_cli/help_nav/_render.py
+- [x] T025 [US2] Add command reference mapping for analysis/reporting flows in packages/drift-cli/src/drift_cli/help_nav/_grouping.py
+- [x] T026 [US2] Integrate grouped capability output into global help composition in packages/drift-cli/src/drift_cli/cli.py
+- [x] T043 [US2] Implement narrow-width fallback formatting rules in packages/drift-cli/src/drift_cli/help_nav/_render.py
+
+**Checkpoint**: User Story 2 ist eigenstaendig funktionsfaehig und testbar
+
+---
+
+## Phase 5: User Story 3 - Stabiler Betrieb fuer bestehende Workflows (Priority: P3)
+
+**Goal**: Bestehende CLI-Aufrufe bleiben stabil, waehrend die neue Orientierungsschicht aktiv ist
+
+**Independent Test**: Legacy-Aufrufe funktionieren unveraendert, neue Help-Navigation bleibt sichtbar
+
+### Tests for User Story 3
+
+- [x] T027 [P] [US3] Add integration test for unchanged legacy command invocation behavior in tests/help_nav/test_help_nav_integration.py
+- [x] T028 [P] [US3] Add integration test for additive help changes without command removal in tests/help_nav/test_help_nav_integration.py
+- [x] T029 [US3] Add contract test for stable top-level section naming/order for regression safety in tests/help_nav/test_help_nav_contract.py
+
+### Implementation for User Story 3
+
+- [x] T030 [US3] Implement legacy command compatibility checks in packages/drift-cli/src/drift_cli/help_nav/_compat.py
+- [x] T031 [US3] Route compatibility checks into help composition workflow in packages/drift-cli/src/drift_cli/cli.py
+- [x] T032 [US3] Ensure additive behavior guardrails in render pipeline in packages/drift-cli/src/drift_cli/help_nav/_render.py
+
+**Checkpoint**: User Story 3 ist eigenstaendig funktionsfaehig und testbar
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Story-uebergreifende Konsolidierung und Validierung
+
+- [x] T033 [P] Update quickstart verification commands and expectations in specs/008-cli-load-reduction/quickstart.md
+- [x] T034 Document final help navigation behavior and examples in specs/008-cli-load-reduction/plan.md
+- [x] T035 Run feature-focused test suite and capture summary in specs/008-cli-load-reduction/quickstart.md
+- [x] T038 Capture baseline time-to-first-analysis metric protocol in specs/008-cli-load-reduction/quickstart.md
+- [ ] T039 Capture post-change time-to-first-analysis and compute delta vs baseline (SC-002) in specs/008-cli-load-reduction/quickstart.md
+- [ ] T040 Define and run first-use findability protocol for SC-001 in specs/008-cli-load-reduction/quickstart.md
+- [ ] T041 Define and run clarity rating protocol for SC-004 in specs/008-cli-load-reduction/quickstart.md
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Setup (Phase 1): Keine Abhaengigkeiten
+- Foundational (Phase 2): Abhaengig von Phase 1; blockiert alle User Stories
+- User Stories (Phase 3 bis Phase 5): Abhaengig von Phase 2
+- Polish (Phase 6): Abhaengig von abgeschlossenen Stories
+
+### User Story Dependencies
+
+- US1 (P1): Startet direkt nach Phase 2
+- US2 (P2): Startet nach Phase 2; keine harte Abhaengigkeit zu US1
+- US3 (P3): Startet nach Phase 2; verifiziert additive Kompatibilitaet zu US1 und US2
+
+### Within Each User Story
+
+- Tests zuerst schreiben und fehlschlagen sehen
+- Implementierung danach in Slice-Modulen
+- CLI-Wiring erst nach Kernlogik
+- Story mit eigenen Tests abschliessen, bevor naechste Story priorisiert wird
+
+### Parallel Opportunities
+
+- T002 und T003 parallel
+- T005, T006, T007 parallel
+- T010 und T011 parallel
+- In US1: T013 und T014 parallel
+- In US2: T020, T021 und T042 parallel
+- In US3: T027 und T028 parallel
+
+---
+
+## Parallel Example: User Story 2
+
+- Task: T020 Add contract test for capability-area grouping presence in tests/help_nav/test_help_nav_contract.py
+- Task: T021 Add contract test for area purpose descriptions readability in tests/help_nav/test_help_nav_contract.py
+- Task: T023 Implement capability-area catalog and ordering rules in packages/drift-cli/src/drift_cli/help_nav/_grouping.py
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1)
+
+1. Phase 1 abschliessen
+2. Phase 2 abschliessen
+3. US1 vollstaendig umsetzen
+4. US1 isoliert validieren
+5. Danach erst US2/US3
+
+### Incremental Delivery
+
+1. Foundation bereitstellen
+2. US1 liefern und validieren
+3. US2 liefern und validieren
+4. US3 liefern und validieren
+5. Polish ausfuehren
+
+### Parallel Team Strategy
+
+1. Gemeinsamer Abschluss von Setup und Foundational
+2. Danach parallele Story-Arbeit moeglich
+3. Story-spezifische Tests halten Inkremente unabhaengig verifizierbar
+
+---
+
+## Notes
+
+- Alle Tasks folgen dem Pflichtformat mit Checkbox, ID, optionalem P-Marker, optionalem Story-Label und Datei-Pfad
+- Story-Labels sind nur in Story-Phasen gesetzt
+- Tasks sind so formuliert, dass sie ohne Zusatzkontext direkt bearbeitet werden koennen

--- a/specs/009-complete-vsa-migration/checklists/requirements.md
+++ b/specs/009-complete-vsa-migration/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Complete VSA Migration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validated in one pass: no unresolved clarifications and no template placeholders remain.

--- a/specs/009-complete-vsa-migration/contracts/migration-boundary.contract.md
+++ b/specs/009-complete-vsa-migration/contracts/migration-boundary.contract.md
@@ -1,0 +1,35 @@
+# Contract: Migration Boundary and Completion
+
+## Contract Scope
+Dieser Vertrag definiert die nachpruefbaren Bedingungen fuer den Abschluss der Monorepo-Migration von Legacy-Strukturen zu Capability-Paketen.
+
+## External Interface Expectations
+
+### 1. Contributor-Navigation Contract
+- Given ein Beitragender sucht eine aktive Drift-Implementierung,
+- When der Codebaum durchsucht wird,
+- Then liegen kanonische Implementierungen in `packages/drift-*` und nicht als aktive Quelle unter `src/drift`.
+
+### 2. Internal Import Contract
+- Given ein interner Drift-Import fuer produktive Logik,
+- When statische Analyse/Tests laufen,
+- Then zeigt der Import auf einen kanonischen Capability-Paketpfad.
+
+### 3. Quality Gate Contract
+- Given der Migrationsabschluss soll festgestellt werden,
+- When der definierte Gate-Lauf ausgefuehrt wird,
+- Then sind Lint, Typecheck, Tests und projektspezifische Gate-Pruefungen erfolgreich.
+
+### 4. Documentation Contract
+- Given die Migration ist als abgeschlossen markiert,
+- When Contributor Architektur- und Developer-Dokumentation lesen,
+- Then sind Paketgrenzen, kanonische Pfade und Abschlusskriterien eindeutig dokumentiert.
+
+## Non-Goals
+- Keine Erweiterung fachlicher Drift-Features.
+- Keine Umgestaltung bestehender Produktlogik ohne direkten Migrationsbezug.
+
+## Verification Evidence
+- Such-/Audit-Ergebnisse fuer verbliebene Legacy-Pfade.
+- Gate-Lauf-Resultate fuer Qualitaets- und Compliance-Pruefungen.
+- Dokumentations-Diffs mit aktualisierten Architekturgrenzen.

--- a/specs/009-complete-vsa-migration/data-model.md
+++ b/specs/009-complete-vsa-migration/data-model.md
@@ -1,0 +1,49 @@
+# Data Model: Complete VSA Migration
+
+## Entity: CapabilityPackage
+- Purpose: Kapselt eine vertikale Drift-Funktionalitaet als kanonische Implementierungseinheit.
+- Fields:
+  - `name` (str): Paketname, z. B. `drift-cli`, `drift-engine`.
+  - `canonical_root` (str): Quellwurzel des Pakets (z. B. `packages/drift-cli/src/drift_cli`).
+  - `owned_capabilities` (list[str]): Fachliche Verantwortlichkeiten des Pakets.
+  - `public_api_surfaces` (list[str]): Exportierte API-Pfade/Module.
+
+## Entity: LegacyPath
+- Purpose: Repräsentiert historische Pfade unter `src/drift`, die waehrend Migration entfernt, ersetzt oder neutralisiert werden.
+- Fields:
+  - `path` (str): Konkreter Legacy-Pfad.
+  - `legacy_role` (enum): `implementation`, `compat_stub`, `doc_only`.
+  - `status` (enum): `present`, `removed`, `redirected`.
+  - `replacement_target` (str | null): Kanonischer Capability-Pfad bei Umleitung.
+
+## Entity: ImportMapping
+- Purpose: Beschreibt die Normalisierung eines internen Imports auf den kanonischen Paketpfad.
+- Fields:
+  - `source_import` (str): Vorheriger Importpfad.
+  - `target_import` (str): Neuer kanonischer Importpfad.
+  - `kind` (enum): `runtime`, `typecheck`, `test`.
+  - `validated_by` (list[str]): Verifikationsschritte/Gates, die den Mapping-Status absichern.
+
+## Entity: MigrationCompletionStatus
+- Purpose: Prüft den Repository-Zielzustand fuer den Monorepo-Migrationsabschluss.
+- Fields:
+  - `active_legacy_impl_count` (int): Anzahl verbleibender aktiver Implementierungen unter `src/drift`.
+  - `import_drift_violations` (int): Anzahl interner Importverstoesse gegen kanonische Paketpfade.
+  - `quality_gate_result` (enum): `pass`, `fail`.
+  - `documentation_synced` (bool): Paketgrenzen und Abschlussstatus sind in Doku aktualisiert.
+  - `completed_at` (date | null): Zeitpunkt des Abschlusses.
+
+## Relationships
+- `CapabilityPackage` owns many `ImportMapping` records.
+- `LegacyPath` may map to one `CapabilityPackage` via `replacement_target`.
+- `MigrationCompletionStatus` aggregates all `LegacyPath` and `ImportMapping` outcomes.
+
+## Validation Rules
+- `active_legacy_impl_count` MUST be `0` for completion.
+- `import_drift_violations` MUST be `0` for completion.
+- `quality_gate_result` MUST be `pass` for completion.
+- `documentation_synced` MUST be `true` before completion is declared.
+
+## State Transitions
+- `MigrationCompletionStatus`: `in_progress` -> `verification` -> `completed`
+- Transition to `completed` is allowed only if all validation rules pass.

--- a/specs/009-complete-vsa-migration/plan.md
+++ b/specs/009-complete-vsa-migration/plan.md
@@ -1,0 +1,88 @@
+# Implementation Plan: Complete VSA Migration
+
+**Branch**: `feat/adr100-phase7a-cleanup` | **Date**: 2026-05-02 | **Spec**: [specs/009-complete-vsa-migration/spec.md](specs/009-complete-vsa-migration/spec.md)
+**Input**: Feature specification from `specs/009-complete-vsa-migration/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Die Monorepo-Migration wird finalisiert, indem aktive Implementierungen unter `src/drift` vollstaendig zugunsten kanonischer Capability-Pakete (`packages/drift-*`) abgeloest werden. Der Plan kombiniert Importnormalisierung, klare Paketgrenzen, dokumentierten Abschlussstatus und Gate-basierte Verifikation, damit Contributor und Agenten nur noch einen eindeutigen Implementierungspfad pro Capability sehen.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+  
+**Primary Dependencies**: Click, Pydantic, Rich, pytest, mypy, ruff  
+**Storage**: N/A (Code- und Importstrukturmigration)  
+**Testing**: pytest, static import audits, `make check`, `make gate-check COMMIT_TYPE=feat`, migrationsspezifische Audit-Skripte  
+**Target Platform**: Cross-platform Entwickler- und CI-Workflows (Windows/Linux/macOS)
+**Project Type**: Monorepo mit Python Capability-Paketen und CLI/Ouput/Engine-Slices  
+**Performance Goals**: Keine regressionsbedingte Verschlechterung gegen bestehende Perf-Budgets; Migrationsverifikation bleibt im normalen Gate-Fenster lauffaehig  
+**Constraints**: Keine funktionalen Breaking Changes bei oeffentlichen Entry-Points; keine parallelen aktiven Implementierungspfade fuer dieselbe Capability  
+**Scale/Scope**: Repository-weite Konsolidierung fuer alle verbleibenden Legacy-Pfade in `src/drift`
+
+## Constitution Check
+
+*GATE: Partially blocked; Governance-Klaerung vor Implementierungsstart erforderlich.*
+
+### Pre-Research Gate
+
+- [ ] **I. Library-First**: Offen bis Governance-Entscheidung dokumentiert ist, ob Capability-Pakete die bestehenden `src/drift`-Slice-Vorgaben formal abloesen.
+- [ ] **II. Test-First**: Offen bis explizite RED-Tasks je User Story mit zuerst scheiternden Tests im Tasks-Artefakt verankert sind.
+- [x] **III. Functional Programming**: Migration veraendert primaer Modulgrenzen und Importe; Side Effects bleiben an CLI/IO-Grenzen isoliert.
+- [x] **IV. CLI Interface & Observability**: Bestehende CLI-/Output-Vertraege bleiben erhalten (JSON + Rich) und werden als Regressionkriterium verifiziert.
+- [x] **V. Simplicity & YAGNI**: Kein neues Framework oder neues Laufzeitmodell; nur strukturell noetige Konsolidierung.
+- [ ] **VI. Vertical Slices**: Offen bis Constitution oder Migrationsziel formal harmonisiert ist (Capability-Paketgrenzen vs. `src/drift/<feature_name>`-Vorgabe).
+
+**Gate-Entscheidung**: Keine Implementierung vor dokumentierter Governance-Klaerung fuer I/VI und RED-Test-Nachweis fuer II.
+
+### Post-Design Re-Check
+
+- [ ] Governance-Artefakte fuer I/VI sind vor Implementierung explizit zu beschliessen und zu dokumentieren.
+- [x] Datenmodell und Contract beschreiben klare Abschlusskriterien (kein aktiver Legacy-Pfad, erfolgreiche Gates, dokumentierter Zielzustand).
+- [x] Quickstart priorisiert schrittweise Verifikation statt Big-Bang-Risiko.
+- [ ] RED-Testpflicht je Story ist im Tasks-Artefakt vor Umsetzungsstart vollstaendig nachzuweisen.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-complete-vsa-migration/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── migration-boundary.contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+```text
+packages/
+├── drift/
+├── drift-cli/
+├── drift-config/
+├── drift-engine/
+├── drift-mcp/
+├── drift-output/
+├── drift-sdk/
+├── drift-session/
+└── drift-verify/
+
+src/
+└── drift/            # wird im Zielzustand nicht mehr als aktive Implementierungsquelle genutzt
+
+tests/
+├── ...               # bestehende suites + migration/contract checks
+```
+
+**Structure Decision**: Vertikale Capability-Paketstruktur ist verbindlich. Die Migration konsolidiert aktive Implementierung auf `packages/drift-*`; `src/drift` wird als produktive Quelle eliminiert. Validierung erfolgt ueber Import-Audits, Contract-Tests und bestehende Repo-Gates.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| Constitution I/VI vs. Capability-Paket-Zielbild | Die Migration zielt auf kanonische `packages/drift-*`-Pfade statt neuer Slices unter `src/drift/`. | Rueckkehr zu `src/drift`-zentrierter Slice-Implementierung konterkariert das definierte Migrationsziel und erhoeht Dual-Ownership-Risiken. |
+| Constitution II (Test-First) nicht explizit per Story-RED belegt | Architekturmigration braucht storyspezifische, zuerst scheiternde Nachweise fuer sichere Umstellung. | Reine Abschluss-Checks ohne fruehe RED-Tests erkennen Fehlzuordnungen erst spaet und erhoehen Rework-Risiko. |

--- a/specs/009-complete-vsa-migration/quickstart.md
+++ b/specs/009-complete-vsa-migration/quickstart.md
@@ -1,0 +1,38 @@
+# Quickstart: Complete VSA Migration
+
+## Goal
+Monorepo-Migrationsabschluss herstellen: `src/drift` ist keine aktive Implementierungsquelle mehr; Capability-Pakete sind kanonisch.
+
+## Preconditions
+- Entwicklungsumgebung ist eingerichtet.
+- Projektabhaengigkeiten sind synchronisiert.
+- Feature-Spec und Plan sind vorhanden.
+
+## Steps
+
+1. Baseline erfassen
+- Aktuelle Legacy-Pfade unter `src/drift` inventarisieren.
+- Aktive Implementierungs- und Importabhaengigkeiten dokumentieren.
+
+2. Zielzuordnung festlegen
+- Fuer jede verbleibende Legacy-Capability den kanonischen Zielpfad in `packages/drift-*` bestimmen.
+- Importnormalisierungsmatrix erstellen (source -> target).
+
+3. Migration ausfuehren
+- Legacy-Implementierungsreste entfernen oder neutralisieren.
+- Interne Importe auf kanonische Paketpfade umstellen.
+- Oeffentliche API-Vertraege stabil halten und regressionssicher pruefen.
+
+4. Verifikation durchfuehren
+- Lint, Typecheck und relevante Test-Suiten ausfuehren.
+- Projektspezifische Gates fuer Migrationsabschluss laufen lassen.
+- Legacy-Pfad-Audit wiederholen und Null-Restbestand bestaetigen.
+
+5. Dokumentation finalisieren
+- Architektur- und Contributor-Doku auf neue Paketgrenzen aktualisieren.
+- Abschlussstatus mit klaren Kriterien festhalten.
+
+## Expected Result
+- Kanonische Drift-Implementierung liegt ausschliesslich in Capability-Paketen.
+- Kein produktiver Pfad haengt von `src/drift` ab.
+- Qualitaets- und Gate-Pruefungen passieren im Zielzustand.

--- a/specs/009-complete-vsa-migration/research.md
+++ b/specs/009-complete-vsa-migration/research.md
@@ -1,0 +1,26 @@
+# Research: Complete VSA Migration
+
+## Decision 1: Capability-Pakete sind alleinige kanonische Implementierungsquelle
+- Decision: Produktive Drift-Implementierungen werden ausschliesslich in `packages/drift-*` Capability-Paketen gefuehrt; `src/drift` bleibt nicht als aktive Implementierungsflaeche bestehen.
+- Rationale: Ein klarer kanonischer Code-Ort reduziert Navigationsfehler, verhindert Doppelwartung und verbessert Agenten-Kontextqualitaet.
+- Alternatives considered: Dauerhafte Dual-Struktur mit parallelen Legacy-Pfaden; verworfen wegen hoher Verwechslungs- und Regressionsgefahr.
+
+## Decision 2: Migration erfolgt ueber API-stabile Importnormalisierung
+- Decision: Interne Importe werden auf kanonische Paketpfade normalisiert, waehrend oeffentliche Nutzungsvertraege explizit geprueft werden.
+- Rationale: So bleibt Verhalten stabil, aber interne Implementierung wird konsequent auf VSA-Slices ausgerichtet.
+- Alternatives considered: Big-Bang-Umstellung ohne Zwischenvalidierung; verworfen wegen hoher Ausfallwahrscheinlichkeit bei grossen Codebasen.
+
+## Decision 3: Verifikation als Gate-Buendel statt Einzeltests
+- Decision: Abschlusskriterium ist ein kombinierter Gate-Lauf (Lint, Typecheck, Tests, projektspezifische Gate-Checks) plus Import-/Pfad-Audits.
+- Rationale: Die Migration ist architekturweit; nur zusammengesetzte Verifikation belegt den sicheren Zielzustand.
+- Alternatives considered: Nur selektive Smoke-Tests; verworfen, da nicht ausreichend fuer Migrationsabschluss.
+
+## Decision 4: Architektur- und Contributor-Doku sind Teil des Deliverables
+- Decision: Dokumentation von Paketgrenzen, kanonischen Pfaden und Migrationsabschluss wird als Pflichtbestandteil der Umsetzung gefuehrt.
+- Rationale: Ohne klare Doku kehrt Legacy-Nutzung schnell zurueck und verwischt wieder die Zustandsgrenzen.
+- Alternatives considered: Doku nachgelagert aktualisieren; verworfen, da Onboarding-Effekt sonst verzögert und fehleranfällig bleibt.
+
+## Decision 5: Abschluss als expliziter Repository-Zustand
+- Decision: Der Migrationszyklus gilt nur dann als abgeschlossen, wenn kein aktiver Produktionspfad mehr von `src/drift` abhaengt und dieser Zustand dokumentiert und testbar nachgewiesen ist.
+- Rationale: Ein expliziter Abschlussstatus verhindert schleichende Rueckfaelle in Hybrid-Architekturen.
+- Alternatives considered: Informeller Abschluss ohne maschinenpruefbare Kriterien; verworfen wegen fehlender Nachhaltigkeit.

--- a/specs/009-complete-vsa-migration/spec.md
+++ b/specs/009-complete-vsa-migration/spec.md
@@ -1,0 +1,89 @@
+# Feature Specification: Complete VSA Migration
+
+**Feature Branch**: `[feat/adr100-phase7a-cleanup]`  
+**Created**: 2026-05-02  
+**Status**: Draft  
+**Input**: User description: "src/drift vollstaendig durch packages/drift-*-Capability-Pakete ersetzen und den Monorepo-Migrationszyklus abschliessen. Nutzen: vollstaendige VSA im Monorepo, klare Paketgrenzen, weniger Verwirrung fuer neue Contributor:innen, bessere Agent-Kontext-Effizienz."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Konsistente Paketnavigation (Priority: P1)
+
+Als Contributor moechte ich jede Drift-Funktionalitaet nur noch in klar abgegrenzten Capability-Paketen finden, damit ich ohne doppelte Pfade und Alias-Verwirrung arbeiten kann.
+
+**Why this priority**: Doppelstrukturen zwischen `src/drift` und Capability-Paketen verursachen die groesste Reibung bei Aenderungen, Reviews und Onboarding.
+
+**Independent Test**: Kann unabhaengig getestet werden, indem ein Contributor eine typische Aenderungsaufgabe (z. B. Kommando, Signal oder Session-Workflow) ohne Rueckgriff auf `src/drift` lokalisiert und durchfuehrt.
+
+**Acceptance Scenarios**:
+
+1. **Given** ein frischer Clone, **When** ein Contributor die relevanten Module fuer eine Feature-Aenderung sucht, **Then** sind die kanonischen Implementierungen ausschliesslich in den vorgesehenen Capability-Paketen auffindbar.
+2. **Given** eine bestehende Referenz auf Legacy-Pfade, **When** die Dokumentation und Architekturuebersicht konsultiert wird, **Then** ist eindeutig ersichtlich, welche Paketpfade verbindlich sind und dass `src/drift` nicht mehr als aktive Implementierungsflaeche dient.
+
+---
+
+### User Story 2 - Verlaesslicher Agenten-Workflow (Priority: P2)
+
+Als Coding-Agent moechte ich bei Aenderungen nur eine kanonische Code-Quelle je Slice sehen, damit Kontextsuche, Diff-Analyse und Fix-Loops ohne Migrationsartefakt-Rauschen funktionieren.
+
+**Why this priority**: Reduzierter Suchraum und eindeutige Ownership verbessern die Genauigkeit agentischer Entscheidungen.
+
+**Independent Test**: Kann unabhaengig getestet werden, indem ein Agent mehrere representative Aufgaben in unterschiedlichen Slices bearbeitet und dabei keine Legacy-Implementierungen unter `src/drift` mehr als aktive Quelle verwendet.
+
+**Acceptance Scenarios**:
+
+1. **Given** eine agentische Suche nach aenderungsrelevanten Symbolen, **When** die erste Treffermenge ausgewertet wird, **Then** zeigen Treffer auf Capability-Paketpfade statt auf Legacy-Implementierungen in `src/drift`.
+2. **Given** ein agentischer Fix-Loop mit Verifikation, **When** Patches erstellt und validiert werden, **Then** entstehen keine Rueckfaelle durch parallele Legacy-Implementierungen.
+
+---
+
+### User Story 3 - Niedrigere Onboarding-Huerde (Priority: P3)
+
+Als neuer Beitragender moechte ich die Architektur in einem Durchgang verstehen, damit ich schneller produktive Beitraege liefern kann.
+
+**Why this priority**: Klarheit in Struktur und Verantwortlichkeiten senkt Einstiegskosten und reduziert Rueckfragen.
+
+**Independent Test**: Kann unabhaengig getestet werden, indem ein neuer Beitragender ein Onboarding-Szenario mit Architektur- und Developer-Dokumentation durchlaeuft und anschliessend eine kleine Aenderung korrekt in einem Capability-Paket umsetzt.
+
+**Acceptance Scenarios**:
+
+1. **Given** Onboarding-Dokumentation und Codebaum, **When** ein neuer Beitragender eine erste Aenderung vorbereitet, **Then** kann er das richtige Capability-Paket ohne Nachfragen identifizieren.
+
+### Edge Cases
+
+- Wie wird mit verbliebenen Imports in externen Skripten oder Tests umgegangen, die noch auf Legacy-Pfade zeigen?
+- Wie wird sichergestellt, dass Build-, Lint-, Test- und Analyse-Workflows nicht implizit von `src/drift`-Resten abhaengen?
+- Was passiert, wenn einzelne Slices bereits migriert sind, andere aber noch Legacy-Referenzen enthalten?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Das System MUSS fuer jede Drift-Capability genau einen kanonischen Implementierungspfad in den vorgesehenen Capability-Paketen definieren.
+- **FR-002**: Das System MUSS alle aktiven Implementierungsreste unter `src/drift` entfernen oder so aufloesen, dass `src/drift` nicht mehr als produktive Implementierungsquelle genutzt wird.
+- **FR-003**: Das System MUSS bestehende interne Importpfade auf die kanonischen Capability-Paketpfade angleichen, sodass keine funktionalen Abhaengigkeiten auf Legacy-Pfade verbleiben.
+- **FR-004**: Das System MUSS Architektur- und Entwicklerdokumentation aktualisieren, damit Contributor den neuen Paketgrenzen eindeutig folgen koennen.
+- **FR-005**: Das System MUSS nach der Migration den bestehenden Qualitaets-Gates entsprechen, inklusive Build, Typpruefung, Tests und projektspezifischen Gate-Pruefungen.
+- **FR-006**: Das System MUSS den Abschluss der Monorepo-Migration als eindeutigen Zustand dokumentieren, damit Folgearbeiten nicht erneut Legacy-Strukturen einfuehren.
+
+### Key Entities *(include if feature involves data)*
+
+- **Capability-Paket**: Fachliche Vertikalscheibe mit klarer Ownership fuer Modelle, Logik und oeffentliche API eines Drift-Teilbereichs.
+- **Legacy-Pfad**: Historischer Pfad unter `src/drift`, der waehrend der Migration als Kompatibilitaets- oder Uebergangsflaeche gedient hat.
+- **Migrationsabschlussstatus**: Nachweisbarer Projektzustand, in dem nur noch die Capability-Pakete als aktive Implementierungsquellen gelten.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% der aktiven Drift-Implementierungen liegen in den definierten Capability-Paketen; `src/drift` wird nicht mehr als produktive Implementierungsflaeche verwendet.
+- **SC-002**: 100% der geprueften internen Referenzen fuer aktive Funktionalitaet zeigen auf kanonische Capability-Paketpfade.
+- **SC-003**: Mindestens 90% der neuen Contributor koennen in einem standardisierten Onboarding-Test mit mindestens 10 Durchlaeufen das korrekte Zielpaket fuer eine Beispielaenderung ohne Zusatzhilfe im ersten Versuch bestimmen.
+- **SC-004**: Alle verbindlichen Qualitaets- und Gate-Pruefungen bestehen im Zielzustand ohne migrationsbedingte Sonderbehandlung.
+
+## Assumptions
+
+- Die bestehenden Capability-Pakete decken fachlich bereits alle benoetigten Drift-Bereiche ab und muessen nur final konsolidiert werden.
+- Externe Integrationen duerfen bei Bedarf ueber klar dokumentierte Kompatibilitaetspfade uebergangsweise stabil gehalten werden, ohne `src/drift` als aktive Implementierungsquelle fortzufuehren.
+- Die Umstellung erfolgt so, dass laufende Contributor-Arbeit nicht durch grossflaechige, ungeplante Nebenmigrationen blockiert wird.
+- Die Architektur- und Entwicklungsdokumentation ist Teil des Lieferumfangs und nicht nur ein nachgelagerter Schritt.


### PR DESCRIPTION
## Summary

Separater PR für Spezifikationen, Dokumentation und Evidence-Artefakte als Abschluss des gestapelten PR-Sets.

## Related issue

Related #576

## Policy criterion served

- [x] Credibility (reproducibility, determinism)
- [ ] Signal precision (fewer false positives/negatives)
- [x] Finding clarity (better explanations, actionable next steps)
- [x] Adoptability (easier setup, onboarding, docs)
- [ ] Trend capability (temporal analysis, delta tracking)
- [ ] None of the above — explain why this is still valuable:

## First contribution?

- [ ] This is my first contribution to drift

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Test-only change
- [ ] CI/Build change

## Release notes label (required)

- [ ] `release:feature`
- [ ] `release:fix`
- [ ] `release:maintenance`
- [x] `release:docs`
- [ ] `release:skip` (internal-only, should not appear in release notes)

## Validation

- [ ] `pytest` passes locally
- [ ] `ruff check src/ tests/` passes locally
- [ ] `mypy src/drift` passes locally
- [ ] `drift self` delta checked (target: <= +0.010)
- [ ] Added/updated tests for behavioral changes

## Empirical evidence (required for new features)

- [x] This PR introduces no new feature (skip section)
- [ ] OR: empirical artifact added/updated in `benchmark_results/` or `audit_results/`
- [ ] OR: feature has benchmark/validation output attached in PR description

Evidence summary (required when feature is introduced):

- Scope / dataset:
- Baseline result:
- New result:
- Reproduction command:
- Interpretation (precision/noise/runtime impact):

## Checklist

- [x] PR is focused on one concern
- [x] Public docs updated (README/docs-site) if needed
- [ ] Changelog entry added if user-visible
- [x] If version/changelog changed: top release entry still fits one short summary plus at most 5 curated bullets
- [x] No unrelated files included

## Risk Audit (POLICY §18 — required for signal/architecture changes)

- [x] This PR does **not** touch `src/drift/signals/`, `src/drift/ingestion/`, or `src/drift/output/` (skip section)
- [ ] OR: `audit_results/fmea_matrix.md` updated (FP + FN entry for affected signal)
- [ ] OR: `audit_results/stride_threat_model.md` updated (new/changed trust boundary)
- [ ] OR: `audit_results/fault_trees.md` reviewed (FT-1/FT-2/FT-3 paths checked)
- [ ] OR: `audit_results/risk_register.md` updated (new risk entry or metric update)
- [ ] All four audit artifacts still exist and are not deleted

## Notes for reviewers

Teil 3 des gestapelten PR-Sets. Base-Branch ist `split/03-vscode-extension`.
