### PR TITLE
fix: resolve CI failures — pre-commit-config.yaml and cockpit test-results cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
         exclude: "^(\\.specify/|specs/|\\.github/agents/speckit\\.)"
       - id: end-of-file-fixer
-        exclude: "^(\\.specify/|specs/|\\.github/agents/speckit\\.|\\.vscode/drift-session\\.json$|playground/.*\\.tsbuildinfo$)"
+        exclude: "^(\\.specify/|specs/|\\.github/agents/speckit\\.|\\.vscode/drift-session\\.json$|playground/.*\\.tsbuildinfo$|packages/cockpit-ui/\\.next/|packages/cockpit-ui/playwright-report/|packages/cockpit-ui/test-results/|td_parsed\\.json$|result_line\\.txt$|_bisect_tests\\.txt$|last_nudge\\.json$|last_scan\\.json$|output\\.json$|(^|[\\/])nudge_baselines[\\/])"
       - id: check-yaml
         args: [--allow-multiple-documents, --unsafe]
         exclude: "^conda\\.recipe/"
@@ -33,6 +33,12 @@ repos:
           - "(^|[\\\\/])benchmarks[\\\\/]corpus[\\\\/]\\.drift-cache-golden[\\\\/]parse([\\\\/]|$)"
           - --exclude-files
           - "(^|[\\\\/])(benchmark_results|audit_results|site|docs-site|\\.hypothesis|\\.venv|dist|build|\\.mypy_cache|\\.pytest_cache|\\.ruff_cache|\\.drift-cache|work_artifacts|master-backlog|tagesplanung)([\\\\/]|$)"
+          - --exclude-files
+          - "(^|[\\\\/])packages[\\\\/]cockpit-ui[\\\\/]\\.next([\\\\/]|$)"
+          - --exclude-files
+          - "(^|[\\\\/])(last_nudge|last_scan|output)\\.json$|(^|[\\\\/])nudge_baselines[\\\\/]"
+          - --exclude-files
+          - "(^|[\\\\/])td_parsed\\.json$"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.1

--- a/packages/cockpit-ui/test-results/.last-run.json
+++ b/packages/cockpit-ui/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/scripts/generate_llms_txt.py
+++ b/scripts/generate_llms_txt.py
@@ -39,12 +39,23 @@ from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
-# Make `src/` importable when this script is run standalone (without an
-# installed drift package). The signal_registry is the authoritative
-# source for signals, so we import it rather than re-declaring data.
-sys.path.insert(0, str(_REPO_ROOT / "src"))
+# Make signal_registry importable when this script is run standalone.
+# ADR-100: canonical implementation moved to drift_engine.signal_registry.
+# Search order: installed package first, then monorepo workspace paths.
+for _p in [
+    _REPO_ROOT / "packages" / "drift" / "src",       # compat re-export stub
+    _REPO_ROOT / "packages" / "drift-engine" / "src", # canonical implementation
+    _REPO_ROOT / "src",                               # legacy layout (pre-ADR-100)
+]:
+    if _p.exists():
+        _ps = str(_p)
+        if _ps not in sys.path:
+            sys.path.insert(0, _ps)
 
-from drift.signal_registry import SignalMeta, get_all_meta  # noqa: E402
+try:
+    from drift.signal_registry import SignalMeta, get_all_meta  # noqa: E402
+except (ImportError, ModuleNotFoundError):
+    from drift_engine.signal_registry import SignalMeta, get_all_meta  # noqa: E402, F401
 
 LLMS_TXT = _REPO_ROOT / "llms.txt"
 PYPROJECT = _REPO_ROOT / "pyproject.toml"


### PR DESCRIPTION
Split from #576 (ADR-100 monorepo migration). Part of the PR decomposition into atomic, reviewable units.