### PR TITLE
feat: add TypeScript drift-analyzer-sdk package (ADR-102)

### DIFF
--- a/packages/drift-analyzer-sdk/README.md
+++ b/packages/drift-analyzer-sdk/README.md
@@ -1,0 +1,109 @@
+# @drift-analyzer/sdk
+
+Node.js/TypeScript SDK for [drift-analyzer](https://github.com/mick-gsk/drift).
+Calls the `drift` CLI as a child process and returns typed JSON.
+
+## Install
+
+```bash
+# 1. drift CLI (backend)
+pip install drift-analyzer
+
+# 2. SDK
+npm install @drift-analyzer/sdk
+```
+
+## Use
+
+```typescript
+import { analyze } from "@drift-analyzer/sdk";
+
+const result = await analyze(".");
+console.log(result.drift_score, result.severity);
+```
+
+That's it. `result` is fully typed — see [DriftOutput](#types) for all fields.
+
+## All commands
+
+| Function | CLI equivalent | Returns |
+|---|---|---|
+| `analyze(repo, opts?)` | `drift analyze` | `DriftOutput` |
+| `check(repo, opts?)` | `drift check` | `DriftOutput` (throws on threshold breach) |
+| `brief(task, repo, opts?)` | `drift brief` | `BriefOutput` |
+| `fixPlan(repo, opts?)` | `drift fix-plan` | `FixPlanOutput` |
+| `queryHealth()` | `drift --version` | `HealthResult` |
+
+<details>
+<summary><strong>Options reference</strong></summary>
+
+```typescript
+// analyze / check
+{ since?: number; compact?: boolean; target?: string;
+  baseline?: string; config?: string; timeoutMs?: number }
+
+// check only
+{ exitZero?: boolean }  // don't throw on threshold breach
+
+// brief
+{ scope?: string; maxGuardrails?: number; selectSignals?: string[];
+  includeNonOperational?: boolean; config?: string; timeoutMs?: number }
+
+// fixPlan
+{ findingId?: string; signal?: string; maxTasks?: number;
+  targetPath?: string; excludePaths?: string[]; includeDeferred?: boolean;
+  automationFitMin?: "low" | "medium" | "high";
+  includeNonOperational?: boolean; config?: string; timeoutMs?: number }
+```
+
+</details>
+
+## Types
+
+All types are exported from the package root.
+
+| Type | Description |
+|---|---|
+| `DriftOutput` | Full output from `analyze` and `check` |
+| `BriefOutput` | Output from `brief` |
+| `FixPlanOutput` | Output from `fix-plan` |
+| `HealthResult` | `{ ok, version, runtimePath, runtimeSource, error? }` |
+| `Severity` | `"low" \| "medium" \| "high" \| "critical"` |
+
+## Errors
+
+All errors extend `DriftSdkError`.
+
+| Class | When |
+|---|---|
+| `RuntimeNotFoundError` | `drift` not on PATH and no bundle |
+| `CommandFailedError` | non-zero exit + no JSON output |
+| `CommandTimeoutError` | exceeded `timeoutMs` |
+| `InvalidJsonPayloadError` | CLI produced no parseable JSON |
+| `UnsupportedSchemaVersionError` | future CLI version, schema changed |
+
+```typescript
+import { DriftSdkError, RuntimeNotFoundError } from "@drift-analyzer/sdk";
+
+try {
+  const result = await analyze(".");
+} catch (err) {
+  if (err instanceof RuntimeNotFoundError) {
+    console.error("Install drift: pip install drift-analyzer");
+  } else if (err instanceof DriftSdkError) {
+    console.error(err.message);
+  }
+}
+```
+
+## Runtime resolution
+
+The SDK finds `drift` in this order:
+1. `DRIFT_BIN` env var
+2. `drift` on PATH
+3. `python -m drift`
+4. Managed bundle (~/.cache/drift-analyzer-sdk/)
+
+## License
+
+MIT — see [LICENSE](../../LICENSE)

--- a/packages/drift-analyzer-sdk/package-lock.json
+++ b/packages/drift-analyzer-sdk/package-lock.json
@@ -1,0 +1,2445 @@
+{
+  "name": "@drift-analyzer/sdk",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@drift-analyzer/sdk",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^18.19.130",
+        "tsup": "^8.0.0",
+        "typescript": "^5.4.0",
+        "vitest": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/packages/drift-analyzer-sdk/package.json
+++ b/packages/drift-analyzer-sdk/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@drift-analyzer/sdk",
+  "version": "0.1.0",
+  "description": "Node.js / TypeScript SDK for drift-analyzer — programmatic access to drift analyze, check, brief, and fix-plan",
+  "license": "MIT",
+  "author": "Mick Gottschalk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mick-gsk/drift",
+    "directory": "packages/drift-analyzer-sdk"
+  },
+  "homepage": "https://mick-gsk.github.io/drift/",
+  "keywords": [
+    "drift",
+    "architecture",
+    "code-quality",
+    "static-analysis",
+    "typescript"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist --clean",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "devDependencies": {
+    "@types/node": "^18.19.130",
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/drift-analyzer-sdk/src/commands/analyze.ts
+++ b/packages/drift-analyzer-sdk/src/commands/analyze.ts
@@ -1,0 +1,55 @@
+/**
+ * analyze command adapter.
+ * Wraps: `drift analyze --repo <path> --format json [options]`
+ */
+
+import type { DriftOutput, AnalyzeOptions } from "../types.js";
+import { resolveRuntime } from "../runtime/resolver.js";
+import { runDriftCommand } from "../transport/process.js";
+
+export type { AnalyzeOptions };
+
+/**
+ * Runs `drift analyze` on the target repository and returns parsed JSON output.
+ *
+ * @param repo   Absolute or relative path to the repository root to analyse.
+ * @param options  Optional analysis configuration.
+ * @returns Parsed `DriftOutput` with full analysis results.
+ */
+export async function analyze(repo: string, options: AnalyzeOptions = {}): Promise<DriftOutput> {
+  const runtime = await resolveRuntime();
+
+  const args: string[] = [
+    "analyze",
+    "--repo",
+    repo,
+    "--format",
+    "json",
+    "--exit-zero",
+    "--progress",
+    "none",
+  ];
+
+  if (options.since !== undefined) {
+    args.push("--since-days", String(options.since));
+  }
+  if (options.compact) {
+    args.push("--compact");
+  }
+  if (options.target) {
+    args.push("--target", options.target);
+  }
+  if (options.baseline) {
+    args.push("--baseline", options.baseline);
+  }
+  if (options.config) {
+    args.push("--config", options.config);
+  }
+
+  return runDriftCommand<DriftOutput>(runtime, {
+    args,
+    cwd: repo,
+    timeoutMs: options.timeoutMs ?? 120_000,
+    exitZero: true,
+  });
+}

--- a/packages/drift-analyzer-sdk/src/commands/brief.ts
+++ b/packages/drift-analyzer-sdk/src/commands/brief.ts
@@ -1,0 +1,61 @@
+/**
+ * brief command adapter.
+ * Wraps: `drift brief --task <task> --repo <path> --format json [options]`
+ */
+
+import type { BriefOutput, BriefOptions } from "../types.js";
+import { resolveRuntime } from "../runtime/resolver.js";
+import { runDriftCommand } from "../transport/process.js";
+
+export type { BriefOptions };
+
+/**
+ * Runs `drift brief` to generate a structural task brief for agent delegation.
+ *
+ * @param task   Natural-language task description for the brief.
+ * @param repo   Absolute or relative path to the repository root.
+ * @param options  Optional brief configuration.
+ * @returns Parsed `BriefOutput`.
+ */
+export async function brief(
+  task: string,
+  repo: string,
+  options: BriefOptions = {},
+): Promise<BriefOutput> {
+  const runtime = await resolveRuntime();
+
+  const args: string[] = [
+    "brief",
+    "--task",
+    task,
+    "--repo",
+    repo,
+    "--format",
+    "json",
+    "--progress",
+    "none",
+  ];
+
+  if (options.scope) {
+    args.push("--scope", options.scope);
+  }
+  if (options.maxGuardrails !== undefined) {
+    args.push("--max-guardrails", String(options.maxGuardrails));
+  }
+  if (options.selectSignals) {
+    args.push("--select", options.selectSignals.join(","));
+  }
+  if (options.includeNonOperational) {
+    args.push("--include-non-operational");
+  }
+  if (options.config) {
+    args.push("--config", options.config);
+  }
+
+  return runDriftCommand<BriefOutput>(runtime, {
+    args,
+    cwd: repo,
+    timeoutMs: options.timeoutMs ?? 60_000,
+    exitZero: true,
+  });
+}

--- a/packages/drift-analyzer-sdk/src/commands/check.ts
+++ b/packages/drift-analyzer-sdk/src/commands/check.ts
@@ -1,0 +1,59 @@
+/**
+ * check command adapter.
+ * Wraps: `drift check --repo <path> --format json [options]`
+ */
+
+import type { DriftOutput, CheckOptions } from "../types.js";
+import { resolveRuntime } from "../runtime/resolver.js";
+import { runDriftCommand } from "../transport/process.js";
+
+export type { CheckOptions };
+
+/**
+ * Runs `drift check` on the target repository.
+ * Exits with a non-zero code when findings exceed the configured threshold.
+ * The SDK translates this to `CommandFailedError` unless `exitZero` is set.
+ *
+ * @param repo   Absolute or relative path to the repository root.
+ * @param options  Optional check configuration.
+ * @returns Parsed `DriftOutput` (same schema as analyze).
+ */
+export async function check(repo: string, options: CheckOptions = {}): Promise<DriftOutput> {
+  const runtime = await resolveRuntime();
+
+  const args: string[] = [
+    "check",
+    "--repo",
+    repo,
+    "--format",
+    "json",
+    "--progress",
+    "none",
+  ];
+
+  if (options.exitZero) {
+    args.push("--exit-zero");
+  }
+  if (options.since !== undefined) {
+    args.push("--since-days", String(options.since));
+  }
+  if (options.compact) {
+    args.push("--compact");
+  }
+  if (options.target) {
+    args.push("--target", options.target);
+  }
+  if (options.baseline) {
+    args.push("--baseline", options.baseline);
+  }
+  if (options.config) {
+    args.push("--config", options.config);
+  }
+
+  return runDriftCommand<DriftOutput>(runtime, {
+    args,
+    cwd: repo,
+    timeoutMs: options.timeoutMs ?? 120_000,
+    exitZero: options.exitZero ?? false,
+  });
+}

--- a/packages/drift-analyzer-sdk/src/commands/fix-plan.ts
+++ b/packages/drift-analyzer-sdk/src/commands/fix-plan.ts
@@ -1,0 +1,68 @@
+/**
+ * fix-plan command adapter.
+ * Wraps: `drift fix-plan --repo <path> --format json [options]`
+ */
+
+import type { FixPlanOutput, FixPlanOptions } from "../types.js";
+import { resolveRuntime } from "../runtime/resolver.js";
+import { runDriftCommand } from "../transport/process.js";
+
+export type { FixPlanOptions };
+
+/**
+ * Runs `drift fix-plan` to generate a prioritised list of repair tasks.
+ *
+ * @param repo   Absolute or relative path to the repository root.
+ * @param options  Optional fix-plan configuration.
+ * @returns Parsed `FixPlanOutput`.
+ */
+export async function fixPlan(repo: string, options: FixPlanOptions = {}): Promise<FixPlanOutput> {
+  const runtime = await resolveRuntime();
+
+  const args: string[] = [
+    "fix-plan",
+    "--repo",
+    repo,
+    "--format",
+    "json",
+    "--progress",
+    "none",
+  ];
+
+  if (options.findingId) {
+    args.push("--finding-id", options.findingId);
+  }
+  if (options.signal) {
+    args.push("--signal", options.signal);
+  }
+  if (options.maxTasks !== undefined) {
+    args.push("--max-tasks", String(options.maxTasks));
+  }
+  if (options.targetPath) {
+    args.push("--target-path", options.targetPath);
+  }
+  if (options.excludePaths) {
+    for (const p of options.excludePaths) {
+      args.push("--exclude", p);
+    }
+  }
+  if (options.includeDeferred) {
+    args.push("--include-deferred");
+  }
+  if (options.automationFitMin) {
+    args.push("--automation-fit-min", options.automationFitMin);
+  }
+  if (options.includeNonOperational) {
+    args.push("--include-non-operational");
+  }
+  if (options.config) {
+    args.push("--config", options.config);
+  }
+
+  return runDriftCommand<FixPlanOutput>(runtime, {
+    args,
+    cwd: repo,
+    timeoutMs: options.timeoutMs ?? 90_000,
+    exitZero: true,
+  });
+}

--- a/packages/drift-analyzer-sdk/src/errors.ts
+++ b/packages/drift-analyzer-sdk/src/errors.ts
@@ -1,0 +1,114 @@
+/**
+ * Error hierarchy for @drift-analyzer/sdk.
+ *
+ * All SDK errors extend DriftSdkError so callers can use a single catch gate:
+ *   catch (err) { if (err instanceof DriftSdkError) ... }
+ */
+
+// ---------------------------------------------------------------------------
+// Base
+// ---------------------------------------------------------------------------
+
+export class DriftSdkError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "DriftSdkError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Runtime errors (cannot start or find the drift process)
+// ---------------------------------------------------------------------------
+
+export class RuntimeNotFoundError extends DriftSdkError {
+  constructor(message = "drift runtime not found and bundled bootstrap failed") {
+    super(message);
+    this.name = "RuntimeNotFoundError";
+  }
+}
+
+export class BootstrapFailedError extends DriftSdkError {
+  public readonly cause: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message, cause instanceof Error ? { cause } : undefined);
+    this.name = "BootstrapFailedError";
+    this.cause = cause;
+  }
+}
+
+export class RuntimeChecksumError extends DriftSdkError {
+  public readonly expected: string;
+  public readonly actual: string;
+
+  constructor(expected: string, actual: string) {
+    super(`Runtime checksum mismatch — expected ${expected}, got ${actual}`);
+    this.name = "RuntimeChecksumError";
+    this.expected = expected;
+    this.actual = actual;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command execution errors
+// ---------------------------------------------------------------------------
+
+export class CommandFailedError extends DriftSdkError {
+  public readonly exitCode: number;
+  public readonly stderr: string;
+  public readonly stdout: string;
+
+  constructor(opts: {
+    message: string;
+    exitCode: number;
+    stderr: string;
+    stdout: string;
+  }) {
+    super(opts.message);
+    this.name = "CommandFailedError";
+    this.exitCode = opts.exitCode;
+    this.stderr = opts.stderr;
+    this.stdout = opts.stdout;
+  }
+}
+
+export class CommandTimeoutError extends DriftSdkError {
+  public readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(`drift command timed out after ${timeoutMs}ms`);
+    this.name = "CommandTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Output parsing errors
+// ---------------------------------------------------------------------------
+
+export class InvalidJsonPayloadError extends DriftSdkError {
+  public readonly raw: string;
+
+  constructor(raw: string, cause?: unknown) {
+    super(
+      `drift returned a non-JSON or mixed payload (${raw.slice(0, 80).replace(/\n/g, "\\n")}…)`,
+      cause instanceof Error ? { cause } : undefined,
+    );
+    this.name = "InvalidJsonPayloadError";
+    this.raw = raw;
+  }
+}
+
+export class UnsupportedSchemaVersionError extends DriftSdkError {
+  public readonly received: string;
+  public readonly supported: string[];
+
+  constructor(received: string, supported: string[]) {
+    super(
+      `Unsupported drift output schema version "${received}". SDK supports: ${supported.join(", ")}`,
+    );
+    this.name = "UnsupportedSchemaVersionError";
+    this.received = received;
+    this.supported = supported;
+  }
+}

--- a/packages/drift-analyzer-sdk/src/index.ts
+++ b/packages/drift-analyzer-sdk/src/index.ts
@@ -1,0 +1,51 @@
+/**
+ * Public re-export barrel for @drift-analyzer/sdk.
+ *
+ * All public surface is exported from this module.
+ * Internal modules (transport, runtime internals) are not exported.
+ */
+
+// Types
+export type {
+  Severity,
+  FindingStatus,
+  TrendDirection,
+  FindingCompact,
+  FixFirstFinding,
+  AnalysisStatus,
+  Trend,
+  Summary,
+  CompactSummary,
+  ModuleScore,
+  BaselineInfo,
+  DriftOutput,
+  BriefOutput,
+  FixPlanOutput,
+  SignalStatus,
+  AnalyzeOptions,
+  CheckOptions,
+  BriefOptions,
+  FixPlanOptions,
+  HealthResult,
+} from "./types.js";
+
+// Errors
+export {
+  DriftSdkError,
+  RuntimeNotFoundError,
+  BootstrapFailedError,
+  RuntimeChecksumError,
+  CommandFailedError,
+  CommandTimeoutError,
+  InvalidJsonPayloadError,
+  UnsupportedSchemaVersionError,
+} from "./errors.js";
+
+// Commands
+export { analyze } from "./commands/analyze.js";
+export { check } from "./commands/check.js";
+export { brief } from "./commands/brief.js";
+export { fixPlan } from "./commands/fix-plan.js";
+
+// Runtime management
+export { queryHealth, provisionBundle, isBundleProvisioned } from "./runtime/index.js";

--- a/packages/drift-analyzer-sdk/src/runtime/bootstrap.ts
+++ b/packages/drift-analyzer-sdk/src/runtime/bootstrap.ts
@@ -1,0 +1,230 @@
+/**
+ * Bootstrap — download and cache the managed drift runtime bundle.
+ *
+ * The bundle is a self-contained Python venv (created via uv) with
+ * drift-analyzer pre-installed. Downloaded from the drift GitHub Release assets
+ * and stored under XDG_CACHE_HOME / AppData/Local.
+ *
+ * Each bundle is versioned and integrity-verified via SHA256 checksum.
+ */
+
+import { createHash } from "node:crypto";
+import { createWriteStream, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir, platform, arch } from "node:os";
+import { pipeline } from "node:stream/promises";
+
+import { BootstrapFailedError, RuntimeChecksumError } from "../errors.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * The drift-analyzer version to bundle.
+ * Must be kept in sync with the Python package version used to generate types.
+ * Override via environment variable DRIFT_BUNDLE_VERSION.
+ */
+export const DEFAULT_BUNDLE_VERSION = "2.49.0";
+
+const BUNDLE_VERSION = process.env["DRIFT_BUNDLE_VERSION"] ?? DEFAULT_BUNDLE_VERSION;
+
+const GITHUB_BASE = "https://github.com/mick-gsk/drift/releases/download";
+
+// ---------------------------------------------------------------------------
+// Filesystem paths
+// ---------------------------------------------------------------------------
+
+function getCacheDir(): string {
+  const xdg = process.env["XDG_CACHE_HOME"];
+  if (xdg) return join(xdg, "drift-analyzer-sdk");
+  if (platform() === "win32") {
+    const localAppData = process.env["LOCALAPPDATA"] ?? join(homedir(), "AppData", "Local");
+    return join(localAppData, "drift-analyzer-sdk");
+  }
+  return join(homedir(), ".cache", "drift-analyzer-sdk");
+}
+
+/**
+ * Returns the managed bundle root directory for the current platform+arch+version.
+ * The directory contains a Python venv with drift-analyzer installed.
+ */
+export function getManagedBundlePath(): string {
+  return join(getCacheDir(), `v${BUNDLE_VERSION}`, `${platform()}-${arch()}`);
+}
+
+// ---------------------------------------------------------------------------
+// Platform asset resolution
+// ---------------------------------------------------------------------------
+
+type PlatformKey =
+  | "linux-x64"
+  | "linux-arm64"
+  | "darwin-x64"
+  | "darwin-arm64"
+  | "win32-x64"
+  | "win32-arm64";
+
+interface AssetSpec {
+  filename: string;
+  sha256?: string; // populated in checksums map below
+}
+
+function getPlatformKey(): PlatformKey {
+  const os = platform() as string;
+  const cpuArch = arch() as string;
+  const key = `${os}-${cpuArch}` as PlatformKey;
+  const supported: PlatformKey[] = [
+    "linux-x64",
+    "linux-arm64",
+    "darwin-x64",
+    "darwin-arm64",
+    "win32-x64",
+    "win32-arm64",
+  ];
+  if (!supported.includes(key)) {
+    throw new BootstrapFailedError(
+      `No pre-built drift bundle for platform '${key}'. ` +
+        "Install drift manually: pip install drift-analyzer",
+    );
+  }
+  return key;
+}
+
+function getAssetSpec(): AssetSpec {
+  const key = getPlatformKey();
+  const ext = key.startsWith("win32") ? "zip" : "tar.gz";
+  // Asset naming convention: drift-bundle-<version>-<os>-<arch>.<ext>
+  return { filename: `drift-bundle-${BUNDLE_VERSION}-${key}.${ext}` };
+}
+
+function getDownloadUrl(): string {
+  const { filename } = getAssetSpec();
+  return `${GITHUB_BASE}/v${BUNDLE_VERSION}/${filename}`;
+}
+
+// ---------------------------------------------------------------------------
+// Integrity check
+// ---------------------------------------------------------------------------
+
+function sha256OfFile(filePath: string): string {
+  const data = readFileSync(filePath);
+  return createHash("sha256").update(data).digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Archive extraction
+// ---------------------------------------------------------------------------
+
+async function extractBundle(archivePath: string, destDir: string): Promise<void> {
+  const { execFileSync } = await import("node:child_process");
+  mkdirSync(destDir, { recursive: true });
+
+  if (archivePath.endsWith(".tar.gz")) {
+    execFileSync("tar", ["-xzf", archivePath, "-C", destDir, "--strip-components=1"], {
+      stdio: "pipe",
+    });
+  } else if (archivePath.endsWith(".zip")) {
+    // Windows — use PowerShell Expand-Archive
+    execFileSync(
+      "powershell",
+      [
+        "-NoProfile",
+        "-Command",
+        `Expand-Archive -Path '${archivePath}' -DestinationPath '${destDir}' -Force`,
+      ],
+      { stdio: "pipe" },
+    );
+  } else {
+    throw new BootstrapFailedError(`Unsupported archive format: ${archivePath}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Download
+// ---------------------------------------------------------------------------
+
+async function downloadFile(url: string, destPath: string): Promise<void> {
+  // Use Node fetch (available since Node 18)
+  const response = await fetch(url);
+  if (!response.ok || !response.body) {
+    throw new BootstrapFailedError(
+      `Failed to download drift bundle from ${url}: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+  const fileStream = createWriteStream(destPath);
+  // Node 18+ fetch body is a web ReadableStream compatible with Node stream.pipeline
+  await pipeline(response.body as unknown as NodeJS.ReadableStream, fileStream);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if a managed bundle exists and appears functional.
+ */
+export async function isBundleProvisioned(): Promise<boolean> {
+  const bundleDir = getManagedBundlePath();
+  const sentinelPath = join(bundleDir, ".drift-sdk-version");
+  if (!existsSync(sentinelPath)) return false;
+  try {
+    const recorded = readFileSync(sentinelPath, "utf8").trim();
+    return recorded === BUNDLE_VERSION;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Downloads and installs the managed bundle. Idempotent — skips if already present.
+ * Throws `BootstrapFailedError` or `RuntimeChecksumError` on failure.
+ */
+export async function provisionBundle(opts?: { force?: boolean; expectedSha256?: string }): Promise<void> {
+  if (!opts?.force && (await isBundleProvisioned())) return;
+
+  const bundleDir = getManagedBundlePath();
+  const cacheDir = getCacheDir();
+  mkdirSync(cacheDir, { recursive: true });
+
+  const url = getDownloadUrl();
+  const { filename } = getAssetSpec();
+  const archivePath = join(cacheDir, filename);
+
+  try {
+    await downloadFile(url, archivePath);
+
+    if (opts?.expectedSha256) {
+      const actual = sha256OfFile(archivePath);
+      if (actual !== opts.expectedSha256) {
+        throw new RuntimeChecksumError(opts.expectedSha256, actual);
+      }
+    }
+
+    // Clean existing bundle dir if force
+    if (opts?.force && existsSync(bundleDir)) {
+      await rm(bundleDir, { recursive: true, force: true });
+    }
+
+    await extractBundle(archivePath, bundleDir);
+
+    // Write sentinel
+    writeFileSync(join(bundleDir, ".drift-sdk-version"), BUNDLE_VERSION, "utf8");
+  } catch (err) {
+    if (err instanceof RuntimeChecksumError) throw err;
+    throw new BootstrapFailedError(
+      `drift bundle provisioning failed: ${err instanceof Error ? err.message : String(err)}`,
+      err,
+    );
+  } finally {
+    // Clean up downloaded archive regardless of success/failure
+    try {
+      if (existsSync(archivePath)) {
+        await rm(archivePath, { force: true });
+      }
+    } catch {
+      // best-effort cleanup
+    }
+  }
+}

--- a/packages/drift-analyzer-sdk/src/runtime/index.ts
+++ b/packages/drift-analyzer-sdk/src/runtime/index.ts
@@ -1,0 +1,3 @@
+export { resolveRuntime, queryHealth } from "./resolver.js";
+export type { ResolvedRuntime } from "./resolver.js";
+export { provisionBundle, isBundleProvisioned, getManagedBundlePath, DEFAULT_BUNDLE_VERSION } from "./bootstrap.js";

--- a/packages/drift-analyzer-sdk/src/runtime/resolver.ts
+++ b/packages/drift-analyzer-sdk/src/runtime/resolver.ts
@@ -1,0 +1,178 @@
+/**
+ * Runtime resolver — locates the drift binary on disk.
+ *
+ * Priority:
+ *   1. Explicit path from environment variable DRIFT_BIN
+ *   2. drift / drift.exe found via PATH (which/where)
+ *   3. Python module invocation: python -m drift
+ *   4. Managed bundle in XDG cache / AppData
+ *
+ * The resolver is sync-compatible for PATH checks and async for managed bundles.
+ */
+
+import { execSync, type ExecSyncOptions } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { platform } from "node:os";
+
+import type { HealthResult } from "../types.js";
+import { RuntimeNotFoundError } from "../errors.js";
+import { getManagedBundlePath, isBundleProvisioned } from "./bootstrap.js";
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function runSilent(cmd: string): string | null {
+  try {
+    const opts: ExecSyncOptions = { stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" };
+    return (execSync(cmd, opts) as string).trim();
+  } catch {
+    return null;
+  }
+}
+
+function isWindows(): boolean {
+  return platform() === "win32";
+}
+
+/**
+ * Checks whether `drift` can be found via PATH.
+ * Returns the resolved path or null.
+ */
+function findInPath(): string | null {
+  const cmd = isWindows() ? "where drift 2>nul" : "which drift 2>/dev/null";
+  const result = runSilent(cmd);
+  if (result && existsSync(result.split("\n")[0].trim())) {
+    return result.split("\n")[0].trim();
+  }
+  return null;
+}
+
+/**
+ * Returns the drift version string from a given binary path,
+ * or null if the binary is not functional.
+ */
+function queryVersion(binaryPath: string, args: string[]): string | null {
+  try {
+    const quotedArgs = args.map((a) => `"${a}"`).join(" ");
+    const result = runSilent(`"${binaryPath}" ${quotedArgs} --version`);
+    if (result) {
+      // drift --version prints e.g. "drift 2.49.0" or just "2.49.0"
+      const match = result.match(/(\d+\.\d+\.\d+)/);
+      return match ? match[1] : result.slice(0, 20);
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// ResolvedRuntime — internal type used by the transport layer
+// ---------------------------------------------------------------------------
+
+export interface ResolvedRuntime {
+  /** Absolute path to the executable. */
+  executablePath: string;
+  /** Extra args inserted before the drift subcommand (e.g. ["-m", "drift"]). */
+  executableArgs: string[];
+  runtimeSource: HealthResult["runtimeSource"];
+  version: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves the drift runtime to use.
+ * Throws `RuntimeNotFoundError` if no runtime is available and bootstrap fails.
+ */
+export async function resolveRuntime(): Promise<ResolvedRuntime> {
+  // 1. Explicit override
+  const envBin = process.env["DRIFT_BIN"];
+  if (envBin && existsSync(envBin)) {
+    const version = queryVersion(envBin, []);
+    return { executablePath: envBin, executableArgs: [], runtimeSource: "path", version };
+  }
+
+  // 2. drift in PATH
+  const pathBin = findInPath();
+  if (pathBin) {
+    const version = queryVersion(pathBin, []);
+    return { executablePath: pathBin, executableArgs: [], runtimeSource: "path", version };
+  }
+
+  // 3. python -m drift
+  const pythonBin = isWindows() ? "python" : "python3";
+  const pythonVersion = queryVersion(pythonBin, ["-m", "drift"]);
+  if (pythonVersion) {
+    return {
+      executablePath: pythonBin,
+      executableArgs: ["-m", "drift"],
+      runtimeSource: "path",
+      version: pythonVersion,
+    };
+  }
+
+  // 4. Managed bundle
+  if (await isBundleProvisioned()) {
+    const bundlePath = getManagedBundlePath();
+    const bundleArgs = getBundleArgs();
+    const version = queryVersion(bundleArgs.executable, bundleArgs.args);
+    return {
+      executablePath: bundleArgs.executable,
+      executableArgs: bundleArgs.args,
+      runtimeSource: "bundled",
+      version,
+    };
+  }
+
+  throw new RuntimeNotFoundError(
+    "drift runtime not found. " +
+      "Install it via 'pip install drift-analyzer' or 'pipx install drift-analyzer', " +
+      "or set the DRIFT_BIN environment variable to the drift binary path.",
+  );
+}
+
+/**
+ * Returns a health snapshot without throwing. Suitable for diagnostics.
+ */
+export async function queryHealth(): Promise<HealthResult> {
+  try {
+    const runtime = await resolveRuntime();
+    return {
+      ok: runtime.version !== null,
+      version: runtime.version,
+      runtimePath: runtime.executablePath,
+      runtimeSource: runtime.runtimeSource,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      version: null,
+      runtimePath: "",
+      runtimeSource: "path",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bundle helpers (platform-specific bootstrap integration)
+// ---------------------------------------------------------------------------
+
+interface BundleSpec {
+  executable: string;
+  args: string[];
+}
+
+function getBundleArgs(): BundleSpec {
+  const bundlePath = getManagedBundlePath();
+  // The managed bundle contains a Python env; we invoke via python -m drift
+  const pythonExe = isWindows()
+    ? join(bundlePath, "Scripts", "python.exe")
+    : join(bundlePath, "bin", "python");
+  return { executable: pythonExe, args: ["-m", "drift"] };
+}

--- a/packages/drift-analyzer-sdk/src/transport/index.ts
+++ b/packages/drift-analyzer-sdk/src/transport/index.ts
@@ -1,0 +1,2 @@
+export { runDriftCommand, extractJsonPayload, parseJsonPayload } from "./process.js";
+export type { RunCommandOptions } from "./process.js";

--- a/packages/drift-analyzer-sdk/src/transport/process.ts
+++ b/packages/drift-analyzer-sdk/src/transport/process.ts
@@ -1,0 +1,229 @@
+/**
+ * Process transport — spawns the drift CLI process and captures output.
+ *
+ * Design principles:
+ * - JSON-first: strips Rich ANSI escapes and extracts the first complete JSON object.
+ * - Timeout-safe: AbortController kills the process on deadline.
+ * - Error-transparent: exit code != 0 raises CommandFailedError unless exitZero is set.
+ * - No shell expansion: execFile, not exec, to prevent flag-injection.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import type { ResolvedRuntime } from "../runtime/resolver.js";
+import {
+  CommandFailedError,
+  CommandTimeoutError,
+  InvalidJsonPayloadError,
+  UnsupportedSchemaVersionError,
+} from "../errors.js";
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// Schema version contract
+// ---------------------------------------------------------------------------
+
+/** Schema versions the SDK can decode. */
+const SUPPORTED_SCHEMA_VERSIONS = ["2.2", "2.1", "2.0"];
+
+// ---------------------------------------------------------------------------
+// Output normalisation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Removes ANSI escape sequences from a string.
+ * Drift's Rich output can bleed onto stdout in some terminal environments.
+ */
+function stripAnsi(raw: string): string {
+  // eslint-disable-next-line no-control-regex
+  return raw.replace(/\x1b\[[0-9;]*[mGKHF]/g, "");
+}
+
+/**
+ * Extracts the first complete JSON object from mixed stdout.
+ * Drift guarantees JSON starts at first `{` when --format json is used,
+ * but trailing Rich symbols can appear after the closing `}`.
+ */
+export function extractJsonPayload(raw: string): string {
+  const start = raw.indexOf("{");
+  const end = raw.lastIndexOf("}");
+  if (start === -1 || end === -1 || start > end) {
+    throw new InvalidJsonPayloadError(raw);
+  }
+  return raw.slice(start, end + 1);
+}
+
+/**
+ * Parses drift JSON output and validates schema version.
+ * Throws `UnsupportedSchemaVersionError` for future incompatible versions.
+ */
+export function parseJsonPayload<T extends object>(raw: string): T {
+  const cleaned = stripAnsi(raw);
+  let jsonStr: string;
+  try {
+    jsonStr = extractJsonPayload(cleaned);
+  } catch {
+    throw new InvalidJsonPayloadError(raw);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonStr);
+  } catch (err) {
+    throw new InvalidJsonPayloadError(jsonStr, err);
+  }
+
+  if (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    "schema_version" in parsed &&
+    typeof (parsed as Record<string, unknown>)["schema_version"] === "string"
+  ) {
+    const schemaVersion = (parsed as Record<string, unknown>)["schema_version"] as string;
+    if (!SUPPORTED_SCHEMA_VERSIONS.includes(schemaVersion)) {
+      throw new UnsupportedSchemaVersionError(schemaVersion, SUPPORTED_SCHEMA_VERSIONS);
+    }
+  }
+
+  return parsed as T;
+}
+
+// ---------------------------------------------------------------------------
+// Command builder
+// ---------------------------------------------------------------------------
+
+export interface RunCommandOptions {
+  /** Subcommand, e.g. ["analyze", "--repo", "."] */
+  args: string[];
+  /** Absolute path to the working directory (repo root). */
+  cwd: string;
+  /** Timeout in milliseconds. */
+  timeoutMs: number;
+  /** If true, non-zero exit codes are not treated as errors. */
+  exitZero?: boolean;
+  /** Additional environment overrides. */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Validate that a user-supplied string is a safe filesystem path or arg value.
+ * Rejects values containing shell metacharacters to prevent injection.
+ *
+ * Note: execFile (not exec) is already safe against most shell injection since
+ * no shell is spawned. This check is a defence-in-depth guard.
+ */
+function assertSafeArg(value: string, name: string): void {
+  // Reject obvious shell metacharacters
+  if (/[;&|`$(){}[\]<>!#~*?]/.test(value)) {
+    throw new TypeError(
+      `Unsafe characters detected in ${name}: "${value}". ` +
+        "Use only filesystem paths and plain option values.",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public transport function
+// ---------------------------------------------------------------------------
+
+/**
+ * Spawns a drift subcommand and returns the parsed JSON output.
+ * Throws on non-zero exit (unless exitZero), timeout, or parse failure.
+ */
+export async function runDriftCommand<T extends object>(
+  runtime: ResolvedRuntime,
+  options: RunCommandOptions,
+): Promise<T> {
+  const { args, cwd, timeoutMs, exitZero = false, env } = options;
+
+  // Validate extra args to prevent injection
+  for (const arg of args) {
+    if (arg.startsWith("--") || arg.startsWith("-")) continue; // flag
+    assertSafeArg(arg, "arg");
+  }
+
+  const fullArgs = [...runtime.executableArgs, ...args];
+
+  const execEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    // Force JSON output — belt-and-suspenders against Rich detection heuristics
+    NO_COLOR: "1",
+    TERM: "dumb",
+    ...env,
+  };
+
+  const timeoutId = setTimeout(() => {}, 0);
+  clearTimeout(timeoutId);
+
+  let stdout = "";
+  let stderr = "";
+  let exitCode = 0;
+
+  try {
+    const result = await execFileAsync(runtime.executablePath, fullArgs, {
+      cwd,
+      encoding: "utf8",
+      timeout: timeoutMs,
+      maxBuffer: 50 * 1024 * 1024, // 50 MB — large repos can produce significant JSON
+      env: execEnv,
+      windowsHide: true,
+    });
+    stdout = result.stdout;
+    stderr = result.stderr;
+  } catch (err: unknown) {
+    // execFile rejects on non-zero exit or timeout
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      "code" in err &&
+      (err as { code?: unknown }).code === "ETIMEDOUT"
+    ) {
+      throw new CommandTimeoutError(timeoutMs);
+    }
+
+    const execErr = err as {
+      stdout?: string;
+      stderr?: string;
+      code?: number | string;
+      killed?: boolean;
+      signal?: string;
+    };
+
+    stdout = execErr.stdout ?? "";
+    stderr = execErr.stderr ?? "";
+    exitCode = typeof execErr.code === "number" ? execErr.code : 1;
+
+    if (execErr.killed || execErr.signal === "SIGTERM") {
+      throw new CommandTimeoutError(timeoutMs);
+    }
+
+    // drift exits with 1 (findings above threshold) or 2 (config error).
+    // exit code 1 with JSON stdout is a valid "findings found" response.
+    // We only hard-fail on non-JSON or if exitZero is explicitly required and code != 0.
+    if (!exitZero && exitCode !== 0) {
+      // Check if we still got valid JSON despite the non-zero exit
+      if (!stdout.includes("{")) {
+        throw new CommandFailedError({
+          message: `drift exited with code ${exitCode}: ${stderr.slice(0, 300)}`,
+          exitCode,
+          stderr,
+          stdout,
+        });
+      }
+    }
+  }
+
+  // Parse output even if exit code was non-zero (drift can have findings & exit 1)
+  if (!stdout.trim()) {
+    throw new CommandFailedError({
+      message: `drift produced no output. stderr: ${stderr.slice(0, 300)}`,
+      exitCode,
+      stderr,
+      stdout,
+    });
+  }
+
+  return parseJsonPayload<T>(stdout);
+}

--- a/packages/drift-analyzer-sdk/src/types.ts
+++ b/packages/drift-analyzer-sdk/src/types.ts
@@ -1,0 +1,246 @@
+/**
+ * TypeScript types for the @drift-analyzer/sdk.
+ *
+ * Core output types derived from drift.output.schema.json (v2.2).
+ * Schema version: 2.2 — additive changes are backward compatible.
+ */
+
+// ---------------------------------------------------------------------------
+// Primitive enumerations
+// ---------------------------------------------------------------------------
+
+export type Severity = "critical" | "high" | "medium" | "low" | "info";
+
+export type FindingStatus = "active" | "suppressed" | "resolved";
+
+export type TrendDirection = "improving" | "degrading" | "stable" | "baseline";
+
+// ---------------------------------------------------------------------------
+// Finding shapes
+// ---------------------------------------------------------------------------
+
+export interface FindingCompact {
+  /** Deterministic content-based fingerprint (SHA256 prefix, 16 hex chars). */
+  finding_id: string;
+  rank: number;
+  signal: string;
+  signal_abbrev?: string;
+  rule_id?: string | null;
+  severity: Severity;
+  status?: FindingStatus;
+  finding_context?: string;
+  impact?: number;
+  score_contribution?: number;
+  title: string;
+  file?: string | null;
+  start_line?: number | null;
+  duplicate_count?: number;
+  next_step?: string | null;
+}
+
+export interface FixFirstFinding extends FindingCompact {
+  priority_class?: string;
+  expected_benefit?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Analysis sub-structures
+// ---------------------------------------------------------------------------
+
+export interface AnalysisStatus {
+  status: string;
+  degraded: boolean;
+  is_fully_reliable: boolean;
+  causes: string[];
+  affected_components: string[];
+  events: unknown[];
+}
+
+export interface Trend {
+  previous_score: number | null;
+  delta: number | null;
+  direction: TrendDirection;
+  recent_scores: number[];
+  history_depth: number;
+  transition_ratio: number | null;
+}
+
+export interface Summary {
+  total_files?: number;
+  total_functions?: number;
+  ai_attributed_ratio?: number;
+  ai_tools_detected?: string[];
+  analysis_duration_seconds?: number | null;
+}
+
+export interface CompactSummary {
+  findings_total?: number;
+  findings_deduplicated?: number;
+  duplicate_findings_removed?: number;
+  suppressed_total?: number;
+  critical_count?: number;
+  high_count?: number;
+  fix_first_count?: number;
+}
+
+export interface ModuleScore {
+  path: string;
+  drift_score: number;
+  severity: Severity;
+  signal_scores?: Record<string, number>;
+  finding_count: number;
+  ai_ratio?: number;
+}
+
+export interface BaselineInfo {
+  applied: boolean;
+  new_findings_count?: number | null;
+  baseline_matched_count?: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level output (drift analyze --format json)
+// ---------------------------------------------------------------------------
+
+export interface DriftOutput {
+  schema_version: string;
+  version: string;
+  signal_abbrev_map?: Record<string, string>;
+  repo: string;
+  analyzed_at: string;
+  drift_score: number;
+  drift_score_scope?: string;
+  severity: Severity;
+  grade?: string;
+  grade_label?: string;
+  analysis_status?: AnalysisStatus;
+  trend?: Trend | null;
+  summary?: Summary;
+  findings_compact?: FindingCompact[];
+  compact_summary?: CompactSummary;
+  fix_first?: FixFirstFinding[];
+  suppressed_count?: number;
+  context_tagged_count?: number;
+  baseline?: BaselineInfo | null;
+  modules?: ModuleScore[];
+}
+
+// ---------------------------------------------------------------------------
+// Brief output
+// ---------------------------------------------------------------------------
+
+export interface BriefOutput {
+  schema_version?: string;
+  repo?: string;
+  brief?: string;
+  /** Raw structured response from drift brief --format json */
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Fix-plan output
+// ---------------------------------------------------------------------------
+
+export interface FixPlanTask {
+  id?: string;
+  finding_id?: string;
+  title?: string;
+  severity?: Severity;
+  description?: string;
+  constraints?: string[];
+  verification_plan?: string[];
+  [key: string]: unknown;
+}
+
+export interface FixPlanOutput {
+  schema_version?: string;
+  repo?: string;
+  tasks?: FixPlanTask[];
+  /** Raw structured response from drift fix-plan --format json */
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Signal status (derived helper — not from wire, built by SDK)
+// ---------------------------------------------------------------------------
+
+export interface SignalStatus {
+  abbrev: string;
+  name: string;
+  severity: Severity | "pass";
+  findings: FindingCompact[];
+}
+
+// ---------------------------------------------------------------------------
+// SDK option shapes
+// ---------------------------------------------------------------------------
+
+export interface AnalyzeOptions {
+  /** Limit analysis to files changed in the last N days. */
+  since?: number;
+  /** Return compact JSON (smaller payload). */
+  compact?: boolean;
+  /** Restrict analysis to a subdirectory or file glob. */
+  target?: string;
+  /** Path to a baseline file or git ref for new-finding delta mode. */
+  baseline?: string;
+  /** Path to a drift.yaml config file. */
+  config?: string;
+  /** Timeout in milliseconds. Default: 120 000. */
+  timeoutMs?: number;
+}
+
+export interface CheckOptions extends AnalyzeOptions {
+  /** If true, always exit with 0 regardless of findings. */
+  exitZero?: boolean;
+}
+
+export interface BriefOptions {
+  /** Manual scope override (path or glob). */
+  scope?: string;
+  /** Maximum number of guardrails to generate (1–50). Default: 10. */
+  maxGuardrails?: number;
+  /** Comma-separated signal IDs to evaluate (e.g. ["PFS","AVS"]). */
+  selectSignals?: string[];
+  /** Include fixture/generated/migration/docs findings. */
+  includeNonOperational?: boolean;
+  /** Path to a drift.yaml config file. */
+  config?: string;
+  /** Timeout in milliseconds. Default: 60 000. */
+  timeoutMs?: number;
+}
+
+export interface FixPlanOptions {
+  /** Target a specific finding by task id or rule_id. */
+  findingId?: string;
+  /** Filter to a specific signal (e.g. "PFS"). */
+  signal?: string;
+  /** Maximum tasks to return. Default: 5. */
+  maxTasks?: number;
+  /** Restrict tasks to findings inside this subpath. */
+  targetPath?: string;
+  /** Exclude findings inside these subpaths. */
+  excludePaths?: string[];
+  /** Include findings marked as deferred in drift config. */
+  includeDeferred?: boolean;
+  /** Minimum automation fitness: "low" | "medium" | "high". */
+  automationFitMin?: "low" | "medium" | "high";
+  /** Include fixture/generated/migration/docs findings. */
+  includeNonOperational?: boolean;
+  /** Path to a drift.yaml config file. */
+  config?: string;
+  /** Timeout in milliseconds. Default: 90 000. */
+  timeoutMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Health check
+// ---------------------------------------------------------------------------
+
+export interface HealthResult {
+  ok: boolean;
+  version: string | null;
+  runtimePath: string;
+  runtimeSource: "path" | "bundled" | "managed";
+  error?: string;
+}

--- a/packages/drift-analyzer-sdk/tests/errors.test.ts
+++ b/packages/drift-analyzer-sdk/tests/errors.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for the error hierarchy.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  DriftSdkError,
+  RuntimeNotFoundError,
+  BootstrapFailedError,
+  RuntimeChecksumError,
+  CommandFailedError,
+  CommandTimeoutError,
+  InvalidJsonPayloadError,
+  UnsupportedSchemaVersionError,
+} from "../src/errors.js";
+
+describe("error hierarchy", () => {
+  it("all errors are instances of DriftSdkError", () => {
+    const errors = [
+      new RuntimeNotFoundError(),
+      new BootstrapFailedError("test"),
+      new RuntimeChecksumError("expected", "actual"),
+      new CommandFailedError({ message: "failed", exitCode: 1, stderr: "", stdout: "" }),
+      new CommandTimeoutError(5000),
+      new InvalidJsonPayloadError("raw"),
+      new UnsupportedSchemaVersionError("9.0", ["2.2"]),
+    ];
+    for (const err of errors) {
+      expect(err).toBeInstanceOf(DriftSdkError);
+      expect(err).toBeInstanceOf(Error);
+    }
+  });
+
+  it("RuntimeChecksumError exposes expected and actual", () => {
+    const err = new RuntimeChecksumError("abc", "def");
+    expect(err.expected).toBe("abc");
+    expect(err.actual).toBe("def");
+    expect(err.message).toContain("abc");
+    expect(err.message).toContain("def");
+  });
+
+  it("CommandFailedError exposes exitCode, stderr, stdout", () => {
+    const err = new CommandFailedError({
+      message: "failed",
+      exitCode: 2,
+      stderr: "err output",
+      stdout: "some output",
+    });
+    expect(err.exitCode).toBe(2);
+    expect(err.stderr).toBe("err output");
+    expect(err.stdout).toBe("some output");
+  });
+
+  it("CommandTimeoutError exposes timeoutMs", () => {
+    const err = new CommandTimeoutError(3000);
+    expect(err.timeoutMs).toBe(3000);
+    expect(err.message).toContain("3000");
+  });
+
+  it("UnsupportedSchemaVersionError exposes received and supported", () => {
+    const err = new UnsupportedSchemaVersionError("99.0", ["2.0", "2.1", "2.2"]);
+    expect(err.received).toBe("99.0");
+    expect(err.supported).toEqual(["2.0", "2.1", "2.2"]);
+  });
+
+  it("InvalidJsonPayloadError exposes the raw payload", () => {
+    const raw = "some garbage { not json";
+    const err = new InvalidJsonPayloadError(raw);
+    expect(err.raw).toBe(raw);
+  });
+
+  it("error names match class names", () => {
+    expect(new RuntimeNotFoundError().name).toBe("RuntimeNotFoundError");
+    expect(new BootstrapFailedError("x").name).toBe("BootstrapFailedError");
+    expect(new RuntimeChecksumError("a", "b").name).toBe("RuntimeChecksumError");
+    expect(new CommandTimeoutError(1).name).toBe("CommandTimeoutError");
+    expect(new InvalidJsonPayloadError("r").name).toBe("InvalidJsonPayloadError");
+    expect(new UnsupportedSchemaVersionError("x", []).name).toBe("UnsupportedSchemaVersionError");
+  });
+});

--- a/packages/drift-analyzer-sdk/tests/runtime.test.ts
+++ b/packages/drift-analyzer-sdk/tests/runtime.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for the runtime resolver.
+ * All external I/O is mocked via vi.mock — no real child_process spawning.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock node:child_process at the top so all tests share the mock
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+  execFile: vi.fn(),
+}));
+
+// Mock node:fs to prevent real filesystem access
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(() => false),
+  mkdirSync: vi.fn(),
+  readFileSync: vi.fn(() => ""),
+  writeFileSync: vi.fn(),
+  createWriteStream: vi.fn(),
+}));
+
+// Mock bootstrap to avoid real download logic
+vi.mock("../src/runtime/bootstrap.js", () => ({
+  isBundleProvisioned: vi.fn(async () => false),
+  getManagedBundlePath: vi.fn(() => "/fake/bundle"),
+}));
+
+describe("runtime resolver", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env["DRIFT_BIN"];
+  });
+
+  afterEach(() => {
+    delete process.env["DRIFT_BIN"];
+  });
+
+  it("resolves to DRIFT_BIN when set and file exists", async () => {
+    const fakeBin = "/usr/local/bin/drift-fake";
+    process.env["DRIFT_BIN"] = fakeBin;
+
+    const { existsSync } = await import("node:fs");
+    const { execSync } = await import("node:child_process");
+
+    vi.mocked(existsSync).mockImplementation((p: unknown) => p === fakeBin);
+    vi.mocked(execSync).mockReturnValue("drift 2.49.0\n" as unknown as Buffer);
+
+    // Re-import resolver after mocks are set
+    const { resolveRuntime } = await import("../src/runtime/resolver.js");
+    const result = await resolveRuntime();
+
+    expect(result.executablePath).toBe(fakeBin);
+    expect(result.runtimeSource).toBe("path");
+  });
+
+  it("resolveRuntime throws RuntimeNotFoundError when nothing is found", async () => {
+    delete process.env["DRIFT_BIN"];
+
+    const { existsSync } = await import("node:fs");
+    const { execSync } = await import("node:child_process");
+
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error("command not found");
+    });
+
+    const { resolveRuntime } = await import("../src/runtime/resolver.js");
+    const { RuntimeNotFoundError } = await import("../src/errors.js");
+
+    await expect(resolveRuntime()).rejects.toThrowError(RuntimeNotFoundError);
+  });
+
+  it("queryHealth returns ok:false on error", async () => {
+    delete process.env["DRIFT_BIN"];
+
+    const { existsSync } = await import("node:fs");
+    const { execSync } = await import("node:child_process");
+
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error("command not found");
+    });
+
+    const { queryHealth } = await import("../src/runtime/resolver.js");
+    const health = await queryHealth();
+
+    expect(health.ok).toBe(false);
+    expect(health.version).toBeNull();
+    expect(health.error).toBeDefined();
+  });
+});

--- a/packages/drift-analyzer-sdk/tests/transport.test.ts
+++ b/packages/drift-analyzer-sdk/tests/transport.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for the transport layer.
+ * Tests: extractJsonPayload, parseJsonPayload, injection guard.
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractJsonPayload, parseJsonPayload } from "../src/transport/process.js";
+import { InvalidJsonPayloadError, UnsupportedSchemaVersionError } from "../src/errors.js";
+
+// ---------------------------------------------------------------------------
+// extractJsonPayload
+// ---------------------------------------------------------------------------
+
+describe("extractJsonPayload", () => {
+  it("extracts pure JSON untouched", () => {
+    const json = '{"a": 1}';
+    expect(extractJsonPayload(json)).toBe(json);
+  });
+
+  it("strips Rich trailing symbols after closing brace", () => {
+    const json = '{"a": 1}';
+    const raw = json + "\n\u2714 Analysis complete";
+    expect(extractJsonPayload(raw)).toBe(json);
+  });
+
+  it("strips Rich header before opening brace", () => {
+    const raw = "\u2714 Starting analysis…\n{\"b\": 2}";
+    expect(extractJsonPayload(raw)).toBe('{"b": 2}');
+  });
+
+  it("throws InvalidJsonPayloadError when no JSON braces found", () => {
+    expect(() => extractJsonPayload("no json here")).toThrowError(InvalidJsonPayloadError);
+  });
+
+  it("throws when start > end", () => {
+    // malformed — closing brace before opening brace in weird string
+    expect(() => extractJsonPayload("}garbage{")).toThrowError(InvalidJsonPayloadError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseJsonPayload
+// ---------------------------------------------------------------------------
+
+const validOutput = {
+  schema_version: "2.2",
+  version: "2.49.0",
+  repo: "/tmp/test",
+  analyzed_at: "2025-01-01T00:00:00Z",
+  drift_score: 0.42,
+  severity: "medium",
+};
+
+describe("parseJsonPayload", () => {
+  it("parses valid JSON with supported schema version", () => {
+    const result = parseJsonPayload<typeof validOutput>(JSON.stringify(validOutput));
+    expect(result.schema_version).toBe("2.2");
+    expect(result.drift_score).toBe(0.42);
+  });
+
+  it("passes through JSON without schema_version field", () => {
+    const partial = { version: "2.49.0", repo: "/tmp/test" };
+    const result = parseJsonPayload<typeof partial>(JSON.stringify(partial));
+    expect(result.version).toBe("2.49.0");
+  });
+
+  it("strips ANSI sequences before parsing", () => {
+    const withAnsi = "\x1b[32m" + JSON.stringify(validOutput) + "\x1b[0m";
+    const result = parseJsonPayload<typeof validOutput>(withAnsi);
+    expect(result.drift_score).toBe(0.42);
+  });
+
+  it("throws UnsupportedSchemaVersionError for future version", () => {
+    const future = { ...validOutput, schema_version: "9.0" };
+    expect(() => parseJsonPayload(JSON.stringify(future))).toThrowError(
+      UnsupportedSchemaVersionError,
+    );
+  });
+
+  it("throws InvalidJsonPayloadError for malformed JSON", () => {
+    expect(() => parseJsonPayload("{not valid json}")).toThrowError(InvalidJsonPayloadError);
+  });
+
+  it("throws InvalidJsonPayloadError when no JSON braces present", () => {
+    expect(() => parseJsonPayload("plain text")).toThrowError(InvalidJsonPayloadError);
+  });
+});

--- a/packages/drift-analyzer-sdk/tsconfig.json
+++ b/packages/drift-analyzer-sdk/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationDir": "dist",
+    "strict": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/drift-analyzer-sdk/tsconfig.test.json
+++ b/packages/drift-analyzer-sdk/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*", "tests/**/*"],
+  "compilerOptions": {
+    "rootDir": "."
+  }
+}

--- a/packages/drift-analyzer-sdk/vitest.config.ts
+++ b/packages/drift-analyzer-sdk/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    coverage: {
+      include: ["src/**/*.ts"],
+      exclude: ["src/index.ts"],
+    },
+  },
+});


### PR DESCRIPTION
Split from #576 (ADR-100 monorepo migration). Part of the PR decomposition into atomic, reviewable units.