### PR TITLE
fix: stabilize fix-plan test isolation and finding_context cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,33 @@
-## [2.50.0] - 2026-05-03
+## [2.50.0] - 2026-05-01
 
-Short version: Add Copilot coding agent setup — issue template, brief-check workflow, labels, and contributor docs.
+Short version: ADR-100 monorepo CI fixes, VSA migration Phase 1, and script catalog improvements.
 
 ### Changed
-- Add Copilot coding agent setup: issue template, brief-check workflow, labels, and contract test
+- merge main into feat/adr100-phase7a-cleanup; add script categories to catalog.py and scripts/README.md
 
 ### Fixed
-- address PR review — cleanup on label removal, consistent section names, direct yaml import
+- stabilize fix-plan test isolation by mocking get_active_dismissal_ids via importlib to bypass re-export aliasing (test_scan_diversity.py)
+- replace id()-based finding_context cache key with stable content-hash to prevent cross-test cache collisions (finding_context.py)
+- resolve monorepo CI regressions, suppress MAZ false positive, align static-analysis paths to packages/drift/src/drift (ADR-100)
+
+### Added
+- Phase 1 complete — VSA migration infrastructure setup (T001-T005)
 
 ## [2.49.0] - 2026-04-30
 
-Short version: drift pr-loop — agent-driven PR review loop command (FR-001–FR-013).
+Short version: drift pr-loop — agent-driven PR review loop command (FR-001–FR-013). Agent harness FU-002 FU-004: neutral ab-harness mock mode and failed-turn repro bundle. New: `@drift-analyzer/sdk` npm package for Node.js/TypeScript programmatic access.
 
 ### Added
-- add `drift pr-loop` command: agent-driven PR review loop (FR-001–FR-013)
+- `drift pr-loop` command: agent-driven PR review loop (FR-001–FR-013)
+- Monorepo ADR-100 capability-split rollout (uv workspace + `drift-config`/`drift-sdk`/`drift-engine`/`drift-session`/`drift-mcp`/`drift-cli`) plus outcome-first validation runner
+- `@drift-analyzer/sdk` npm package for Node.js/TypeScript programmatic access (`analyze`, `check`, `brief`, `fix-plan`)
 
 ### Fixed
-- resolve PR #563 review issues — PollTimeoutError partial verdicts, gate_output keys, CHANGELOG Short version, evidence tests field, workflow branch scope
+- resolve PR #563 review issues; harden output stubs; restore brief command console state; FU-002/004 ab-harness mock mode
 
 ### Changed
-- update harness prompt and skill catalog
+- add packages/ to repo-root-allowlist; phase 6b CI/workflow path-filters (ADR-100)
+- prevent post-commit hook from re-inserting CHANGELOG bullet on amend
 
 ## [2.48.5] - 2026-04-29
 

--- a/src/drift/finding_context.py
+++ b/src/drift/finding_context.py
@@ -60,14 +60,23 @@ def _ordered_rules(config: DriftConfig) -> list:
     )
 
 
-# Module-level caches keyed by id(config.finding_context) — stable within a run.
-_ordered_rules_cache: dict[int, list] = {}
-_path_context_cache: dict[tuple[int, str], str] = {}
+def _finding_context_signature(config: DriftConfig) -> tuple[str, tuple[tuple[str, str, int], ...]]:
+    """Return a stable signature for finding-context rules and default context."""
+    rules = tuple(
+        (rule.pattern, _normalise_context(rule.context), int(rule.precedence))
+        for rule in config.finding_context.rules
+    )
+    return (_normalise_context(config.finding_context.default_context), rules)
+
+
+# Module-level caches keyed by a stable finding-context signature.
+_ordered_rules_cache: dict[tuple[str, tuple[tuple[str, str, int], ...]], list] = {}
+_path_context_cache: dict[tuple[tuple[str, tuple[tuple[str, str, int], ...]], str], str] = {}
 
 
 def _ordered_rules_for(config: DriftConfig) -> list:
-    """Return sorted rules, reusing a module-level cache per config identity."""
-    key = id(config.finding_context)
+    """Return sorted rules, reusing a module-level cache per finding-context signature."""
+    key = _finding_context_signature(config)
     cached = _ordered_rules_cache.get(key)
     if cached is None:
         cached = _ordered_rules(config)
@@ -100,7 +109,7 @@ def classify_path_context(path: Path | None, config: DriftConfig) -> str:
         return config.finding_context.default_context
 
     posix = path.as_posix()
-    cache_key = (id(config.finding_context), posix)
+    cache_key = (_finding_context_signature(config), posix)
     cached = _path_context_cache.get(cache_key)
     if cached is not None:
         return cached

--- a/tests/test_scan_diversity.py
+++ b/tests/test_scan_diversity.py
@@ -1893,6 +1893,10 @@ class TestFixPlanFindingIdDiagnostics:
             "drift.output.agent_tasks.analysis_to_agent_tasks",
             lambda *a, **kw: tasks,
         )
+        import importlib
+
+        fix_plan_module = importlib.import_module("drift_sdk.api.fix_plan")
+        monkeypatch.setattr(fix_plan_module, "get_active_dismissal_ids", lambda *a, **kw: set())
         monkeypatch.setattr(api_module, "_emit_api_telemetry", lambda **kw: None)
 
         result = fix_plan(Path("."), max_tasks=5)
@@ -1936,6 +1940,10 @@ class TestFixPlanFindingIdDiagnostics:
             "drift.output.agent_tasks.analysis_to_agent_tasks",
             lambda *a, **kw: tasks,
         )
+        import importlib
+
+        fix_plan_module = importlib.import_module("drift_sdk.api.fix_plan")
+        monkeypatch.setattr(fix_plan_module, "get_active_dismissal_ids", lambda *a, **kw: set())
         monkeypatch.setattr(api_module, "_emit_api_telemetry", lambda **kw: None)
 
         result = fix_plan(Path("."), finding_id="explainability_deficit", max_tasks=5)
@@ -1978,6 +1986,10 @@ class TestFixPlanFindingIdDiagnostics:
             "drift.output.agent_tasks.analysis_to_agent_tasks",
             lambda *a, **kw: tasks,
         )
+        import importlib
+
+        fix_plan_module = importlib.import_module("drift_sdk.api.fix_plan")
+        monkeypatch.setattr(fix_plan_module, "get_active_dismissal_ids", lambda *a, **kw: set())
         monkeypatch.setattr(api_module, "_emit_api_telemetry", lambda **kw: None)
 
         result = fix_plan(Path("."), finding_id="not-a-real-id", max_tasks=5)


### PR DESCRIPTION
Split from #576 (ADR-100 monorepo migration). Part of the PR decomposition into atomic, reviewable units.