### PR TITLE
docs: add Copilot coding agent setup — issue template, brief-check workflow, labels, and contract tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/copilot_agent_task.yml
+++ b/.github/ISSUE_TEMPLATE/copilot_agent_task.yml
@@ -1,0 +1,105 @@
+name: Copilot Coding Agent Task
+description: Structured task brief for assigning an issue to GitHub Copilot coding agent
+title: "[Agent Task] "
+labels: ["copilot-agent", "enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when you plan to assign the issue to GitHub Copilot coding agent.
+
+        Keep the issue machine-actionable: clear scope, explicit acceptance criteria,
+        deterministic verification commands, and strict non-goals.
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: One concise outcome sentence. What should be true when this task is done?
+      placeholder: "Example: Add XYZ validation so invalid profile names are rejected before analysis starts."
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What files/modules are in scope, and what is explicitly excluded?
+      placeholder: |
+        In scope:
+        - src/drift/commands/config_cmd.py
+        - tests/test_config_validate.py
+
+        Out of scope:
+        - unrelated CLI refactors
+        - docs-site restructuring
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Provide measurable criteria as a checklist.
+      placeholder: |
+        - [ ] Invalid config key returns a user-facing error
+        - [ ] Existing valid configs are unchanged
+        - [ ] New regression test covers the failing case
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: Exact commands that prove the task is complete.
+      placeholder: |
+        make test-fast
+        .venv\Scripts\python.exe -m pytest tests/test_config_validate.py -q --tb=short
+    validations:
+      required: true
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints and guardrails
+      description: Policy, safety, compatibility, or architecture boundaries the agent must respect.
+      placeholder: |
+        - Keep changes minimal and task-focused
+        - Do not change public API names
+        - Follow POLICY.md gates
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: List changes that must not happen in this task.
+      placeholder: |
+        - No dependency upgrades
+        - No unrelated formatting-only edits
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context links
+      description: Add links to PRs/issues/docs relevant for the agent.
+      placeholder: |
+        - Related issue: #123
+        - Related PR: #456
+        - Docs: docs-site/reference/commands.md
+    validations:
+      required: false
+
+  - type: dropdown
+    id: agent_assignment
+    attributes:
+      label: Ready to assign to Copilot coding agent?
+      options:
+        - "Yes"
+        - "No, still refining"
+    validations:
+      required: true

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -46,6 +46,14 @@
   color: "a2eeef"
   description: New feature or improvement
 
+- name: copilot-agent
+  color: "0052CC"
+  description: Issue is prepared for GitHub Copilot coding agent assignment
+
+- name: needs-agent-brief
+  color: "B60205"
+  description: Copilot-agent issue is missing required task brief sections
+
 - name: not-prioritized
   color: "e4e4e4"
   description: Acknowledged but not currently prioritized

--- a/.github/workflows/copilot-agent-issue-brief-check.yml
+++ b/.github/workflows/copilot-agent-issue-brief-check.yml
@@ -1,0 +1,138 @@
+name: Copilot Agent Issue Brief Check
+
+on:
+  issues:
+    types: [opened, edited, reopened, labeled, unlabeled]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: copilot-agent-brief-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    if: github.event.issue.pull_request == null
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate Copilot-agent issue brief sections
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const issue = context.payload.issue;
+            if (!issue) {
+              core.info("No issue payload; skipping.");
+              return;
+            }
+
+            const labels = new Set((issue.labels || []).map((l) => (l.name || "").toLowerCase()));
+            const requiresValidation = labels.has("copilot-agent");
+            if (!requiresValidation) {
+              core.info("Issue has no copilot-agent label; skipping.");
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = issue.number;
+            const body = issue.body || "";
+
+            const requiredSections = [
+              { label: "Goal", pattern: /^#{2,3}\s*Goal\b/im },
+              { label: "Scope", pattern: /^#{2,3}\s*Scope\b/im },
+              {
+                label: "Acceptance Criteria",
+                pattern: /^#{2,3}\s*Acceptance\s+Criteria\b/im,
+              },
+              { label: "Verification", pattern: /^#{2,3}\s*Verification\b/im },
+              { label: "Constraints", pattern: /^#{2,3}\s*(Constraints|Constraints and guardrails)\b/im },
+              { label: "Non-goals", pattern: /^#{2,3}\s*Non-goals\b/im },
+            ];
+
+            const missingSections = requiredSections
+              .filter((section) => !section.pattern.test(body))
+              .map((section) => section.label);
+            const needsLabel = "needs-agent-brief";
+            const marker = "<!-- copilot-agent-brief-check -->";
+
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+                await github.rest.issues.createLabel({ owner, repo, name, color, description });
+              }
+            }
+
+            await ensureLabel(
+              needsLabel,
+              "B60205",
+              "Copilot-agent issue is missing required task brief sections",
+            );
+
+            const existingComments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: issueNumber, per_page: 100 },
+            );
+            const priorBotComment = existingComments.find(
+              (comment) =>
+                comment.user?.type === "Bot" &&
+                typeof comment.body === "string" &&
+                comment.body.includes(marker),
+            );
+
+            if (missingSections.length === 0) {
+              core.info("Issue brief is complete.");
+              if (labels.has(needsLabel)) {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: issueNumber, name: needsLabel });
+              }
+              if (priorBotComment) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: priorBotComment.id,
+                  body: `${marker}\nIssue brief validation passed. All required Copilot-agent sections are present.`,
+                });
+              }
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              labels: [needsLabel],
+            });
+
+            const missingList = missingSections.map((s) => `- ${s}`).join("\\n");
+            const guidance = [
+              marker,
+              "This issue is labeled `copilot-agent` but is missing required brief sections:",
+              "",
+              missingList,
+              "",
+              "Please add the missing sections so Copilot coding agent can produce a high-quality PR.",
+              "Best-practice references:",
+              "- https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent-to-work-on-tasks/about-assigning-tasks-to-copilot",
+              "- https://docs.github.com/en/copilot/tutorials/best-practices-for-using-github-copilot-coding-agent",
+            ].join("\\n");
+
+            if (priorBotComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: priorBotComment.id,
+                body: guidance,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body: guidance,
+              });
+            }

--- a/.github/workflows/copilot-agent-issue-brief-check.yml
+++ b/.github/workflows/copilot-agent-issue-brief-check.yml
@@ -29,33 +29,52 @@ jobs:
 
             const labels = new Set((issue.labels || []).map((l) => (l.name || "").toLowerCase()));
             const requiresValidation = labels.has("copilot-agent");
-            if (!requiresValidation) {
-              core.info("Issue has no copilot-agent label; skipping.");
-              return;
-            }
-
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const issueNumber = issue.number;
+            const needsLabel = "needs-agent-brief";
+            const marker = "<!-- copilot-agent-brief-check -->";
+
+            if (!requiresValidation) {
+              // copilot-agent label was removed — clean up any stale state
+              if (labels.has(needsLabel)) {
+                try {
+                  await github.rest.issues.removeLabel({ owner, repo, issue_number: issueNumber, name: needsLabel });
+                } catch (error) {
+                  if (error.status !== 404) throw error;
+                }
+              }
+              const allComments = await github.paginate(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number: issueNumber, per_page: 100 },
+              );
+              const staleComment = allComments.find(
+                (c) => c.user?.type === "Bot" && typeof c.body === "string" && c.body.includes(marker),
+              );
+              if (staleComment) {
+                await github.rest.issues.deleteComment({ owner, repo, comment_id: staleComment.id });
+              }
+              core.info("Issue has no copilot-agent label; cleaned up stale state.");
+              return;
+            }
+
             const body = issue.body || "";
 
             const requiredSections = [
               { label: "Goal", pattern: /^#{2,3}\s*Goal\b/im },
               { label: "Scope", pattern: /^#{2,3}\s*Scope\b/im },
               {
-                label: "Acceptance Criteria",
+                label: "Acceptance criteria",
                 pattern: /^#{2,3}\s*Acceptance\s+Criteria\b/im,
               },
               { label: "Verification", pattern: /^#{2,3}\s*Verification\b/im },
-              { label: "Constraints", pattern: /^#{2,3}\s*(Constraints|Constraints and guardrails)\b/im },
+              { label: "Constraints and guardrails", pattern: /^#{2,3}\s*(Constraints|Constraints and guardrails)\b/im },
               { label: "Non-goals", pattern: /^#{2,3}\s*Non-goals\b/im },
             ];
 
             const missingSections = requiredSections
               .filter((section) => !section.pattern.test(body))
               .map((section) => section.label);
-            const needsLabel = "needs-agent-brief";
-            const marker = "<!-- copilot-agent-brief-check -->";
 
             async function ensureLabel(name, color, description) {
               try {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.50.0] - 2026-05-03
+
+Short version: Add Copilot coding agent setup — issue template, brief-check workflow, labels, and contributor docs.
+
+### Changed
+- Add Copilot coding agent setup: issue template, brief-check workflow, labels, and contract test
+
 ## [2.49.0] - 2026-04-30
 
 Short version: drift pr-loop — agent-driven PR review loop command (FR-001–FR-013).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,8 +105,8 @@ structured issue and explicit verification commands.
 Recommended flow:
 
 1. Open a new issue with the **Copilot Coding Agent Task** template.
-2. Keep the sections complete: `Goal`, `Scope`, `Acceptance Criteria`,
-    `Verification`, `Constraints`, `Non-goals`.
+2. Keep the sections complete: `Goal`, `Scope`, `Acceptance criteria`,
+    `Verification`, `Constraints and guardrails`, `Non-goals`.
 3. Apply (or keep) the `copilot-agent` label.
 4. Assign the issue to Copilot in GitHub.
 5. Review the generated PR with normal CI gates and request changes where needed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,31 @@ Not sure where to go? Use this routing table:
 | Submit a small docs/typo improvement | Open a PR directly — no issue needed |
 | Report a security vulnerability | [SECURITY.md](SECURITY.md) — do not open a public issue |
 
+## Assigning tasks to Copilot coding agent
+
+If you want GitHub Copilot coding agent to open a PR autonomously, use a
+structured issue and explicit verification commands.
+
+Recommended flow:
+
+1. Open a new issue with the **Copilot Coding Agent Task** template.
+2. Keep the sections complete: `Goal`, `Scope`, `Acceptance Criteria`,
+    `Verification`, `Constraints`, `Non-goals`.
+3. Apply (or keep) the `copilot-agent` label.
+4. Assign the issue to Copilot in GitHub.
+5. Review the generated PR with normal CI gates and request changes where needed.
+
+Automation in this repository:
+
+- Workflow: `.github/workflows/copilot-agent-issue-brief-check.yml`
+- Behavior: if a `copilot-agent` issue misses required sections, Drift adds
+    `needs-agent-brief` and posts a checklist comment.
+
+Best-practice references:
+
+- https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent-to-work-on-tasks/about-assigning-tasks-to-copilot
+- https://docs.github.com/en/copilot/tutorials/best-practices-for-using-github-copilot-coding-agent
+
 ## Contributor ladder
 
 Drift contributions range from 15-minute improvements to multi-day signal work. Pick the level that fits your time and familiarity:

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ Every finding includes a human-readable `reason` and a concrete `next_action`. F
 |:---:|:---:|:---:|:---:|:---:|
 | `/drift-fix-plan` · `/drift-export-report` · `/drift-auto-fix-loop` | GitHub Actions · SARIF | pre-commit · pre-push | pip · pipx · uvx · Homebrew · Docker | Cursor · Claude Code · Copilot |
 
+For GitHub Copilot coding agent (issue-assigned autonomous PRs), use the
+`Copilot Coding Agent Task` issue template and keep required task-brief
+sections complete. See [CONTRIBUTING.md](CONTRIBUTING.md#assigning-tasks-to-copilot-coding-agent).
+
 `Start here (no MCP needed):` `drift kit init` → `/drift-fix-plan` in VS Code Copilot Chat. `Full CI + MCP:` `drift init --mcp --ci --hooks`. Language support: Python (full) · TypeScript/TSX 17/24 via `pip install 'drift-analyzer[typescript]'` · [language matrix](docs/language-support-matrix.md)
 
 ### GitHub Actions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 2.50.x  | :white_check_mark: |
+| 2.50.x  | :white_check_mark: |
 | 2.49.x  | :white_check_mark: |
 | 2.48.x  | :white_check_mark: |
 | 2.47.x  | :white_check_mark: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,6 @@
 | Version | Supported          |
 | ------- | ------------------ |
 | 2.50.x  | :white_check_mark: |
-| 2.50.x  | :white_check_mark: |
 | 2.49.x  | :white_check_mark: |
 | 2.48.x  | :white_check_mark: |
 | 2.47.x  | :white_check_mark: |

--- a/tests/test_copilot_agent_issue_brief_contract.py
+++ b/tests/test_copilot_agent_issue_brief_contract.py
@@ -1,0 +1,121 @@
+"""Contract tests for Copilot coding agent issue brief workflow."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO = Path(__file__).resolve().parent.parent
+TEMPLATE = REPO / ".github" / "ISSUE_TEMPLATE" / "copilot_agent_task.yml"
+WORKFLOW = REPO / ".github" / "workflows" / "copilot-agent-issue-brief-check.yml"
+
+REQUIRED_LABELS = (
+    "Goal",
+    "Scope",
+    "Acceptance criteria",
+    "Verification",
+    "Constraints and guardrails",
+    "Non-goals",
+)
+
+SECTION_PATTERNS = {
+    "Goal": re.compile(r"^#{2,3}\s*Goal\b", re.IGNORECASE | re.MULTILINE),
+    "Scope": re.compile(r"^#{2,3}\s*Scope\b", re.IGNORECASE | re.MULTILINE),
+    "Acceptance Criteria": re.compile(
+        r"^#{2,3}\s*Acceptance\s+Criteria\b", re.IGNORECASE | re.MULTILINE
+    ),
+    "Verification": re.compile(r"^#{2,3}\s*Verification\b", re.IGNORECASE | re.MULTILINE),
+    "Constraints": re.compile(
+        r"^#{2,3}\s*(Constraints|Constraints and guardrails)\b",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    "Non-goals": re.compile(r"^#{2,3}\s*Non-goals\b", re.IGNORECASE | re.MULTILINE),
+}
+
+
+def _template() -> dict:
+    return yaml.safe_load(TEMPLATE.read_text(encoding="utf-8"))
+
+
+def _missing_sections(issue_body: str) -> list[str]:
+    missing: list[str] = []
+    for label, pattern in SECTION_PATTERNS.items():
+        if not pattern.search(issue_body):
+            missing.append(label)
+    return missing
+
+
+class TestCopilotAgentIssueTemplate:
+    def test_template_exists_and_has_copilot_label(self) -> None:
+        assert TEMPLATE.exists()
+        data = _template()
+        labels = set(data.get("labels", []))
+        assert "copilot-agent" in labels
+
+    def test_template_contains_required_brief_fields(self) -> None:
+        data = _template()
+        labels = [item.get("attributes", {}).get("label") for item in data.get("body", [])]
+        for required in REQUIRED_LABELS:
+            assert required in labels
+
+
+class TestCopilotAgentIssueWorkflow:
+    def test_workflow_exists_and_is_issue_triggered(self) -> None:
+        assert WORKFLOW.exists()
+        data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        on_block = data.get("on")
+        if on_block is None:
+            # PyYAML may coerce the key 'on' to boolean True (YAML 1.1 behavior).
+            on_block = data.get(True, {})
+        issues = on_block.get("issues", {})
+        issue_types = set(issues.get("types", []))
+        expected = {"opened", "edited", "reopened", "labeled", "unlabeled"}
+        assert expected.issubset(issue_types)
+
+    def test_workflow_references_copilot_agent_labels(self) -> None:
+        raw = WORKFLOW.read_text(encoding="utf-8")
+        assert "copilot-agent" in raw
+        assert "needs-agent-brief" in raw
+
+    def test_section_detection_contract_matches_template_style(self) -> None:
+        complete = """
+### Goal
+Add validation for unknown config keys.
+
+### Scope
+Only config parser and config tests.
+
+### Acceptance Criteria
+- [ ] Unknown keys produce clear user-facing error
+
+### Verification
+make test-fast
+
+### Constraints and guardrails
+- Keep API stable
+
+### Non-goals
+- No dependency upgrade
+"""
+        assert _missing_sections(complete) == []
+
+    def test_section_detection_flags_missing_brief_sections(self) -> None:
+        incomplete = """
+### Goal
+Stabilize issue brief checker.
+
+### Scope
+Workflow file only.
+
+### Verification
+python -m pytest tests/test_copilot_agent_issue_brief_contract.py -q
+"""
+        assert _missing_sections(incomplete) == [
+            "Acceptance Criteria",
+            "Constraints",
+            "Non-goals",
+        ]

--- a/tests/test_copilot_agent_issue_brief_contract.py
+++ b/tests/test_copilot_agent_issue_brief_contract.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-import pytest
-
-yaml = pytest.importorskip("yaml")
+import yaml
 
 REPO = Path(__file__).resolve().parent.parent
 TEMPLATE = REPO / ".github" / "ISSUE_TEMPLATE" / "copilot_agent_task.yml"
@@ -25,11 +23,11 @@ REQUIRED_LABELS = (
 SECTION_PATTERNS = {
     "Goal": re.compile(r"^#{2,3}\s*Goal\b", re.IGNORECASE | re.MULTILINE),
     "Scope": re.compile(r"^#{2,3}\s*Scope\b", re.IGNORECASE | re.MULTILINE),
-    "Acceptance Criteria": re.compile(
+    "Acceptance criteria": re.compile(
         r"^#{2,3}\s*Acceptance\s+Criteria\b", re.IGNORECASE | re.MULTILINE
     ),
     "Verification": re.compile(r"^#{2,3}\s*Verification\b", re.IGNORECASE | re.MULTILINE),
-    "Constraints": re.compile(
+    "Constraints and guardrails": re.compile(
         r"^#{2,3}\s*(Constraints|Constraints and guardrails)\b",
         re.IGNORECASE | re.MULTILINE,
     ),
@@ -115,7 +113,7 @@ Workflow file only.
 python -m pytest tests/test_copilot_agent_issue_brief_contract.py -q
 """
         assert _missing_sections(incomplete) == [
-            "Acceptance Criteria",
-            "Constraints",
+            "Acceptance criteria",
+            "Constraints and guardrails",
             "Non-goals",
         ]


### PR DESCRIPTION
## Summary

Adds full Copilot Coding Agent enablement infrastructure to the drift repo.

### Changes

- **`.github/ISSUE_TEMPLATE/copilot_agent_task.yml`** — Structured GitHub Issue Form for Copilot coding agent task briefs. Enforces all required sections (Goal, Scope, Acceptance Criteria, Verification, Constraints, Non-goals). Auto-applies `copilot-agent` label.
- **`.github/workflows/copilot-agent-issue-brief-check.yml`** — GitHub Actions workflow that validates task-brief completeness on every `copilot-agent`-labeled issue. Posts/updates idempotent bot comment, adds/removes `needs-agent-brief` label.
- **`.github/labels.yml`** — Adds `copilot-agent` and `needs-agent-brief` labels.
- **`CONTRIBUTING.md`** — New section "Assigning tasks to Copilot coding agent" with 5-step flow and official GitHub docs links.
- **`README.md`** — Points to the new issue template and CONTRIBUTING section in the "Works with" table.
- **`tests/test_copilot_agent_issue_brief_contract.py`** — Contract tests: template structure, workflow triggers, section detection (positive + negative case). 6 tests.
- **`SECURITY.md`** — Added 2.50.x as supported version (required by pre-push model-consistency gate).

### Verification

- `pytest tests/test_copilot_agent_issue_brief_contract.py` → 6 passed
- `pytest tests/test_agent_harness_contract.py` → 37 passed
- ruff, mypy: no issues
- All pre-push gates passed