### PR TITLE
chore: phase 7a update guard-skills and DEVELOPER.md to packages/** paths

### DIFF
--- a/.github/skills/guard-src-drift-api/SKILL.md
+++ b/.github/skills/guard-src-drift-api/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: guard-src-drift-api
-description: "Drift-generierter Guard fuer `src/drift/api`. Aktiv bei Signalen: EDS, PFS. Konfidenz: 0.95. Verwende diesen Skill wenn du Aenderungen an `src/drift/api` planst oder wiederholte Drift-Findings (EDS, PFS) fuer dieses Modul bearbeitest."
-argument-hint: "Beschreibe die geplante Aenderung in `src/drift/api` — welche Funktion, welches Modul, welcher Zweck."
+description: "Drift-generierter Guard fuer `packages/drift-sdk` API. Aktiv bei Signalen: EDS, PFS. Konfidenz: 0.95. Verwende diesen Skill wenn du Aenderungen an `packages/drift-sdk/src/drift_sdk/api` planst oder wiederholte Drift-Findings (EDS, PFS) fuer dieses Modul bearbeitest."
+argument-hint: "Beschreibe die geplante Aenderung in `packages/drift-sdk/src/drift_sdk/api` — welche Funktion, welches Modul, welcher Zweck."
 ---
 
-# Guard: `src/drift/api`
+# Guard: `packages/drift-sdk/src/drift_sdk/api`
 
-`src/drift/api` ist die einzige legitime Eintrittspforte fuer alle Agenten- und MCP-Aufrufe. Jede Datei hier (`scan.py`, `fix_plan.py`, `steer.py`, `nudge.py`, `brief.py`, `suggest_rules.py`, `generate_skills.py`, `diff.py`, `verify.py`) repraesentiert genau einen oeffentlichen Vertrag.
+> **ADR-100 Phase 7a:** Kanonischer Code liegt in `packages/drift-sdk/src/drift_sdk/api/`.
+> `src/drift/api/` ist ein Re-export-Stub und darf nicht direkt editiert werden.
+
+`packages/drift-sdk/src/drift_sdk/api` ist die einzige legitime Eintrittspforte fuer alle Agenten- und MCP-Aufrufe. Jede Datei hier (`scan.py`, `fix_plan.py`, `steer.py`, `nudge.py`, `brief.py`, `suggest_rules.py`, `generate_skills.py`, `diff.py`, `verify.py`) repraesentiert genau einen oeffentlichen Vertrag.
 
 **Konfidenz: 0.95** — EDS und PFS treten wiederholt auf, weil API-Funktionen interne Submodule direkt verdrahten statt sauber zu delegieren.
 
@@ -15,7 +18,7 @@ argument-hint: "Beschreibe die geplante Aenderung in `src/drift/api` — welche 
 - Du fuegest eine neue oeffentliche API-Funktion hinzu oder aenderst eine bestehende
 - Du implementierst einen neuen MCP-Tool-Handler
 - Du rufst intern `pipeline.py`, `analyzer.py` oder `scoring/` direkt aus einer neuen Funktion auf
-- Drift meldet EDS oder PFS fuer eine Datei in `src/drift/api/`
+- Drift meldet EDS oder PFS fuer eine Datei in `packages/drift-sdk/src/drift_sdk/api/`
 
 **Nicht benutzen** fuer reine CLI-Aenderungen — dafuer gibt es `guard-src-drift-commands`.
 
@@ -68,7 +71,7 @@ print(f'{len(findings)} findings in api/')
 
 ## References
 
-- [src/drift/api/_util.py](../../../src/drift/api/_util.py) — Gemeinsame API-Hilfsfunktionen
-- [src/drift/api/_config.py](../../../src/drift/api/_config.py) — API-Bootstrapping
-- [src/drift/api/scan.py](../../../src/drift/api/scan.py) — Referenz-Implementierung
+- [packages/drift-sdk/src/drift_sdk/api/_util.py](../../../packages/drift-sdk/src/drift_sdk/api/_util.py) — Gemeinsame API-Hilfsfunktionen
+- [packages/drift-sdk/src/drift_sdk/api/_config.py](../../../packages/drift-sdk/src/drift_sdk/api/_config.py) — API-Bootstrapping
+- [packages/drift-sdk/src/drift_sdk/api/scan.py](../../../packages/drift-sdk/src/drift_sdk/api/scan.py) — Referenz-Implementierung
 - [DEVELOPER.md](../../DEVELOPER.md)

--- a/.github/skills/guard-src-drift-commands/SKILL.md
+++ b/.github/skills/guard-src-drift-commands/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: guard-src-drift-commands
-description: "Drift-generierter Guard fuer `src/drift/commands`. Aktiv bei Signalen: EDS, PFS. Konfidenz: 0.89. Verwende diesen Skill wenn du Aenderungen an `src/drift/commands` planst oder wiederholte Drift-Findings (EDS, PFS) fuer dieses Modul bearbeitest."
+description: "Drift-generierter Guard fuer `packages/drift-cli` Commands. Aktiv bei Signalen: EDS, PFS. Konfidenz: 0.89. Verwende diesen Skill wenn du Aenderungen an `packages/drift-cli/src/drift_cli/commands` planst oder wiederholte Drift-Findings (EDS, PFS) fuer dieses Modul bearbeitest."
 argument-hint: "Beschreibe welchen CLI-Befehl (analyze, verify, serve, calibrate...) du veraenderst und warum."
 ---
 
-# Guard: `src/drift/commands`
+# Guard: `packages/drift-cli/src/drift_cli/commands`
 
-`src/drift/commands` enthaelt die CLI-Command-Handler. Jeder Subbefehl (`analyze`, `verify`, `serve`, `calibrate`, ...) hat eine eigene Datei. EDS entsteht wenn Commands direkt in `pipeline.py` oder `Analyzer()` einsteigen. PFS entsteht wenn Commands inkonsistente Argument-Parsing- oder Output-Handling-Muster verwenden.
+> **ADR-100 Phase 7a:** Kanonischer Code liegt in `packages/drift-cli/src/drift_cli/commands/`.
+> `src/drift/commands/` ist ein Re-export-Stub und darf nicht direkt editiert werden.
+
+`packages/drift-cli/src/drift_cli/commands` enthaelt die CLI-Command-Handler. Jeder Subbefehl (`analyze`, `verify`, `serve`, `calibrate`, ...) hat eine eigene Datei. EDS entsteht wenn Commands direkt in `pipeline.py` oder `Analyzer()` einsteigen. PFS entsteht wenn Commands inkonsistente Argument-Parsing- oder Output-Handling-Muster verwenden.
 
 **Konfidenz: 0.89** — EDS und PFS treten regelmaessig auf, oft nach Features die Shortcuts einbauen.
 
@@ -15,9 +18,9 @@ argument-hint: "Beschreibe welchen CLI-Befehl (analyze, verify, serve, calibrate
 - Du fuegest einen neuen CLI-Subbefehl hinzu
 - Du aenderst wie ein bestehender Befehl Argumente verarbeitet oder Ergebnisse ausgibt
 - Du aenderst wie Exit-Codes gesetzt werden
-- Drift meldet EDS oder PFS fuer eine Datei in `src/drift/commands/`
+- Drift meldet EDS oder PFS fuer eine Datei in `packages/drift-cli/src/drift_cli/commands/`
 
-**Nicht benutzen** fuer Aenderungen an der CLI-Definition in `cli.py` — das ist ein anderer Scope.
+**Nicht benutzen** fuer Aenderungen an der CLI-Definition in `packages/drift-cli/src/drift_cli/cli.py` — das ist ein anderer Scope.
 
 ## Warum dieses Modul kritisch ist
 
@@ -50,7 +53,7 @@ argument-hint: "Beschreibe welchen CLI-Befehl (analyze, verify, serve, calibrate
 
 ## References
 
-- [src/drift/cli.py](../../../src/drift/cli.py) — CLI-Einstiegspunkt und Command-Registrierung
-- [src/drift/api/](../../../src/drift/api/) — Alle aufrufbaren API-Funktionen
-- [src/drift/output/](../../../src/drift/output/) — Output-Formatter
+- [packages/drift-cli/src/drift_cli/cli.py](../../../packages/drift-cli/src/drift_cli/cli.py) — CLI-Einstiegspunkt und Command-Registrierung
+- [packages/drift-sdk/src/drift_sdk/api/](../../../packages/drift-sdk/src/drift_sdk/api/) — Alle aufrufbaren API-Funktionen
+- [packages/drift-output/src/drift_output/](../../../packages/drift-output/src/drift_output/) — Output-Formatter
 - [DEVELOPER.md](../../DEVELOPER.md)

--- a/.github/skills/guard-src-drift-ingestion/SKILL.md
+++ b/.github/skills/guard-src-drift-ingestion/SKILL.md
@@ -16,7 +16,7 @@ argument-hint: "Beschreibe die geplante Aenderung in `src/drift/ingestion` — w
 - Du erweiterst den AST-Parser fuer neue Python-Konstrukte oder Tree-sitter-Nodes
 - Du veraenderst wie Git-Commits oder Blame-Daten eingelesen werden
 - Du fuegest Unterstuetzung fuer ein neues Sprachformat hinzu
-- Drift meldet AVS, EDS oder PFS fuer Dateien in `src/drift/ingestion/`
+- Drift meldet AVS, EDS oder PFS fuer Dateien in `packages/drift-engine/src/drift_engine/ingestion/`
 
 ## Warum dieses Modul kritisch ist
 
@@ -54,7 +54,7 @@ argument-hint: "Beschreibe die geplante Aenderung in `src/drift/ingestion` — w
 
 ## References
 
-- [src/drift/ingestion/file_discovery.py](../../../src/drift/ingestion/file_discovery.py) — Discovery-Pipeline
-- [src/drift/ingestion/ast_parser.py](../../../src/drift/ingestion/ast_parser.py) — Python-AST-Parser
-- [src/drift/ingestion/git_history.py](../../../src/drift/ingestion/git_history.py) — Git-History-Reader
+- [packages/drift-engine/src/drift_engine/ingestion/file_discovery.py](../../../packages/drift-engine/src/drift_engine/ingestion/file_discovery.py) — Discovery-Pipeline
+- [packages/drift-engine/src/drift_engine/ingestion/ast_parser.py](../../../packages/drift-engine/src/drift_engine/ingestion/ast_parser.py) — Python-AST-Parser
+- [packages/drift-engine/src/drift_engine/ingestion/git_history.py](../../../packages/drift-engine/src/drift_engine/ingestion/git_history.py) — Git-History-Reader
 - [tests/test_file_discovery.py](../../../tests/test_file_discovery.py) — Discovery-Tests

--- a/.github/skills/guard-src-drift-output/SKILL.md
+++ b/.github/skills/guard-src-drift-output/SKILL.md
@@ -15,7 +15,7 @@ argument-hint: "Beschreibe welches Ausgabeformat (rich/json/markdown/llm/badge) 
 - Du aenderst wie Findings angezeigt, formatiert oder gerendert werden
 - Du fuegest ein neues Ausgabeformat hinzu
 - Du aenderst `rich_output.py`, `json_output.py`, `markdown_report.py` oder `guided_output.py`
-- Drift meldet EDS fuer eine Datei in `src/drift/output/`
+- Drift meldet EDS fuer eine Datei in `packages/drift-output/src/drift_output/`
 
 ## Warum dieses Modul kritisch ist
 
@@ -53,7 +53,7 @@ Jede neue Berechnung in einem Formatter verstaerkt diese Verschraenkung.
 
 ## References
 
-- [src/drift/output/grouping.py](../../../src/drift/output/grouping.py) — Gemeinsame Gruppierungs-Logik
-- [src/drift/output/json_output.py](../../../src/drift/output/json_output.py) — Kanonisches JSON-Format
+- [packages/drift-output/src/drift_output/grouping.py](../../../packages/drift-output/src/drift_output/grouping.py) — Gemeinsame Gruppierungs-Logik
+- [packages/drift-output/src/drift_output/json_output.py](../../../packages/drift-output/src/drift_output/json_output.py) — Kanonisches JSON-Format
 - [drift.output.schema.json](../../../drift.output.schema.json) — JSON-Output-Schema
-- [src/drift/models/_findings.py](../../../src/drift/models/_findings.py) — `RepoAnalysis`-Modell
+- [packages/drift-sdk/src/drift_sdk/models/_findings.py](../../../packages/drift-sdk/src/drift_sdk/models/_findings.py) — `RepoAnalysis`-Modell

--- a/.github/skills/guard-src-drift-signals/SKILL.md
+++ b/.github/skills/guard-src-drift-signals/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: guard-src-drift-signals
-description: "Drift-generierter Guard fuer `src/drift/signals`. Aktiv bei Signalen: AVS, EDS, PFS. Konfidenz: 0.95. Verwende diesen Skill wenn du Aenderungen an `src/drift/signals` planst oder wiederholte Drift-Findings (AVS, EDS, PFS) fuer dieses Modul bearbeitest."
+description: "Drift-generierter Guard fuer `packages/drift-engine` Signals. Aktiv bei Signalen: AVS, EDS, PFS. Konfidenz: 0.95. Verwende diesen Skill wenn du Aenderungen an `packages/drift-engine/src/drift_engine/signals` planst oder wiederholte Drift-Findings (AVS, EDS, PFS) fuer dieses Modul bearbeitest."
 argument-hint: "Beschreibe das neue oder zu aendernde Signal — Name, Typ, was es erkennen soll."
 ---
 
-# Guard: `src/drift/signals`
+# Guard: `packages/drift-engine/src/drift_engine/signals`
 
-`src/drift/signals` enthaelt alle 25+ `BaseSignal`-Implementierungen. Jede Datei hier ist eine eigenstaendige Erkennungseinheit. AVS, EDS und PFS entstehen wenn Signals zu viel tun, intern verwoben sind oder voneinander abweichende Muster verwenden.
+> **ADR-100 Phase 7a:** Kanonischer Code liegt in `packages/drift-engine/src/drift_engine/signals/`.
+> `src/drift/signals/` ist ein Re-export-Stub und darf nicht direkt editiert werden.
+
+`packages/drift-engine/src/drift_engine/signals` enthaelt alle 25+ `BaseSignal`-Implementierungen. Jede Datei hier ist eine eigenstaendige Erkennungseinheit. AVS, EDS und PFS entstehen wenn Signals zu viel tun, intern verwoben sind oder voneinander abweichende Muster verwenden.
 
 **Konfidenz: 0.95** — dieses Modul ist der Kern der Erkennungsqualitaet; Fehler hier beeinflussen direkt Precision und Recall.
 
@@ -16,7 +19,7 @@ argument-hint: "Beschreibe das neue oder zu aendernde Signal — Name, Typ, was 
 - Du veraenderst die Erkennungslogik eines bestehenden Signals
 - Du aenderst `base.py`, `_utils.py`, `__init__.py` oder `register_signal`
 - Du bearbeitest `incremental_scope` fuer ein Signal
-- Drift meldet AVS, EDS oder PFS fuer eine Datei in `src/drift/signals/`
+- Drift meldet AVS, EDS oder PFS fuer Dateien in `packages/drift-engine/src/drift_engine/signals/`
 
 **Fuer ein vollstaendiges neues Signal** verwende stattdessen `drift-signal-development-full-lifecycle` — der Skill dort enthaelt den vollstaendigen ADR-, Fixture- und Audit-Workflow.
 
@@ -69,7 +72,7 @@ drift analyze --repo . --exit-zero
 
 ## References
 
-- [src/drift/signals/base.py](../../../src/drift/signals/base.py) — `BaseSignal`, `AnalysisContext`, `register_signal`
-- [src/drift/signals/_utils.py](../../../src/drift/signals/_utils.py) — Gemeinsame Signal-Helfer
+- [packages/drift-engine/src/drift_engine/signals/base.py](../../../packages/drift-engine/src/drift_engine/signals/base.py) — `BaseSignal`, `AnalysisContext`, `register_signal`
+- [packages/drift-engine/src/drift_engine/signals/_utils.py](../../../packages/drift-engine/src/drift_engine/signals/_utils.py) — Gemeinsame Signal-Helfer
 - [tests/fixtures/ground_truth.py](../../../tests/fixtures/ground_truth.py) — Precision/Recall-Fixtures
 - [.github/skills/drift-signal-development-full-lifecycle/SKILL.md](../drift-signal-development-full-lifecycle/SKILL.md) — Vollstaendiger Signal-Lifecycle

--- a/.github/skills/guard-src-drift/SKILL.md
+++ b/.github/skills/guard-src-drift/SKILL.md
@@ -1,23 +1,28 @@
 ---
 name: guard-src-drift
-description: "Drift-generierter Guard fuer `src/drift`. Aktiv bei Signalen: AVS, EDS, MDS, PFS. Konfidenz: 0.95. Verwende diesen Skill wenn du Aenderungen an `src/drift` planst oder wiederholte Drift-Findings (AVS, EDS, MDS, PFS) fuer dieses Modul bearbeitest."
-argument-hint: "Beschreibe die geplante Aenderung in `src/drift` — welche Datei, welche Funktion, welcher Zweck."
+description: "Drift-generierter Guard fuer `packages/drift-engine` (Kern-Analyzer). Aktiv bei Signalen: AVS, EDS, MDS, PFS. Konfidenz: 0.95. Verwende diesen Skill wenn du Aenderungen an `packages/drift-engine` planst oder wiederholte Drift-Findings (AVS, EDS, MDS, PFS) fuer dieses Modul bearbeitest."
+argument-hint: "Beschreibe die geplante Aenderung in `packages/drift-engine` — welche Datei, welche Funktion, welcher Zweck."
 ---
 
-# Guard: `src/drift`
+# Guard: `packages/drift-engine` (kanonischer Code, vormals `src/drift`)
 
-`src/drift` ist der Kern des gesamten Analyzers. Er enthaelt `analyzer.py`, `pipeline.py`, `cache.py`, `scoring/`, `mcp_*.py`-Orchestrierung und alle oeffentlichen Einstiegspunkte. Jede Aenderung hier hat breite Auswirkungen auf Scan-Korrektheit, Scoring und Agenten-Verhalten.
+> **ADR-100 Phase 7a:** Der kanonische Code liegt in `packages/drift-engine/src/drift_engine/`.
+> `src/drift/` ist ein reiner Backward-Compat-Layer (Re-export-Stubs). Aenderungen gehoeren in `packages/drift-engine/`, nie in die Stubs.
+
+`packages/drift-engine/src/drift_engine/` enthaelt `analyzer.py`, `pipeline.py`, `cache.py`, `scoring/`, und alle MCP-Orchestrierungs-Module. Jede Aenderung hier hat breite Auswirkungen auf Scan-Korrektheit, Scoring und Agenten-Verhalten.
 
 **Konfidenz: 0.95** — alle vier Hauptsignale treten wiederholt auf.
 
 ## When To Use
 
-- Du aenderst eine Datei direkt in `src/drift/` (nicht in einem Unterpaket)
+- Du aenderst eine Datei in `packages/drift-engine/src/drift_engine/`
 - Du bearbeitest `analyzer.py`, `pipeline.py`, `cache.py`, `api_helpers.py`, `task_graph.py` oder `scoring/`
-- Ein Drift-Scan meldet AVS, EDS, MDS oder PFS fuer Dateien im Wurzelpaket
-- Vor einem Commit der `src/drift/__init__.py` oder oeffentliche Exports aendert
+- Ein Drift-Scan meldet AVS, EDS, MDS oder PFS fuer Dateien im Engine-Paket
+- Vor einem Commit der `packages/drift-engine/src/drift_engine/__init__.py` oder oeffentliche Exports aendert
 
-**Nicht benutzen** fuer Aenderungen ausschliesslich in `src/drift/signals/`, `src/drift/api/` oder `src/drift/output/` — dafuer gibt es dedizierte Guards.
+**Nicht benutzen** fuer Aenderungen ausschliesslich in `packages/drift-engine/src/drift_engine/signals/`, `packages/drift-sdk/src/drift_sdk/api/` oder `packages/drift-output/` — dafuer gibt es dedizierte Guards.
+
+> Hinweis: `src/drift/` im Repo-Root enthaelt nur Re-export-Stubs (ADR-100). Dort nichts aendern.
 
 ## Warum dieses Modul kritisch ist
 
@@ -67,6 +72,6 @@ drift nudge  # erwartet: safe_to_commit: true
 ## References
 
 - [DEVELOPER.md](../../DEVELOPER.md)
-- [src/drift/pipeline.py](../../../src/drift/pipeline.py) — Analyse-Pipeline
-- [src/drift/analyzer.py](../../../src/drift/analyzer.py) — Haupt-Analyzer
-- [src/drift/api_helpers.py](../../../src/drift/api_helpers.py) — Gemeinsame Hilfsfunktionen
+- [packages/drift-engine/src/drift_engine/pipeline.py](../../../packages/drift-engine/src/drift_engine/pipeline.py) — Analyse-Pipeline
+- [packages/drift-engine/src/drift_engine/analyzer.py](../../../packages/drift-engine/src/drift_engine/analyzer.py) — Haupt-Analyzer
+- [packages/drift-sdk/src/drift_sdk/](../../../packages/drift-sdk/src/drift_sdk/) — SDK inkl. api_helpers und types

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -73,13 +73,14 @@ baselines per repository and automatically invalidates them when:
 
 | Directory | Purpose |
 |---|---|
-| `src/drift/ingestion/` | File discovery, AST parsing (Python + TypeScript), git log parsing |
-| `src/drift/signals/` | 24 detection signals (19 scoring-active, 5 report-only), each implementing `BaseSignal` |
-| `src/drift/scoring/` | Weighted composite score, severity gating, module scores |
-| `src/drift/output/` | Rich terminal dashboard, JSON, SARIF formatters |
-| `src/drift/commands/` | Click CLI subcommands |
-| `src/drift/config.py` | Pydantic-based configuration with defaults |
-| `src/drift/models.py` | Core data models: `Finding`, `ParseResult`, `RepoAnalysis` |
+| `packages/drift-engine/src/drift_engine/ingestion/` | File discovery, AST parsing (Python + TypeScript), git log parsing |
+| `packages/drift-engine/src/drift_engine/signals/` | 24 detection signals (19 scoring-active, 5 report-only), each implementing `BaseSignal` |
+| `packages/drift-engine/src/drift_engine/scoring/` | Weighted composite score, severity gating, module scores |
+| `packages/drift-output/src/drift_output/` | Rich terminal dashboard, JSON, SARIF formatters |
+| `packages/drift-cli/src/drift_cli/commands/` | Click CLI subcommands |
+| `packages/drift-config/src/drift_config/` | Pydantic-based configuration with defaults |
+| `packages/drift-sdk/src/drift_sdk/models/` | Core data models: `Finding`, `ParseResult`, `RepoAnalysis` |
+| `src/drift/` | Backward-compat re-export stubs only (ADR-100) — do not edit |
 
 ---
 
@@ -221,33 +222,33 @@ Bei Drift-Fix-Loops gezielte Tests unmittelbar nach jeder Dateiänderung ausfüh
 
 | Geänderte Datei | Empfohlene Tests |
 |---|---|
-| `src/drift/signals/architecture_violation*` | `pytest tests/test_avs_*.py -q --tb=short` |
-| `src/drift/signals/doc_impl_drift*` | `pytest tests/test_dia_*.py -q --tb=short` |
-| `src/drift/signals/explainability_deficit*` | `pytest tests/test_eds_*.py -q --tb=short` |
-| `src/drift/signals/mutant_duplicates*` | `pytest tests/test_mutant_duplicates*.py -q --tb=short` |
-| `src/drift/signals/dead_code_accumulation*` | `pytest tests/test_dead_code*.py -q --tb=short` |
-| `src/drift/signals/pattern_fragmentation*` | `pytest tests/test_pattern_fragmentation*.py -q --tb=short` |
-| `src/drift/signals/naming_contract*` | `pytest tests/test_naming_contract*.py -q --tb=short` |
-| `src/drift/signals/test_polarity_deficit*` | `pytest tests/test_test_polarity_deficit*.py -q --tb=short` |
-| `src/drift/signals/cognitive_complexity*` | `pytest tests/test_cognitive_complexity*.py -q --tb=short` |
-| `src/drift/signals/circular_import*` | `pytest tests/test_circular_import*.py -q --tb=short` |
-| `src/drift/signals/guard_clause*` | `pytest tests/test_guard_clause*.py -q --tb=short` |
-| `src/drift/signals/insecure_default*` | `pytest tests/test_insecure_default*.py -q --tb=short` |
-| `src/drift/signals/missing_authorization*` | `pytest tests/test_missing_authorization*.py -q --tb=short` |
-| `src/drift/signals/hardcoded_secret*` | `pytest tests/test_hardcoded_secret*.py -q --tb=short` |
-| `src/drift/signals/exception_contract*` | `pytest tests/test_exception_contract*.py -q --tb=short` |
-| `src/drift/signals/fan_out_explosion*` | `pytest tests/test_fan_out_explosion*.py -q --tb=short` |
-| `src/drift/signals/cohesion_deficit*` | `pytest tests/test_cohesion_deficit*.py -q --tb=short` |
-| `src/drift/signals/bypass_accumulation*` | `pytest tests/test_bypass_accumulation*.py -q --tb=short` |
-| `src/drift/signals/*` (andere) | `pytest tests/test_precision_recall.py tests/test_mirofish_signal_improvements.py -q --tb=short` |
-| `src/drift/api.py` | `pytest tests/test_brief.py tests/test_integration.py tests/test_incremental.py tests/test_fix_actionability.py tests/test_nudge.py -q --tb=short` |
-| `src/drift/mcp_server.py` | `pytest tests/test_mcp_copilot.py tests/test_mcp_hardening.py tests/test_tool_metadata.py tests/test_negative_context_export.py -q --tb=short` |
-| `src/drift/output/*` | `pytest tests/test_json_output.py tests/test_csv_output.py tests/test_sarif_contract.py tests/test_output_golden.py tests/test_agent_tasks.py -q --tb=short` |
-| `src/drift/ingestion/*` | `pytest tests/test_ast_parser.py tests/test_file_discovery.py tests/test_scope_resolver.py tests/test_typescript_parser.py -q --tb=short` |
-| `src/drift/config.py` | `pytest tests/test_config.py tests/test_config_validate.py tests/test_model_consistency.py -q --tb=short` |
-| `src/drift/commands/*` | `pytest tests/test_self_command.py tests/test_patterns_command.py tests/test_ci_reality.py -q --tb=short` |
-| `src/drift/session.py` | `pytest tests/test_session.py -q --tb=short` |
-| `src/drift/incremental.py` | `pytest tests/test_incremental.py tests/test_nudge.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/architecture_violation*` | `pytest tests/test_avs_*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/doc_impl_drift*` | `pytest tests/test_dia_*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/explainability_deficit*` | `pytest tests/test_eds_*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/mutant_duplicates*` | `pytest tests/test_mutant_duplicates*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/dead_code_accumulation*` | `pytest tests/test_dead_code*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/pattern_fragmentation*` | `pytest tests/test_pattern_fragmentation*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/naming_contract*` | `pytest tests/test_naming_contract*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/test_polarity_deficit*` | `pytest tests/test_test_polarity_deficit*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/cognitive_complexity*` | `pytest tests/test_cognitive_complexity*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/circular_import*` | `pytest tests/test_circular_import*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/guard_clause*` | `pytest tests/test_guard_clause*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/insecure_default*` | `pytest tests/test_insecure_default*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/missing_authorization*` | `pytest tests/test_missing_authorization*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/hardcoded_secret*` | `pytest tests/test_hardcoded_secret*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/exception_contract*` | `pytest tests/test_exception_contract*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/fan_out_explosion*` | `pytest tests/test_fan_out_explosion*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/cohesion_deficit*` | `pytest tests/test_cohesion_deficit*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/bypass_accumulation*` | `pytest tests/test_bypass_accumulation*.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/signals/*` (andere) | `pytest tests/test_precision_recall.py tests/test_mirofish_signal_improvements.py -q --tb=short` |
+| `packages/drift-sdk/src/drift_sdk/api/` | `pytest tests/test_brief.py tests/test_integration.py tests/test_incremental.py tests/test_fix_actionability.py tests/test_nudge.py -q --tb=short` |
+| `packages/drift-mcp/src/drift_mcp/mcp_server.py` | `pytest tests/test_mcp_copilot.py tests/test_mcp_hardening.py tests/test_tool_metadata.py tests/test_negative_context_export.py -q --tb=short` |
+| `packages/drift-output/src/drift_output/*` | `pytest tests/test_json_output.py tests/test_csv_output.py tests/test_sarif_contract.py tests/test_output_golden.py tests/test_agent_tasks.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/ingestion/*` | `pytest tests/test_ast_parser.py tests/test_file_discovery.py tests/test_scope_resolver.py tests/test_typescript_parser.py -q --tb=short` |
+| `packages/drift-config/src/drift_config/` | `pytest tests/test_config.py tests/test_config_validate.py tests/test_model_consistency.py -q --tb=short` |
+| `packages/drift-cli/src/drift_cli/commands/*` | `pytest tests/test_self_command.py tests/test_patterns_command.py tests/test_ci_reality.py -q --tb=short` |
+| `packages/drift-session/src/drift_session/session.py` | `pytest tests/test_session.py -q --tb=short` |
+| `packages/drift-engine/src/drift_engine/incremental.py` | `pytest tests/test_incremental.py tests/test_nudge.py -q --tb=short` |
 | Fallback | `pytest tests/ -q --tb=short --ignore=tests/test_smoke_real_repos.py --maxfail=5` |
 
 Bei Testfehlschlag gilt: `AttributeError`/`TypeError` auf Interna → Test anpassen; `AssertionError` auf Public-API-Vertrag → Production-Fix überdenken. Vollständiger Entscheidungsbaum: `.github/prompts/drift-fix-loop.prompt.md` (Schritt 3b).
@@ -445,8 +446,8 @@ The `.githooks/pre-push` hook enforces 6 gates before code reaches the remote. T
 | **Changelog** | `feat:` or `fix:` commits | `CHANGELOG.md` must be updated |
 | **Version Bump** | `pyproject.toml` changed | Version must be valid SemVer and > last remote tag |
 | **Lockfile Sync** | `pyproject.toml` changed | `uv.lock` must exist and be synchronized |
-| **Public API Docstrings** | `src/drift/` changes | New public functions must have docstrings |
-| **Risk Audit (§18)** | `src/drift/signals/`, `ingestion/`, `output/` changes | At least one audit artifact under `audit_results/` must be updated |
+| **Public API Docstrings** | `packages/drift-*/` or `src/drift/` changes | New public functions must have docstrings |
+| **Risk Audit (§18)** | `packages/drift-engine/src/drift_engine/signals/`, `ingestion/`, `packages/drift-output/` changes | At least one audit artifact under `audit_results/` must be updated |
 
 ### Generating Feature Evidence before a feat: commit
 

--- a/docs/decisions/ADR-100-uv-workspace-monorepo-capability-split.md
+++ b/docs/decisions/ADR-100-uv-workspace-monorepo-capability-split.md
@@ -1,0 +1,233 @@
+---
+id: ADR-100
+status: proposed
+date: 2026-05-01
+supersedes: []
+---
+
+# ADR-100: uv Workspace Monorepo mit physischen Capability-Paketen
+
+## Kontext
+
+ADR-099 hat VSA als **Konvention** innerhalb des bestehenden `src/drift/`-Layouts eingeführt
+und physische Verzeichnisumstellungen bewusst ausgeschlossen. Der verbleibende Hauptreibungspunkt
+ist ein anderer: Coding-Agenten laden beim Bearbeiten einer Aufgabe (z.B. "fix MCP routing")
+den gesamten `src/drift/`-Kontext (80+ Dateien, 343 Module) und können den für die Aufgabe
+relevanten Code nicht von anderen Capabilities abgrenzen.
+
+ADR-100 **ergänzt** ADR-099 (insbesondere die dort gesetzten Grenzen zur Signal-Slicierung)
+und ersetzt ADR-099 nicht.
+
+Das führt zu:
+- Übermäßigem Kontext-Blast bei Agent-Tasks (kein klares Scope-Signal)
+- Agent-Guards müssen auf Dateiebene gewartet werden statt auf Paketebene zu stehen
+- `make test-for FILE=src/drift/mcp_server.py` läuft immer die volle Suite ohne natürliche
+  Test-Scope-Grenze
+
+Grundlage: Circular-Import-Analyse (2026-05-01) ergab **keine zirkulären Abhängigkeiten**
+in `src/drift/` — die physische Trennung ist damit ohne vorherige Entkopplungsarbeit möglich.
+
+## Entscheidung
+
+Drift migriert schrittweise zu einem **uv Workspace Monorepo** mit physisch getrennten
+Capability-Paketen unter `packages/`. Build-Backend bleibt hatchling je Paket.
+PyPI-Distribution erfolgt weiterhin ausschließlich über das Meta-Paket `drift-analyzer`.
+Die Slice-Pakete werden **nicht** eigenständig auf PyPI released.
+
+### Zielstruktur
+
+```
+drift/                              # Workspace-Root
+├── pyproject.toml                  # [tool.uv.workspace] members=["packages/*"]
+├── uv.lock                         # workspace-weites Lockfile (ersetzt Root-Lockfile)
+├── packages/
+│   ├── drift-config/               # config/, profiles.py, rules/
+│   │   ├── pyproject.toml          # hatchling, no upstream deps
+│   │   ├── src/drift_config/
+│   │   └── tests/
+│   ├── drift-sdk/                  # api/, types.py, models/
+│   │   ├── pyproject.toml          # depends: drift-config
+│   │   ├── src/drift_sdk/
+│   │   └── tests/
+│   ├── drift-engine/               # signals/, scoring/, ingestion/, pipeline.py, analyzer.py
+│   │   ├── pyproject.toml          # depends: drift-sdk, drift-config
+│   │   ├── src/drift_engine/
+│   │   └── tests/
+│   ├── drift-output/               # output/, finding_rendering.py, recommendations.py
+│   │   ├── pyproject.toml          # depends: drift-sdk
+│   │   ├── src/drift_output/
+│   │   └── tests/
+│   ├── drift-session/              # session.py, session_*.py, outcome_*/, reward_chain.py
+│   │   ├── pyproject.toml          # depends: drift-engine, drift-output
+│   │   ├── src/drift_session/
+│   │   └── tests/
+│   ├── drift-mcp/                  # mcp_server.py, mcp_router_*.py, mcp_orchestration.py
+│   │   ├── pyproject.toml          # depends: drift-engine, drift-session, drift-output
+│   │   ├── src/drift_mcp/
+│   │   └── tests/
+│   ├── drift-cli/                  # commands/, cli.py
+│   │   ├── pyproject.toml          # depends: alle slice packages
+│   │   ├── src/drift_cli/
+│   │   └── tests/
+│   └── drift/                      # Meta-Paket (PyPI: drift-analyzer)
+│       ├── pyproject.toml          # aggregiert alle packages, entry-points hier
+│       └── src/drift/              # re-exportiert Public API für Backward-Compat
+├── tests/                          # Integration-Tests (cross-slice, unveränderter Pfad)
+└── extensions/vscode-drift/        # unverändert
+```
+
+### Dependency-DAG (strikt leftward, kein Cross-Slice-Import)
+
+```
+drift-config
+└── drift-sdk
+  ├── drift-engine
+  │   └── drift-session
+  │       └── drift-mcp
+  └── drift-output
+    ├── drift-session
+    └── drift-mcp
+
+drift-cli
+├── drift-config
+├── drift-sdk
+├── drift-engine
+├── drift-output
+├── drift-session
+└── drift-mcp
+
+drift (meta)
+└── drift-cli
+```
+
+### Migrationsstrategie (iterativ, Phase für Phase)
+
+Jede Phase ist ein eigenständiger PR. CI muss nach jeder Phase grün bleiben.
+Backward-Compat wird durch das Meta-Paket-Re-export sichergestellt — bestehende
+`from drift.X import Y`-Imports in `tests/` und Consumers müssen nicht sofort geändert werden.
+
+**Scope-Abgrenzung `drift-sdk` (Phase 2):**
+`drift-sdk` enthält `types.py` und `models/` (7 Untermodule: `_enums`, `_git`,
+`_parse`, `_patch`, `_policy`, `_context`, `_agent`, `_findings`).
+`api/` wird **nicht** in Phase 2 migriert: Die `api/`-Module haben Runtime-Imports auf
+`drift.analyzer` (Engine-Layer) — eine Migration würde Kreisabhängigkeiten erzeugen.
+`api/` wandert in Phase 3 zusammen mit `drift-engine`.
+
+| Phase | Inhalt | Voraussetzung |
+|-------|--------|---------------|
+| 0 ✅ | ADR anlegen, Circular-Import-Analyse, feat-start | keine |
+| 1 ✅ | uv Workspace Root + `drift-config` extrahieren | Phase 0 |
+| 2 ✅ | `drift-sdk` extrahieren (`types.py`, `models/`) | Phase 1 |
+| 3 ✅ | `drift-engine` extrahieren | Phase 2 |
+| 4a ✅ | `drift-output` extrahieren | Phase 3 |
+| 4b ✅ | `drift-session` extrahieren | Phase 4a |
+| 5a ✅ | `drift-mcp` extrahieren | Phase 4b |
+| 5b ✅ | `drift-cli` extrahieren | Phase 5a |
+| 6a ✅ | Meta-Paket (`packages/drift`) + Re-export-Stubs | Phase 5b |
+| 6b ✅ | Workflow- und Path-Filter-Migration (`src/drift/**` -> `packages/**`) | Phase 6a |
+| 6c _(in 7a aufgegangen)_ | ~~Docs/Guard-Skills/Cleanup (u.a. `DEVELOPER.md`, Guard-Pfade)~~ | Phase 6b |
+| 7a ✅ | Guard-Skills auf `packages/drift-*/`-Pfade aktualisieren; `DEVELOPER.md` auf workspace-weite `uv sync`-Anleitung umstellen; veraltete `src/drift/**`-Referenzen in Docs und Instructions bereinigen | Phase 6b |
+
+### Was explizit **nicht** entschieden wird
+
+- Keine eigenständigen PyPI-Releases der Slice-Pakete.
+- Kein Wechsel von hatchling zu einem anderen Build-Backend.
+- Keine Änderungen an Signal-/Scoring-/Output-Logik als Teil der Migration.
+- Keine Änderung der Import-Pfade in `tests/` bis Phase 6 (Meta-Paket-Re-export hält sie valide).
+- Keine Slicierung von `signals/` entlang einzelner Signal-Klassen (ADR-099 §3 bleibt gültig).
+
+### Meta-Paket-Grenze (`packages/drift/src/drift/`)
+
+`packages/drift/src/drift/` ist in dieser Migration ein **reiner Kompatibilitäts-Layer**:
+
+- erlaubt sind Re-export-Stubs, Entry-Point-Bindings und dünne Import-Weiterleitungen
+- nicht erlaubt ist neue produktive Fachlogik im Meta-Paket
+
+Damit bleibt die Suchfläche für `drift.*` eindeutig: produktive Logik lebt in Slice-Paketen,
+das Meta-Paket hält nur Backward-Compat.
+
+## Begründung
+
+**Warum physische Pakete statt nur logische Guards?**
+Logische Guards (`.github/skills/guard-src-drift-mcp/`) müssen manuell mit dem Code synchron
+gehalten werden. Ein physisches Paket ist eine klare, unveränderliche Scope-Grenze, die
+jeder Agent sofort aus dem Dateisystem ablesen kann ohne Guard-Dateien zu kennen.
+
+**Warum uv Workspaces?**
+Das Repo nutzt bereits `uv.lock` und `uv sync`. uv Workspaces sind die native Erweiterung
+ohne Build-Backend-Wechsel. Alternativ wäre `pip` editable installs möglich, aber ohne
+Workspace-weites Lockfile-Management.
+
+**Warum Meta-Paket statt direkter Import-Pfad-Migration?**
+300+ Testdateien importieren `from drift.X`. Eine sofortige Migration würde alle PRs
+blockieren. Das Meta-Paket-Re-export entkoppelt Migrations-Timeline von Test-Stabilität.
+
+**Warum bleibt `drift-engine` zunächst breit?**
+`signals/`, `scoring/`, `ingestion/`, `pipeline.py` und `analyzer.py` werden bewusst zusammen
+verschoben, um zuerst die Capability-Grenze gegenüber Session/MCP/CLI zu stabilisieren.
+Eine feinere Zerlegung innerhalb von `drift-engine` ist als Folgeentscheidung möglich,
+aber nicht Teil dieser ADR (ADR-099 §3 bleibt maßgeblich).
+
+**Verworfene Alternativen:**
+
+- **Nur logische Guards ohne physische Trennung:** Scope-Signal bleibt schwach; Agenten
+  müssen Guard-Dateien kennen und befolgen.
+- **Eigenständige PyPI-Releases der Slice-Pakete:** Erhöht Release-Komplexität massiv
+  ohne messbaren Nutzen für das Haupt-Use-Case (Agenten-Kontext-Reduktion).
+- **Domain-driven Microservices:** widerspricht Single-Process-CLI-/MCP-Modell (ADR-099).
+
+## Konsequenzen
+
+**Akzeptierte Trade-offs:**
+
+- Workspace-Root `pyproject.toml` verliert `[project]`-Sektion nach Phase 6 — das
+  Root-Paket ist dann kein installierbares Paket mehr, nur Workspace-Koordinator.
+- 50+ GitHub Workflows müssen in Phase 6b `src/drift/**` → `packages/**` path-filter
+  aktualisieren.
+- `hatch build` muss für das Meta-Paket in `packages/drift/` aufgerufen werden (nicht Root).
+- Migration POLICY §18: betrifft keine Signale/Scoring/Output-Verträge/Trust-Boundaries →
+  keine Audit-Artefakt-Pflicht durch dieses ADR selbst. Audit-Pflichten greifen wenn
+  einzelne Slice-Migrationen Domain Core berühren (insbesondere Phase 3: drift-engine).
+
+**Folgepflichten:**
+
+- Guard-Skills in `.github/skills/guard-src-drift-*/` müssen nach Phase 6c auf neue
+  Pfade `packages/drift-*/` aktualisiert werden.
+- `DEVELOPER.md` muss nach Phase 6c auf workspace-weite `uv sync`-Anleitung umgestellt werden.
+- `drift.schema.json`-Konsistenztest (ADR via tests/test_config_schema.py) bleibt unverändert
+  gültig — liegt im Meta-Paket.
+
+### Rollback- und Replan-Regel
+
+Wenn eine Phase ungeplante Kopplungen aufdeckt und nicht innerhalb von zwei Wochen
+abschließbar ist, wird die laufende Migrationsumsetzung für diese Phase eingefroren,
+es erfolgt ein Replan-PR mit dokumentierter Ursache und eine ADR-100-Neubewertung,
+bevor weitere Slice-Phasen gestartet werden.
+
+## Validierung
+
+Die Entscheidung gilt als **bestätigt** nach Abschluss von Phase 1 (`drift-config`), wenn:
+
+1. `uv sync` im Workspace-Root ohne Fehler läuft.
+2. `pytest tests/test_config.py tests/test_config_schema.py -q` grün.
+3. `drift --version` aus dem installierten Meta-Paket korrekt auflöst.
+4. `drift analyze --repo . --exit-zero` produziert identisches Finding-Set wie vor Phase 1.
+5. `make check` vollständig grün.
+
+### Phasen-spezifische Zusatz-Gates
+
+Zusätzlich zu den fünf Basis-Kriterien gelten je Phase folgende Zusatzprüfungen:
+
+| Phase | Zusatz-Gate |
+|-------|-------------|
+| 2 (`drift-sdk`) | API- und Modell-Imports in bestehenden `from drift.X`-Callsites bleiben ohne Testanpassung auflösbar |
+| 3 (`drift-engine`) | Analyzer-Pipeline-Regressionstest gegen repräsentatives Fixture-Set (inkl. Signale + Scoring) grün |
+| 4a (`drift-output`) | CLI- und JSON/SARIF-Output-Snapshots bleiben format- und schema-kompatibel |
+| 4b (`drift-session`) | dedizierte Session-Integrationssuite (u.a. Session-Loop/Handover/Task-Graph) grün |
+| 5a (`drift-mcp`) | MCP-Router- und Tool-Contract-Tests grün, keine Routing-Regression in Session-gebundenen Tools |
+| 5b (`drift-cli`) | End-to-end CLI-Command-Dispatch inkl. Entry-Points weiterhin funktional |
+| 6a | Re-export-Stubs vollständig, `drift --version` und Kernimporte aus Consumer-Sicht unverändert |
+| 6b | Workflow-Path-Filter decken `packages/**` vollständig ab, ohne unbeabsichtigte Trigger-Lücken |
+| 7a ✅ | Guard-Skills referenzieren `packages/drift-*/`-Pfade; `DEVELOPER.md` beschreibt workspace-weiten `uv sync`-Workflow; keine `src/drift/**`-Pfad-Referenzen mehr in Docs, Instructions oder Skill-Descriptions |
+
+Referenz Policy §10 Lernzyklus: offen bis Phase-1-Validierung.


### PR DESCRIPTION
Split from #576 (ADR-100 monorepo migration). Part of the PR decomposition into atomic, reviewable units.