### PR TITLE
fix: repair signal-label and Windows cache mtime flaky tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,29 @@
-## [2.50.0] - 2026-05-03
+## [2.50.0] - 2026-05-01
 
-Short version: Add Copilot coding agent setup — issue template, brief-check workflow, labels, and contributor docs.
+Short version: ADR-100 monorepo CI fixes, VSA migration Phase 1, and script catalog improvements.
 
 ### Changed
-- Add Copilot coding agent setup: issue template, brief-check workflow, labels, and contract test
+- merge main into feat/adr100-phase7a-cleanup; add script categories to catalog.py and scripts/README.md; VSA migration Phase 1 (T001-T005)
 
 ### Fixed
-- address PR review — cleanup on label removal, consistent section names, direct yaml import
+- stabilize full-suite CI tests: fix-plan monkeypatch via importlib, finding_context stable cache key, signal-label __globals__ patch, Windows NTFS mtime flakiness in dismissal cache
+- resolve monorepo CI regressions, suppress MAZ false positive, align static-analysis paths to packages/drift/src/drift (ADR-100)
 
 ## [2.49.0] - 2026-04-30
 
-Short version: drift pr-loop — agent-driven PR review loop command (FR-001–FR-013).
+Short version: drift pr-loop — agent-driven PR review loop command (FR-001–FR-013). Agent harness FU-002 FU-004: neutral ab-harness mock mode and failed-turn repro bundle. New: `@drift-analyzer/sdk` npm package for Node.js/TypeScript programmatic access.
 
 ### Added
-- add `drift pr-loop` command: agent-driven PR review loop (FR-001–FR-013)
+- `drift pr-loop` command: agent-driven PR review loop (FR-001–FR-013)
+- Monorepo ADR-100 capability-split rollout (uv workspace + `drift-config`/`drift-sdk`/`drift-engine`/`drift-session`/`drift-mcp`/`drift-cli`) plus outcome-first validation runner
+- `@drift-analyzer/sdk` npm package for Node.js/TypeScript programmatic access (`analyze`, `check`, `brief`, `fix-plan`)
 
 ### Fixed
-- resolve PR #563 review issues — PollTimeoutError partial verdicts, gate_output keys, CHANGELOG Short version, evidence tests field, workflow branch scope
+- resolve PR #563 review issues; harden output stubs; restore brief command console state; FU-002/004 ab-harness mock mode
 
 ### Changed
-- update harness prompt and skill catalog
+- add packages/ to repo-root-allowlist; phase 6b CI/workflow path-filters (ADR-100)
+- prevent post-commit hook from re-inserting CHANGELOG bullet on amend
 
 ## [2.48.5] - 2026-04-29
 

--- a/tests/test_coverage_pipeline_and_helpers.py
+++ b/tests/test_coverage_pipeline_and_helpers.py
@@ -156,24 +156,30 @@ class TestMakeDegradationEvent:
 
 class TestPruneGitHistoryCache:
     def test_removes_stale_entries(self):
-        import drift.pipeline as pipeline_mod
         from drift.pipeline import (
             _GIT_HISTORY_CACHE_TTL_SECONDS,
             _prune_git_history_cache,
         )
 
-        now = 1000.0
-        stale_time = now - _GIT_HISTORY_CACHE_TTL_SECONDS - 1
-        pipeline_mod._GIT_HISTORY_CACHE["stale_key"] = (stale_time, [], {})
-        pipeline_mod._GIT_HISTORY_CACHE["fresh_key"] = (now, [], {})
+        # Use the function's own globals to get the authoritative cache dict,
+        # bypassing any re-export stub name-binding difference. Save/restore to
+        # keep the test isolated from real cache entries added by other tests.
+        cache = _prune_git_history_cache.__globals__["_GIT_HISTORY_CACHE"]
+        saved = dict(cache)
+        cache.clear()
+        try:
+            now = 1000.0
+            stale_time = now - _GIT_HISTORY_CACHE_TTL_SECONDS - 1
+            cache["stale_key"] = (stale_time, [], {})
+            cache["fresh_key"] = (now, [], {})
 
-        _prune_git_history_cache(now)
+            _prune_git_history_cache(now)
 
-        assert "stale_key" not in pipeline_mod._GIT_HISTORY_CACHE
-        assert "fresh_key" in pipeline_mod._GIT_HISTORY_CACHE
-
-        # Cleanup
-        pipeline_mod._GIT_HISTORY_CACHE.pop("fresh_key", None)
+            assert "stale_key" not in cache
+            assert "fresh_key" in cache
+        finally:
+            cache.clear()
+            cache.update(saved)
 
 
 # ===========================================================================

--- a/tests/test_issue_379_dismissal_readonly_cache.py
+++ b/tests/test_issue_379_dismissal_readonly_cache.py
@@ -105,16 +105,16 @@ class TestWriteOnExpiredPrune:
         ]
         _write_raw(tmp_path, entries)
         cache = _cache_path(tmp_path)
-        mtime_before = cache.stat().st_mtime_ns
 
         active = get_active_dismissals(tmp_path)
 
-        assert cache.stat().st_mtime_ns != mtime_before, (
-            "Cache file was NOT rewritten after expired entry pruning"
-        )
+        # Verify the file was rewritten by checking content (mtime-based checks
+        # are unreliable on Windows NTFS due to 100 ns timestamp granularity).
         assert [e["task_id"] for e in active] == ["active-task"]
         payload = json.loads(cache.read_text(encoding="utf-8"))
-        assert len(payload["dismissed"]) == 1
+        assert len(payload["dismissed"]) == 1, (
+            "Cache file was NOT rewritten after expired entry pruning"
+        )
         assert payload["dismissed"][0]["task_id"] == "active-task"
 
 

--- a/tests/test_output_minimal_and_signal_labels.py
+++ b/tests/test_output_minimal_and_signal_labels.py
@@ -76,9 +76,11 @@ def test_check_quiet_emits_minimal_line(monkeypatch, tmp_path: Path) -> None:
 
 
 def test_signal_label_fallback_returns_real_signal_id(monkeypatch) -> None:
-    import drift.output.rich_output as rich_output
-
-    monkeypatch.delitem(rich_output._SIGNAL_LABELS, SignalType.COHESION_DEFICIT, raising=False)
+    # Use _signal_label.__globals__ to reach the exact _SIGNAL_LABELS dict
+    # the function uses at runtime, bypassing drift.output re-export stub
+    # module-identity differences caused by drift.output.__path__ override.
+    labels = _signal_label.__globals__["_SIGNAL_LABELS"]
+    monkeypatch.delitem(labels, SignalType.COHESION_DEFICIT, raising=False)
 
     assert _signal_label(SignalType.COHESION_DEFICIT) == SignalType.COHESION_DEFICIT.value
 


### PR DESCRIPTION
Split from #576 (ADR-100 monorepo migration). Part of the PR decomposition into atomic, reviewable units.