### PR TITLE
fix: install workspace packages in drift-agent-gate workflow

### DIFF
--- a/.github/workflows/drift-agent-gate.yml
+++ b/.github/workflows/drift-agent-gate.yml
@@ -52,17 +52,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up Python + workspace dependencies
+        uses: ./.github/actions/python-setup
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
-      - name: Install drift from workspace
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .
 
       - name: Run drift analyze
         id: analyze


### PR DESCRIPTION
Split from #576 (ADR-100 monorepo migration). Part of the PR decomposition into atomic, reviewable units.