### PR TITLE
refactor: add drift meta package compatibility layer (ADR-100)

### DIFF
--- a/packages/drift/pyproject.toml
+++ b/packages/drift/pyproject.toml
@@ -1,0 +1,167 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "drift-analyzer"
+version = "2.49.0"
+description = "Catches structural erosion from AI-generated code — the bugs that pass all your tests"
+readme = "../../README.md"
+license = "MIT"
+requires-python = ">=3.11"
+authors = [
+    { name = "Mick Gottschalk", email = "mick.gottsch@gmail.com" },
+]
+keywords = [
+    "ai",
+    "ai-assisted-development",
+    "code-analysis",
+    "code-quality",
+    "architecture",
+    "architecture-drift",
+    "architectural-erosion",
+    "architectural-linter",
+    "codebase-coherence",
+    "developer-tools",
+    "developer-tooling",
+    "github-actions",
+    "linter",
+    "pre-commit",
+    "technical-debt",
+    "github-action",
+    "sarif",
+    "static-analysis",
+    "structural-analysis",
+    "dependency-analysis",
+    "monorepo",
+    "dependency-cycle-detection",
+    "import-analysis",
+    "python-linter",
+    "coherence-check",
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Software Development :: Build Tools",
+    "Topic :: Software Development :: Testing",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+    "Topic :: Utilities",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Environment :: Console",
+    "Typing :: Typed",
+]
+dependencies = [
+    "click>=8.1",
+    "rich>=13.0",
+    "pyyaml>=6.0",
+    "pydantic>=2.0",
+    "gitpython>=3.1",
+    "networkx>=3.0",
+    "drift-config",
+    "drift-sdk",
+    "drift-engine",
+    "drift-output",
+    "drift-session",
+    "drift-mcp",
+    "drift-cli",
+]
+
+[tool.uv.sources]
+drift-config = { workspace = true }
+drift-sdk = { workspace = true }
+drift-engine = { workspace = true }
+drift-output = { workspace = true }
+drift-session = { workspace = true }
+drift-mcp = { workspace = true }
+drift-cli = { workspace = true }
+
+[project.urls]
+Homepage = "https://mick-gsk.github.io/drift/"
+Repository = "https://github.com/mick-gsk/drift"
+Issues = "https://github.com/mick-gsk/drift/issues"
+Discussions = "https://github.com/mick-gsk/drift/discussions"
+Documentation = "https://mick-gsk.github.io/drift/"
+Changelog = "https://github.com/mick-gsk/drift/blob/main/CHANGELOG.md"
+Releases = "https://github.com/mick-gsk/drift/releases"
+CI = "https://github.com/mick-gsk/drift/actions/workflows/ci.yml"
+Funding = "https://github.com/sponsors/mick-gsk"
+
+[project.optional-dependencies]
+# Analyze TypeScript, TSX, JavaScript, JSX files via tree-sitter
+typescript = [
+    "tree-sitter>=0.22",
+    "tree-sitter-typescript>=0.22",
+]
+# Semantic similarity matching for pattern fragmentation detection
+embeddings = [
+    "sentence-transformers>=3.0",
+    "faiss-cpu>=1.7",
+    "numpy>=1.26",
+]
+# Parse Markdown files for documentation-level analysis
+markdown = [
+    "mistune>=3.0",
+]
+# Enable MCP server mode for AI agent orchestration (Copilot, Cursor, Claude)
+mcp = [
+    "mcp[cli]>=1.2.0,<2.0",
+]
+# Auto-apply patches for high-confidence findings (add_docstring, add_guard_clause)
+autopatch = [
+    "libcst>=1.0",
+]
+# Live file-watching for `drift watch` (re-analyzes on save)
+watch = [
+    "watchfiles>=1.0",
+]
+# Fast JSON serialization/deserialization for parse cache (optional; stdlib fallback)
+fast-json = [
+    "orjson>=3.9",
+]
+# LLM-backed intent classification via litellm (optional)
+llm = [
+    "litellm>=1.0",
+]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-cov>=5.0",
+    "pytest-xdist>=3.6",
+    "pytest-timeout>=2.3",
+    "libcst>=1.0",
+    "textual>=0.80",
+    "mypy>=1.10",
+    "ruff>=0.4",
+    "mistune>=3.0",
+    "numpy>=1.26",
+    "vulture>=2.11",
+    "hypothesis>=6.100",
+    "mutmut>=2.4",
+    "pytest-benchmark>=4.0",
+    "python-semantic-release>=9.0",
+    "jsonschema>=4.0",
+    "scipy>=1.13",
+    "openai>=1.30",
+    "python-multipart>=0.0.26",
+    "setuptools>=78.1.1",
+    # tree-sitter required for TypeScript signal tests (tsb_ts_tp, etc.)
+    "tree-sitter>=0.22",
+    "tree-sitter-typescript>=0.22",
+]
+all = [
+    "drift-analyzer[typescript,embeddings,markdown,mcp,llm,dev]",
+]
+
+[project.scripts]
+drift = "drift.cli:safe_main"
+drift-analyzer = "drift.cli:safe_main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/drift"]

--- a/packages/drift/src/drift/__init__.py
+++ b/packages/drift/src/drift/__init__.py
@@ -1,0 +1,32 @@
+"""Meta compatibility package for ADR-100 phase 6a.
+
+This package keeps ``drift.*`` import paths stable while capability modules
+are moved into dedicated workspace packages.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+
+def _resolve_version() -> str:
+    """Resolve installed package version for CLI/output metadata."""
+    for package_name in ("drift-analyzer", "drift-analyzer-meta", "drift"):
+        try:
+            return version(package_name)
+        except PackageNotFoundError:
+            continue
+    return "0.0.0"
+
+
+# During workspace development, keep legacy ``src/drift`` on package search path
+# so all existing re-export stubs remain importable without duplicating modules.
+_workspace_src = Path(__file__).resolve().parents[4] / "src" / "drift"
+if _workspace_src.exists():
+    path_entry = str(_workspace_src)
+    if path_entry not in __path__:
+        __path__.append(path_entry)
+
+
+__version__ = _resolve_version()

--- a/packages/drift/src/drift/__main__.py
+++ b/packages/drift/src/drift/__main__.py
@@ -1,0 +1,6 @@
+"""Module entry point for ``python -m drift``."""
+
+from drift_cli.cli import safe_main
+
+if __name__ == "__main__":
+    safe_main()

--- a/packages/drift/src/drift/cli.py
+++ b/packages/drift/src/drift/cli.py
@@ -1,0 +1,6 @@
+"""Alias stub -- drift_cli.cli (ADR-100 phase 6a)."""
+
+import importlib as _importlib
+import sys as _sys
+
+_sys.modules[__name__] = _importlib.import_module("drift_cli.cli")

--- a/packages/drift/tests/test_meta_imports.py
+++ b/packages/drift/tests/test_meta_imports.py
@@ -1,0 +1,76 @@
+"""Meta-package import contract tests (ADR-100 Phase 6a).
+
+Verifies that all critical ``drift.*`` import paths remain stable after the
+capability split. Each assertion confirms the re-export stub / __path__
+extension correctly delegates to the target slice package.
+"""
+
+from __future__ import annotations
+
+
+def test_meta_package_version_and_cli_imports() -> None:
+    import drift
+    import drift.cli
+
+    assert isinstance(drift.__version__, str)
+    assert drift.__version__
+    assert drift.cli.__name__ == "drift_cli.cli"
+
+
+def test_drift_config_delegates_to_drift_config_package() -> None:
+    from drift.config import DriftConfig
+
+    assert DriftConfig.__module__.startswith("drift_config")
+
+
+def test_drift_models_exports_core_types() -> None:
+    from drift.models import AgentTask, AnalysisStatus  # noqa: F401
+
+
+def test_drift_signals_base_delegates_to_drift_engine() -> None:
+    from drift.signals.base import BaseSignal
+
+    assert BaseSignal.__module__.startswith("drift_engine")
+
+
+def test_drift_ingestion_delegates_to_drift_engine() -> None:
+    from drift.ingestion.ast_parser import parse_file  # noqa: F401
+    from drift.ingestion.file_discovery import discover_files  # noqa: F401
+
+
+def test_drift_scoring_delegates_to_drift_engine() -> None:
+    from drift.scoring.engine import composite_score  # noqa: F401
+
+
+def test_drift_output_delegates_to_drift_output_package() -> None:
+    import drift.output
+
+    assert drift.output.__name__ == "drift_output"
+    from drift.output import analysis_to_json  # noqa: F401
+
+
+def test_drift_session_delegates_to_drift_session_package() -> None:
+    import drift.session
+
+    assert drift.session.__name__ == "drift_session.session"
+    from drift.session import DriftSession  # noqa: F401
+
+
+def test_drift_mcp_server_delegates_to_drift_mcp_package() -> None:
+    import drift.mcp_server
+
+    assert drift.mcp_server.__name__ == "drift_mcp.mcp_server"
+
+
+def test_drift_commands_delegates_to_drift_cli_package() -> None:
+    import drift.commands
+
+    assert drift.commands.__name__ == "drift.commands"
+
+
+def test_drift_main_entrypoint() -> None:
+    import drift.__main__  # noqa: F401
+    from drift.cli import safe_main
+
+    assert callable(safe_main)
+    assert safe_main.__module__ == "drift_cli.cli"


### PR DESCRIPTION
Split from #576 (ADR-100 monorepo migration). Part of the PR decomposition into atomic, reviewable units.