### PR TITLE
fix: update test_blast_radius fixtures for ADR-100 monorepo migration

### DIFF
--- a/tests/test_blast_radius_core.py
+++ b/tests/test_blast_radius_core.py
@@ -25,10 +25,14 @@ from drift.blast_radius._skill_analyzer import analyze_skill_impacts
 
 @pytest.fixture
 def repo_root() -> Path:
-    """Drift-Repository-Root (Eltern von ``src/drift``)."""
+    """Drift-Repository-Root (Eltern von ``packages/drift/src/drift``)."""
 
     path = Path(__file__).resolve().parents[1]
-    assert (path / "src" / "drift").is_dir(), "Repo-Root falsch aufgelöst."
+    # After ADR-100 monorepo migration, the canonical drift source lives under
+    # packages/drift/src/drift (compat stub) and packages/drift-engine/src/drift_engine.
+    assert (path / "packages" / "drift" / "src" / "drift").is_dir(), (
+        "Repo-Root falsch aufgelöst."
+    )
     return path
 
 

--- a/tests/test_blast_radius_mcp.py
+++ b/tests/test_blast_radius_mcp.py
@@ -12,7 +12,9 @@ from drift.serve.a2a_router import _ensure_dispatch_table
 @pytest.fixture
 def repo_root() -> Path:
     path = Path(__file__).resolve().parents[1]
-    assert (path / "src" / "drift").is_dir()
+    # After ADR-100 monorepo migration, the canonical drift source lives under
+    # packages/drift/src/drift (compat stub) instead of src/drift.
+    assert (path / "packages" / "drift" / "src" / "drift").is_dir()
     return path
 
 


### PR DESCRIPTION
Split from #576 (ADR-100 monorepo migration). Part of the PR decomposition into atomic, reviewable units.