### PR TITLE
chore: phase 6b add packages/** to CI/workflow path-filters

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,6 +18,7 @@ on:
     branches: [main]
     paths:
       - "src/drift/**"
+      - "packages/**"
       - "tests/benchmarks/**"
   schedule:
     # Nightly at 04:30 UTC (after perf-regression-loop at 04:00)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
               - 'src/drift/signals/**'
               - 'src/drift/scoring/**'
               - 'src/drift/ingestion/**'
+              - 'packages/**'
               - 'tests/**'
             docs:
               - 'docs/**'

--- a/.github/workflows/daily-fuzz.yml
+++ b/.github/workflows/daily-fuzz.yml
@@ -23,6 +23,7 @@ on:
       - "src/drift/ingestion/**"
       - "src/drift/signals/**"
       - "src/drift/scoring/**"
+      - "packages/**"
       - "tests/fuzz/**"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -18,6 +18,7 @@ on:
     branches: [main]
     paths:
       - "src/drift/**"
+      - "packages/**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -18,6 +18,7 @@ on:
     paths:
       - "src/drift/scoring/**"
       - "src/drift/signals/**"
+      - "packages/**"
       - "tests/**"
   schedule:
     # Every Sunday at 03:00 UTC (before perf-regression-loop at 04:00)

--- a/.github/workflows/perf-regression-loop.yml
+++ b/.github/workflows/perf-regression-loop.yml
@@ -11,6 +11,7 @@ on:
     branches: [main]
     paths:
       - "src/drift/**"
+      - "packages/**"
   workflow_dispatch:
     inputs:
       budget:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,37 @@
-## [2.50.0] - 2026-05-03
+## [2.49.0] - 2026-05-01
 
-Short version: Add Copilot coding agent setup — issue template, brief-check workflow, labels, and contributor docs.
+Short version: Monorepo Phase 0+1+3+4a — uv workspace root + drift-config + drift-engine + drift-output capability packages extracted.
 
-### Changed
-- Add Copilot coding agent setup: issue template, brief-check workflow, labels, and contract test
-
-### Fixed
-- address PR review — cleanup on label removal, consistent section names, direct yaml import
+### Added
+- monorepo phase 0+1: uv workspace root + drift-config capability package (ADR-100)
+- monorepo phase 3: drift-engine capability package (signals/scoring/ingestion/pipeline/analyzer, ADR-100)
+- monorepo phase 4a: drift-output capability package (rendering/export surface, ADR-100)
 
 ## [2.49.0] - 2026-04-30
 
-Short version: drift pr-loop — agent-driven PR review loop command (FR-001–FR-013).
+Short version: drift pr-loop — agent-driven PR review loop command (FR-001–FR-013). Agent harness FU-002 FU-004: neutral ab-harness mock mode and failed-turn repro bundle.
 
 ### Added
 - add `drift pr-loop` command: agent-driven PR review loop (FR-001–FR-013)
+- monorepo phase 0+1 -- uv workspace root + drift-config capability package (ADR-100)
+- monorepo phase 2 -- drift-sdk capability package (types + models, ADR-100)
+- monorepo phase 3 -- drift-engine capability package (signals/scoring/ingestion/pipeline/analyzer, ADR-100)
+- monorepo phase 4b -- drift-session capability package (session/outcome/reward, ADR-100)
+- monorepo phase 5a -- drift-mcp capability package (MCP server/routers, ADR-100)
+- monorepo phase 5b -- drift-cli capability package (CLI commands, ADR-100)
 
 ### Fixed
 - resolve PR #563 review issues — PollTimeoutError partial verdicts, gate_output keys, CHANGELOG Short version, evidence tests field, workflow branch scope
+- harden output re-export stubs for typing
+- restore global console state in brief cmd and fix Click 8.3 compat in tests
 
 ### Changed
 - update harness prompt and skill catalog
+- agent harness FU-002 FU-004: neutral ab-harness mock mode and failed-turn repro bundle
+- agent harness FU-002 FU-004 -- neutral ab-harness mock mode and failed-turn repro bundle
+- revert unintended changelog carryover
+- add packages/ to repo-root-allowlist (ADR-100 monorepo)
+- phase 6b -- add packages/** to CI/workflow path-filters (ADR-100)
 
 ## [2.48.5] - 2026-04-29
 


### PR DESCRIPTION
Split from #576 (ADR-100 monorepo migration). Part of the PR decomposition into atomic, reviewable units.