### PR TITLE
fix: stop changelog bot from rewriting PR branch heads

### DIFF
--- a/.github/workflows/changelog-auto-insert.yml
+++ b/.github/workflows/changelog-auto-insert.yml
@@ -9,12 +9,9 @@ name: changelog-auto-insert
 
 on:
   push:
-    # Restrict to integration branches to avoid bot commits on every feature branch.
+    # Only run on main so PR branch heads are never rewritten by bot commits.
     branches:
       - "main"
-      - "feat/**"
-      - "fix/**"
-      - "chore/**"
 
 jobs:
   insert:


### PR DESCRIPTION
Split from #576 (ADR-100 monorepo migration). Part of the PR decomposition into atomic, reviewable units.