### PR TITLE
fix: add packages/drift to CI model-consistency install (ADR-100 drift namespace fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
               - 'src/drift/signals/**'
               - 'src/drift/scoring/**'
               - 'src/drift/ingestion/**'
+              - 'packages/**'
               - 'tests/**'
             docs:
               - 'docs/**'
@@ -117,8 +118,21 @@ jobs:
 
       - name: Check model consistency
         # [win-only] PowerShell invocation on Windows runner.
+        # Requires workspace packages (drift_engine) to be importable.
+        # packages/drift (drift-analyzer meta) provides drift.signal_registry
+        # stub so generate_llms_txt.py resolves correctly (ADR-100 monorepo).
         shell: powershell
         run: |
+          & $env:PYTHON_BIN -m pip install --quiet `
+            -e packages/drift `
+            -e packages/drift-config `
+            -e packages/drift-engine `
+            -e packages/drift-sdk `
+            -e packages/drift-output `
+            -e packages/drift-session `
+            -e packages/drift-mcp `
+            -e packages/drift-verify `
+            -e packages/drift-cli
           & $env:PYTHON_BIN scripts/check_model_consistency.py
 
   test:
@@ -245,6 +259,16 @@ jobs:
         run: |
           & $env:PYTHON_BIN -m pip config set global.cache-dir $env:PIP_CACHE_DIR
           & $env:PYTHON_BIN -m pip install --upgrade pip
+          # Install workspace packages FIRST so pip resolves them locally.
+          & $env:PYTHON_BIN -m pip install `
+            -e packages/drift-config `
+            -e packages/drift-engine `
+            -e packages/drift-sdk `
+            -e packages/drift-output `
+            -e packages/drift-session `
+            -e packages/drift-mcp `
+            -e packages/drift-verify `
+            -e packages/drift-cli
           $maxRetries = 3
           for ($i = 1; $i -le $maxRetries; $i++) {
             & $env:PYTHON_BIN -m pip install -e ".[dev,mcp]"
@@ -281,7 +305,7 @@ jobs:
       - name: Dead code detection with vulture
         shell: pwsh
         run: |
-          & $env:PYTHON_BIN -m vulture src/drift --min-confidence 65
+          & $env:PYTHON_BIN -m vulture src/drift --min-confidence 65 --ignore-names cls
 
       - name: Run tests with coverage (reference Python, Linux)
         if: matrix.python-version == '3.12' && runner.os == 'Linux'
@@ -498,6 +522,15 @@ jobs:
         shell: powershell
         run: |
           python -m pip install --upgrade pip
+          python -m pip install `
+            -e packages/drift-config `
+            -e packages/drift-engine `
+            -e packages/drift-sdk `
+            -e packages/drift-output `
+            -e packages/drift-session `
+            -e packages/drift-mcp `
+            -e packages/drift-verify `
+            -e packages/drift-cli
           python -m pip install -e ".[dev]"
 
       - name: Run fast smoke profile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,34 @@
-## [2.50.0] - 2026-05-03
+## [2.50.0] - 2026-05-01
 
-Short version: Add Copilot coding agent setup — issue template, brief-check workflow, labels, and contributor docs.
+Short version: ADR-100 monorepo CI fixes, VSA migration Phase 1, and script catalog improvements.
 
 ### Changed
-- Add Copilot coding agent setup: issue template, brief-check workflow, labels, and contract test
+- merge main into feat/adr100-phase7a-cleanup; add script categories to catalog.py and scripts/README.md
 
 ### Fixed
-- address PR review — cleanup on label removal, consistent section names, direct yaml import
+- install workspace packages in all CI workflows and drift-agent-gate (ADR-100 monorepo)
+- ruff, shellcheck, mypy re-exports, UTF-8 BOM, and end-of-file fixes across packages/
+- resolve failing CI checks for PR 576 (CodeQL, Bandit, uninitialized vars)
+- add packages/drift to CI model-consistency install step (ADR-100 drift.signal_registry resolution)
+
+### Added
+- Phase 1 complete — VSA migration infrastructure setup (T001-T005)
 
 ## [2.49.0] - 2026-04-30
 
-Short version: drift pr-loop — agent-driven PR review loop command (FR-001–FR-013).
+Short version: drift pr-loop — agent-driven PR review loop command (FR-001–FR-013). Agent harness FU-002 FU-004: neutral ab-harness mock mode and failed-turn repro bundle. New: `@drift-analyzer/sdk` npm package for Node.js/TypeScript programmatic access.
 
 ### Added
-- add `drift pr-loop` command: agent-driven PR review loop (FR-001–FR-013)
+- `drift pr-loop` command: agent-driven PR review loop (FR-001–FR-013)
+- Monorepo ADR-100 capability-split rollout (uv workspace + `drift-config`/`drift-sdk`/`drift-engine`/`drift-session`/`drift-mcp`/`drift-cli`) plus outcome-first validation runner
+- `@drift-analyzer/sdk` npm package for Node.js/TypeScript programmatic access (`analyze`, `check`, `brief`, `fix-plan`)
 
 ### Fixed
-- resolve PR #563 review issues — PollTimeoutError partial verdicts, gate_output keys, CHANGELOG Short version, evidence tests field, workflow branch scope
+- resolve PR #563 review issues; harden output stubs; restore brief command console state; FU-002/004 ab-harness mock mode
 
 ### Changed
-- update harness prompt and skill catalog
+- add packages/ to repo-root-allowlist; phase 6b CI/workflow path-filters (ADR-100)
+- prevent post-commit hook from re-inserting CHANGELOG bullet on amend
 
 ## [2.48.5] - 2026-04-29
 


### PR DESCRIPTION
Split from #576 (ADR-100 monorepo migration). Part of the PR decomposition into atomic, reviewable units.