### PR TITLE
fix: consolidate pip install calls in python-setup action

### DIFF
--- a/.github/actions/python-setup/action.yml
+++ b/.github/actions/python-setup/action.yml
@@ -28,4 +28,15 @@ runs:
       shell: bash
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e ".[dev]"
+        # Install all workspace capability packages and root in a single pip call
+        # so pip resolves the full cross-package dependency graph at once.
+        python -m pip install \
+          -e packages/drift-config \
+          -e packages/drift-engine \
+          -e packages/drift-sdk \
+          -e packages/drift-output \
+          -e packages/drift-session \
+          -e packages/drift-mcp \
+          -e packages/drift-verify \
+          -e packages/drift-cli \
+          -e ".[dev]"


### PR DESCRIPTION
Split from #576 (ADR-100 monorepo migration). Part of the PR decomposition into atomic, reviewable units.