### PR TITLE
feat: add drift-mcp capability package (MCP server and routers, ADR-100 phase 5a)

### DIFF
--- a/packages/drift-mcp/pyproject.toml
+++ b/packages/drift-mcp/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "drift-mcp"
+version = "2.49.0"
+description = "MCP server and tool routing for drift-analyzer"
+requires-python = ">=3.11"
+dependencies = [
+    "drift-engine",
+    "drift-session",
+    "drift-output",
+    "drift-sdk",
+    "drift-config",
+]
+
+[tool.uv.sources]
+drift-engine = { workspace = true }
+drift-session = { workspace = true }
+drift-output = { workspace = true }
+drift-sdk = { workspace = true }
+drift-config = { workspace = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/drift_mcp"]

--- a/packages/drift-mcp/src/drift_mcp/__init__.py
+++ b/packages/drift-mcp/src/drift_mcp/__init__.py
@@ -1,0 +1,5 @@
+"""MCP server and routing surface for drift-analyzer."""
+
+from drift_mcp.mcp_server import main, mcp
+
+__all__ = ["main", "mcp"]

--- a/packages/drift-mcp/src/drift_mcp/mcp_autopilot.py
+++ b/packages/drift-mcp/src/drift_mcp/mcp_autopilot.py
@@ -1,0 +1,186 @@
+"""Autopilot pipeline helpers for MCP session start (ADR-025 Phase D).
+
+Contains the building blocks for the compact ``autopilot=true`` payload
+that ``drift_session_start`` returns after running
+validate → brief → scan → fix_plan automatically.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+AUTOPILOT_PAYLOAD_MODES: frozenset[str] = frozenset({"summary", "full"})
+_AUTOPILOT_PREVIEW_LIMIT = 3
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — payload building
+# ---------------------------------------------------------------------------
+
+
+def _payload_checksum(payload: Any) -> str:
+    """Return a stable 16-char hex checksum for on-demand payload references."""
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def _autopilot_scan_finding_preview(item: dict[str, Any]) -> dict[str, Any]:
+    """Return a slim finding preview entry for summary autopilot payloads."""
+    return {
+        "finding_id": item.get("finding_id"),
+        "signal": item.get("signal") or item.get("signal_abbrev"),
+        "severity": item.get("severity"),
+        "title": item.get("title"),
+        "file": item.get("file"),
+        "line": item.get("line") or item.get("start_line"),
+    }
+
+
+def _autopilot_task_preview(item: dict[str, Any]) -> dict[str, Any]:
+    """Return a slim fix-plan task preview entry for summary autopilot payloads."""
+    metadata_raw = item.get("metadata")
+    metadata: dict[str, Any] = metadata_raw if isinstance(metadata_raw, dict) else {}
+    return {
+        "id": item.get("id"),
+        "signal": item.get("signal") or item.get("signal_abbrev"),
+        "severity": item.get("severity"),
+        "title": item.get("title"),
+        "file": item.get("file") or item.get("file_path"),
+        "start_line": item.get("start_line"),
+        "batch_eligible": bool(item.get("batch_eligible") or metadata.get("batch_eligible")),
+    }
+
+
+def _autopilot_refs(
+    *,
+    session_id: str,
+    validate_result: dict[str, Any],
+    brief_result: dict[str, Any],
+    scan_result: dict[str, Any],
+    fix_plan_result: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    """Return on-demand references and checksums for heavy autopilot payload sections."""
+    return {
+        "validate": {
+            "tool": "drift_validate",
+            "params": {"session_id": session_id},
+            "checksum": _payload_checksum(validate_result),
+        },
+        "brief": {
+            "tool": "drift_brief",
+            "params": {"session_id": session_id},
+            "checksum": _payload_checksum(brief_result),
+        },
+        "scan": {
+            "tool": "drift_scan",
+            "params": {"session_id": session_id},
+            "checksum": _payload_checksum(scan_result),
+        },
+        "fix_plan": {
+            "tool": "drift_fix_plan",
+            "params": {"session_id": session_id},
+            "checksum": _payload_checksum(fix_plan_result),
+        },
+    }
+
+
+def build_autopilot_summary(
+    *,
+    session_id: str,
+    validate_result: dict[str, Any],
+    brief_result: dict[str, Any],
+    scan_result: dict[str, Any],
+    fix_plan_result: dict[str, Any],
+) -> dict[str, Any]:
+    """Build compact default autopilot payload with previews and references."""
+    finding_items_raw = scan_result.get("findings")
+    task_items_raw = fix_plan_result.get("tasks")
+    guardrail_items_raw = brief_result.get("guardrails")
+
+    finding_items = finding_items_raw if isinstance(finding_items_raw, list) else []
+    task_items = task_items_raw if isinstance(task_items_raw, list) else []
+    guardrail_items = guardrail_items_raw if isinstance(guardrail_items_raw, list) else []
+
+    finding_preview = [
+        _autopilot_scan_finding_preview(item)
+        for item in finding_items[:_AUTOPILOT_PREVIEW_LIMIT]
+        if isinstance(item, dict)
+    ]
+    task_preview = [
+        _autopilot_task_preview(item)
+        for item in task_items[:_AUTOPILOT_PREVIEW_LIMIT]
+        if isinstance(item, dict)
+    ]
+    guardrail_preview = guardrail_items[:_AUTOPILOT_PREVIEW_LIMIT]
+
+    top_signals_raw = scan_result.get("top_signals")
+    top_signals = [
+        {
+            "signal": item.get("signal"),
+            "score": item.get("score"),
+            "finding_count": item.get("finding_count"),
+        }
+        for item in (top_signals_raw if isinstance(top_signals_raw, list) else [])[:3]
+        if isinstance(item, dict)
+    ]
+
+    total_finding_count = scan_result.get("total_finding_count")
+    if not isinstance(total_finding_count, int):
+        total_finding_count = int(scan_result.get("finding_count", len(finding_items)))
+
+    total_task_count = fix_plan_result.get("total_available")
+    if not isinstance(total_task_count, int):
+        total_task_count = int(fix_plan_result.get("task_count", len(task_items)))
+
+    return {
+        "mode": "summary",
+        "drift_score": scan_result.get("drift_score"),
+        "task_count": total_task_count,
+        "top_signals": top_signals,
+        "next_tool_call": {
+            "tool": "drift_fix_plan",
+            "params": {"session_id": session_id},
+        },
+        "patch_protocol": {
+            "steps": [
+                "drift_patch_begin(task_id=<id>, declared_files=[...], expected_outcome=...)",
+                "drift_patch_check(task_id=<id>, declared_files=[...])",
+                "drift_patch_commit(task_id=<id>)",
+            ],
+            "when": "before_editing",
+            "reference": "ADR-074",
+        },
+        "findings_preview": {
+            "items": finding_preview,
+            "count": len(finding_preview),
+            "total_available": total_finding_count,
+        },
+        "tasks_preview": {
+            "items": task_preview,
+            "count": len(task_preview),
+            "total_available": total_task_count,
+        },
+        "guardrails_preview": {
+            "items": guardrail_preview,
+            "count": len(guardrail_preview),
+            "total_available": len(guardrail_items),
+        },
+        "payload_refs": _autopilot_refs(
+            session_id=session_id,
+            validate_result=validate_result,
+            brief_result=brief_result,
+            scan_result=scan_result,
+            fix_plan_result=fix_plan_result,
+        ),
+    }

--- a/packages/drift-mcp/src/drift_mcp/mcp_catalog.py
+++ b/packages/drift-mcp/src/drift_mcp/mcp_catalog.py
@@ -1,0 +1,191 @@
+"""MCP tool catalog — parameter introspection and metadata enrichment.
+
+Extracted from ``mcp_server.py`` to separate catalog generation from
+MCP tool registration and transport wiring.
+
+Decision: ADR-022
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import logging
+import re as _re
+from typing import Any
+
+_LAST_TOOL_CATALOG_ERROR: str | None = None
+_LOGGER = logging.getLogger("drift")
+
+
+def _extract_param_descriptions(doc: str) -> dict[str, str]:
+    """Extract parameter descriptions from Google-style Args: docstring section."""
+    result: dict[str, str] = {}
+    in_args = False
+    current_param: str | None = None
+    current_parts: list[str] = []
+    for line in doc.splitlines():
+        stripped = line.strip()
+        if stripped == "Args:":
+            in_args = True
+            continue
+        if not in_args:
+            continue
+        if not stripped:
+            continue
+        # Non-indented non-empty line = section ended
+        if not line.startswith("    ") and not line.startswith("\t"):
+            break
+        # New param: "name: description" at first indent level
+        m = _re.match(r"^(\w+):\s*(.*)", stripped)
+        if m:
+            if current_param:
+                result[current_param] = " ".join(current_parts).strip()
+            current_param = m.group(1)
+            current_parts = [m.group(2)] if m.group(2) else []
+        elif current_param:
+            current_parts.append(stripped)
+    if current_param:
+        result[current_param] = " ".join(current_parts).strip()
+    return result
+
+
+def _annotation_to_string(annotation: Any) -> str:
+    """Resolve a Python type annotation to a JSON Schema type string.
+
+    Properly unwraps ``Annotated[T, ...]`` and maps Python primitives to
+    their JSON Schema equivalents.
+    """
+    import types as _bt
+    import typing
+
+    if annotation is inspect.Signature.empty:
+        return "Any"
+    if isinstance(annotation, str):
+        return annotation
+
+    # Unwrap Annotated[T, ...] → T
+    origin = typing.get_origin(annotation)
+    if origin is typing.Annotated:
+        args = typing.get_args(annotation)
+        if args:
+            return _annotation_to_string(args[0])
+
+    # Handle Union / Optional (T | None)
+    if origin is _bt.UnionType or origin is typing.Union:
+        args = typing.get_args(annotation)
+        non_none = [a for a in args if a is not type(None)]
+        if len(non_none) == 1:
+            return _annotation_to_string(non_none[0])
+
+    # Map Python primitives to JSON Schema types
+    json_type_map: dict[type, str] = {
+        str: "string",
+        int: "integer",
+        float: "number",
+        bool: "boolean",
+    }
+    if isinstance(annotation, type) and annotation in json_type_map:
+        return json_type_map[annotation]
+
+    name = getattr(annotation, "__name__", None)
+    if isinstance(name, str):
+        return name
+    return str(annotation).replace("typing.", "")
+
+
+def _field_description_from_annotation(annotation: Any) -> str | None:
+    """Extract Field(description=...) from typing.Annotated metadata when present."""
+    import typing
+
+    if typing.get_origin(annotation) is not typing.Annotated:
+        return None
+
+    args = typing.get_args(annotation)
+    for meta in args[1:]:
+        description = getattr(meta, "description", None)
+        if isinstance(description, str) and description.strip():
+            return description.strip()
+    return None
+
+
+@functools.lru_cache(maxsize=1)
+def get_tool_catalog() -> list[dict[str, Any]]:
+    """Return MCP tool metadata for local inspection via CLI."""
+    import typing
+
+    global _LAST_TOOL_CATALOG_ERROR
+
+    try:
+        from drift_mcp.mcp_server import _EXPORTED_MCP_TOOLS
+    except ImportError as exc:
+        _LAST_TOOL_CATALOG_ERROR = str(exc)
+        _LOGGER.warning(
+            "MCP tool catalog unavailable; returning empty catalog (%s)",
+            _LAST_TOOL_CATALOG_ERROR,
+        )
+        return []
+
+    _LAST_TOOL_CATALOG_ERROR = None
+
+    catalog: list[dict[str, Any]] = []
+
+    for tool in _EXPORTED_MCP_TOOLS:
+        signature = inspect.signature(tool)
+        doc = inspect.getdoc(tool) or ""
+        summary = doc.splitlines()[0] if doc else ""
+        param_descs = _extract_param_descriptions(doc)
+
+        # Resolve string annotations (from __future__ annotations) to real types
+        try:
+            resolved_hints = typing.get_type_hints(tool, include_extras=True)
+        except Exception:
+            resolved_hints = {}
+
+        parameters: list[dict[str, Any]] = []
+        for parameter in signature.parameters.values():
+            if parameter.kind in (
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.VAR_KEYWORD,
+            ):
+                continue
+
+            annotation = resolved_hints.get(parameter.name, parameter.annotation)
+            required = parameter.default is inspect.Signature.empty
+            parameter_info: dict[str, Any] = {
+                "name": parameter.name,
+                "type": _annotation_to_string(annotation),
+                "required": required,
+            }
+            if not required:
+                parameter_info["default"] = parameter.default
+            if parameter.name in param_descs:
+                parameter_info["description"] = param_descs[parameter.name]
+            else:
+                field_desc = _field_description_from_annotation(annotation)
+                if field_desc:
+                    parameter_info["description"] = field_desc
+            parameters.append(parameter_info)
+
+        catalog.append(
+            {
+                "name": tool.__name__,
+                "description": summary,
+                "parameters": parameters,
+            }
+        )
+
+    # Enrich catalog entries with cost metadata
+    from drift.tool_metadata import TOOL_CATALOG, metadata_as_dict
+
+    for entry in catalog:
+        meta = TOOL_CATALOG.get(entry["name"])
+        if meta is not None:
+            entry["cost_metadata"] = metadata_as_dict(meta)
+
+    return catalog
+
+
+def get_tool_catalog_error() -> str | None:
+    """Return the last catalog-build error, if one occurred."""
+    return _LAST_TOOL_CATALOG_ERROR

--- a/packages/drift-mcp/src/drift_mcp/mcp_enrichment.py
+++ b/packages/drift-mcp/src/drift_mcp/mcp_enrichment.py
@@ -1,0 +1,156 @@
+"""MCP response enrichment — session metadata injection and error helpers.
+
+Extracted from ``mcp_server.py`` to separate response-transformation from
+MCP tool registration.
+
+Decision: ADR-022
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from drift_mcp.mcp_orchestration import _pre_call_advisory  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+def _exported_mcp_tool_names() -> set[str] | None:
+    """Return exported MCP tool names when available."""
+    try:
+        from drift_mcp.mcp_server import _EXPORTED_MCP_TOOLS
+    except ImportError:
+        return None
+    return {tool.__name__ for tool in _EXPORTED_MCP_TOOLS}
+
+
+def _enrich_response_with_session(
+    raw_json: str,
+    session: Any,
+    tool_name: str = "",
+    trace_meta: dict[str, Any] | None = None,
+) -> str:
+    """Inject session metadata into a tool response JSON string."""
+    if session is None:
+        return raw_json
+
+    # Record trace entry + pre-call advisory
+    advisory = _pre_call_advisory(tool_name, session) if tool_name else ""
+    if tool_name:
+        session.record_trace(tool_name, advisory=advisory, metadata=trace_meta)
+    try:
+        result = json.loads(raw_json)
+    except (json.JSONDecodeError, TypeError):
+        return raw_json
+
+    if not isinstance(result, dict):
+        if tool_name:
+            logger.warning(
+                "Enrichment skipped for %s: response is not a JSON object (type: %s)",
+                tool_name,
+                type(result).__name__,
+            )
+        return raw_json
+
+    session_block: dict[str, Any] = {
+        "session_id": session.session_id,
+        "scope": session.scope_label(),
+        "tasks_remaining": session.tasks_remaining(),
+        "phase": session.phase,
+        "score_delta_since_start": (
+            round(session.last_scan_score - session.score_at_start, 2)
+            if session.last_scan_score is not None and session.score_at_start is not None
+            else None
+        ),
+    }
+
+    if session.git_head_at_plan:
+        try:
+            from drift.pipeline import _current_git_head
+
+            current_head = _current_git_head(Path(session.repo_path))
+        except Exception:  # noqa: BLE001
+            current_head = None
+
+        if current_head and current_head != session.git_head_at_plan:
+            session_block["plan_stale"] = True
+            session_block["plan_stale_reason"] = (
+                "Plan baseline head "
+                f"{session.git_head_at_plan} differs from current head {current_head}."
+            )
+
+    # Quality-drift detection
+    from drift.quality_gate import quality_drift_from_history
+
+    qd = quality_drift_from_history(session.run_history)
+    if qd is not None:
+        session_block["quality_drift"] = {
+            "direction": qd.direction,
+            "score_delta": qd.score_delta,
+            "finding_delta": qd.finding_delta,
+            "advisory": qd.advisory,
+        }
+
+    # Progressive tool disclosure — top tools for current phase (max 4)
+    from drift.tool_metadata import tools_for_phase
+
+    next_tools = tools_for_phase(session.phase)
+    exported_names = _exported_mcp_tool_names()
+    if exported_names is not None:
+        next_tools = [name for name in next_tools if name in exported_names]
+    session_block["next_tools"] = next_tools[:4]
+
+    # Pre-call advisory (soft guidance)
+    if advisory:
+        session_block["advisory"] = advisory
+
+    # Tool context hint for the current tool
+    if tool_name:
+        from drift.tool_metadata import TOOL_CATALOG
+
+        tool_entry = TOOL_CATALOG.get(tool_name)
+        if tool_entry:
+            follow_up_tools = list(tool_entry.context.follow_up_tools)
+            exported_names = _exported_mcp_tool_names()
+            if exported_names is not None:
+                follow_up_tools = [t for t in follow_up_tools if t in exported_names]
+            session_block["context_hint"] = {
+                "when_to_use": tool_entry.context.when_to_use,
+                "follow_up_tools": follow_up_tools,
+            }
+
+    result["session"] = session_block
+
+    # Enrich agent_instruction with session hint
+    hint = (
+        f"Session {session.session_id[:8]} active"
+        f" (phase={session.phase},"
+        f" {session.tasks_remaining()} tasks remaining)."
+        " Use drift_session_status for full state."
+    )
+    existing = result.get("agent_instruction", "")
+    if existing:
+        result["agent_instruction"] = f"{existing} {hint}"
+    else:
+        result["agent_instruction"] = hint
+
+    # Inject session_id into next-step contracts (ADR-024)
+    sid = session.session_id
+    for key in ("next_tool_call", "fallback_tool_call"):
+        tc = result.get(key)
+        if isinstance(tc, dict) and isinstance(tc.get("params"), dict):
+            tc["params"].setdefault("session_id", sid)
+
+    return json.dumps(result, default=str)
+
+
+def _session_error_response(code: str, message: str, session_id: str) -> str:
+    """Build a JSON error response for session-related failures."""
+    from drift.api_helpers import _error_response
+
+    error = _error_response(code, message, recoverable=True)
+    error["session_id"] = session_id
+    return json.dumps(error, default=str)

--- a/packages/drift-mcp/src/drift_mcp/mcp_instructions.py
+++ b/packages/drift-mcp/src/drift_mcp/mcp_instructions.py
@@ -1,0 +1,158 @@
+"""MCP server instruction builder.
+
+Contains the base instructions string, negative-context enrichment logic,
+and the timeout helper for the drift MCP server.
+
+Extracted from mcp_server.py as part of Issue #378 — further modularisation
+of the MCP transport layer.  Import from here instead of from mcp_server.py.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Negative-context timeout (env-configurable)
+# ---------------------------------------------------------------------------
+
+
+def _load_negative_context_timeout_seconds() -> float:
+    """Resolve MCP timeout for drift_negative_context from environment."""
+    raw = os.getenv("DRIFT_MCP_NEGATIVE_CONTEXT_TIMEOUT_SECONDS", "20")
+    try:
+        return max(0.0, float(raw))
+    except (TypeError, ValueError):
+        return 20.0
+
+
+_NEGATIVE_CONTEXT_TIMEOUT_SECONDS = _load_negative_context_timeout_seconds()
+
+# ---------------------------------------------------------------------------
+# Dynamic instructions builder
+# ---------------------------------------------------------------------------
+
+_MAX_NEGATIVE_CONTEXT_BYTES = 10 * 1024  # 10 KB
+_SAFE_DO_NOT_RE = re.compile(r"^[\w\s.,;:!?()\'\"/@#%&\-+=<>|\\\[\]{}~^`]{1,200}$")
+
+_BASE_INSTRUCTIONS = (
+    "Drift is a deterministic static analyzer that detects architectural "
+    "erosion in Python codebases. Use these tools to analyze repositories "
+    "for coherence problems like pattern fragmentation, layer violations, "
+    "and near-duplicate code.\n\n"
+    "Tool workflow:\n"
+    "1. drift_validate — check config & environment before first analysis\n"
+    "2. drift_brief — get a structural briefing BEFORE implementing a task "
+    "(returns scope-aware guardrails as prompt constraints)\n"
+    "3. drift_scan — assess overall architectural health\n"
+    "4. drift_negative_context — get anti-patterns to avoid in new code\n"
+    "5. drift_diff — detect regressions or verify completed batches\n"
+    "6. drift_fix_plan — get actionable repair tasks with constraints\n"
+    "7. drift_explain — understand unfamiliar signals or findings\n"
+    "8. drift_nudge — fast directional feedback between edits "
+    "(usable inside batches)\n\n"
+    "IMPORTANT: When asked to implement a feature, add functionality, or make "
+    'structural changes, call drift_brief(task="<task description>") FIRST '
+    "before writing any code. Use the returned guardrails as constraints "
+    "in your code generation. If the scope confidence is below 0.5, ask the "
+    "user to specify a --scope path.\n\n"
+    "FEEDBACK LOOP ROLES:\n"
+    "- drift_nudge = fast inner loop (use between edits, even inside a batch)\n"
+    "- drift_diff  = full verification outer loop (use after completing a "
+    "batch or before committing)\n"
+    "Every response includes an 'agent_instruction' field — follow it.\n\n"
+    "FIX-LOOP PROTOCOL (when fixing multiple findings):\n"
+    '0. SESSION START: Call drift_session_start(path=".", autopilot=true) '
+    "— this single call runs validate → brief → scan → fix_plan and "
+    "returns combined results, saving 4 round-trips.\n"
+    "1. TASK LOOP: Take the first task from the fix_plan result. Fix it. "
+    'Call drift_nudge(session_id=sid, changed_files="path/to/file.py") '
+    "for fast feedback (~0.2s). If direction=degrading, revert and retry.\n"
+    "   NOTE on latency: if latency_exceeded=true AND baseline_created=true, "
+    "this was a one-time cold-start cost — do NOT skip subsequent nudge calls. "
+    "Only skip further nudge calls when latency_exceeded=true AND "
+    "baseline_created=false (genuinely slow system).\n"
+    "2. NEXT TASK: Call drift_fix_plan(session_id=sid, max_tasks=1) to get "
+    "the next task. Repeat step 1.\n"
+    "3. BATCH AWARENESS: Tasks with batch_eligible=true share a fix pattern. "
+    "Apply the fix to ALL affected_files_for_pattern listed, not just the "
+    "first. Use drift_nudge between edits for quick direction checks.\n"
+    "4. VERIFICATION: After all tasks are done, call "
+    "drift_diff(session_id=sid, uncommitted=True) once to verify.\n"
+    "5. COMPLETED: When drift_diff shows 0 new findings, session is done.\n\n"
+    "CRITICAL RULES:\n"
+    "- Always use autopilot=true in session_start (saves 4 round-trips)\n"
+    "- Always pass session_id to every tool call\n"
+    "- In the fix loop, use max_tasks=1 for each subsequent task request. "
+    "For the initial overview, follow the max_tasks value from the scan "
+    "agent_instruction (autopilot handles this automatically).\n"
+    "- Use drift_nudge (not drift_scan) after each file edit\n"
+    "- Use drift_diff only once at the end, not after every edit\n"
+    "- Follow agent_instruction and next_tool_call from every response\n\n"
+    "BATCH REPAIR MODE:\n"
+    "When fixing drift findings, apply the same fix pattern across "
+    "multiple files in one iteration for batch_eligible tasks.\n"
+    "Rules: Only batch fixes where batch_eligible=true in fix_plan response. "
+    "Apply the SAME fix template to ALL affected_files_for_pattern. "
+    "Verify the batch with a single drift_diff call, not per-file. "
+    "If any file in the batch fails verification, revert that file only.\n\n"
+    "SESSION WORKFLOW (recommended for multi-step tasks):\n"
+    '1. drift_session_start(path=".", autopilot=true) → session_id '
+    "(runs validate+brief+scan+fix_plan automatically)\n"
+    "2. [fix loop: edit file → drift_nudge(session_id=sid) → check direction]\n"
+    "3. drift_fix_plan(session_id=sid, max_tasks=1) → next task\n"
+    "4. drift_diff(session_id=sid, uncommitted=True) → final verify\n"
+    "5. drift_session_end(session_id=sid) → summary + cleanup\n"
+    "Benefits: scope defaults carry across calls, scan results feed into "
+    "fix_plan, guardrails persist, progress is tracked automatically."
+)
+
+
+def _load_negative_context_instructions() -> str:
+    """Build MCP instructions, enriching with cached anti-patterns if available."""
+    ctx_file = Path(".drift-negative-context.md")
+    if not ctx_file.is_file():
+        return _BASE_INSTRUCTIONS
+
+    try:
+        content = ctx_file.read_text(encoding="utf-8")
+    except OSError:
+        return _BASE_INSTRUCTIONS
+
+    if len(content.encode("utf-8")) > _MAX_NEGATIVE_CONTEXT_BYTES:
+        return _BASE_INSTRUCTIONS
+
+    from drift.negative_context.export import MARKER_BEGIN, MARKER_END
+
+    begin = content.find(MARKER_BEGIN)
+    end = content.find(MARKER_END)
+    if begin < 0 or end < 0:
+        return _BASE_INSTRUCTIONS
+
+    section = content[begin + len(MARKER_BEGIN) : end].strip()
+    if not section:
+        return _BASE_INSTRUCTIONS
+
+    do_not_lines: list[str] = []
+    for line in section.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- **DO NOT:**"):
+            candidate = stripped.removeprefix("- **DO NOT:** ")[:200]
+            if _SAFE_DO_NOT_RE.match(candidate):
+                do_not_lines.append(candidate)
+
+    if not do_not_lines:
+        return _BASE_INSTRUCTIONS
+
+    top = do_not_lines[:10]
+    suffix = f"\n  ... and {len(do_not_lines) - 10} more" if len(do_not_lines) > 10 else ""
+
+    anti_pattern_block = (
+        "\n\nKNOWN ANTI-PATTERNS IN THIS REPOSITORY "
+        "(from last drift export-context):\n"
+        + "\n".join(f"- DO NOT: {line}" for line in top)
+        + suffix
+    )
+
+    return _BASE_INSTRUCTIONS + anti_pattern_block

--- a/packages/drift-mcp/src/drift_mcp/mcp_legacy.py
+++ b/packages/drift-mcp/src/drift_mcp/mcp_legacy.py
@@ -1,0 +1,256 @@
+"""Deprecated task-leasing MCP tools (multi-agent coordination).
+
+These tools will be removed in v3.0.
+Use ``drift_session_end(completed_tasks=[...])`` instead.
+
+Moving them to this isolated module keeps mcp_server.py clean while
+preserving backward compatibility until the planned removal.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from drift_mcp.mcp_enrichment import _session_error_response
+
+_TASK_DEPRECATION_MSG = (
+    "DEPRECATED: Task leasing tools (drift_task_claim, drift_task_renew, "
+    "drift_task_release, drift_task_complete, drift_task_status) will be "
+    "removed in v3.0. Use drift_session_end(completed_tasks=[...]) instead."
+)
+
+
+async def run_task_claim(
+    *,
+    session_id: str,
+    agent_id: str,
+    task_id: str | None,
+    lease_ttl_seconds: int,
+    max_reclaim: int,
+) -> str:
+    """Claim a pending task from the session's fix-plan queue."""
+    import warnings
+
+    warnings.warn(_TASK_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+    from drift.session import SessionManager
+
+    session = SessionManager.instance().get(session_id)
+    if session is None:
+        return _session_error_response(
+            "DRIFT-6001",
+            f"Session {session_id[:8]} not found or expired.",
+            session_id,
+        )
+
+    claim = session.claim_task(
+        agent_id=agent_id,
+        task_id=task_id or None,
+        lease_ttl_seconds=lease_ttl_seconds,
+        max_reclaim=max_reclaim,
+    )
+    if claim is None:
+        q = session.queue_status()
+        result: dict[str, Any] = {
+            "status": "no_tasks_available",
+            "session_id": session_id,
+            "pending_count": q["pending_count"],
+            "claimed_count": q["claimed_count"],
+            "completed_count": q["completed_count"],
+            "failed_count": q["failed_count"],
+            "agent_instruction": (
+                "No pending tasks available in this session."
+                " All tasks may be claimed, completed, or failed."
+                " Call drift_task_status for a full queue overview."
+            ),
+        }
+        return json.dumps(result, default=str)
+
+    task_dict = claim["task"]
+    lease_dict = claim["lease"]
+    result = {
+        "status": "claimed",
+        "session_id": session_id,
+        "task": task_dict,
+        "lease": lease_dict,
+        "agent_instruction": (
+            f"Task {lease_dict['task_id']} claimed by {agent_id}."
+            f" Lease expires in {lease_ttl_seconds}s."
+            " Call drift_task_renew before expiry if more time is needed."
+            " Call drift_task_complete when done, or drift_task_release to"
+            " return the task to the pending pool."
+        ),
+    }
+    return json.dumps(result, default=str)
+
+
+async def run_task_renew(
+    *,
+    session_id: str,
+    agent_id: str,
+    task_id: str,
+    extend_seconds: int,
+) -> str:
+    """Extend an active task lease to prevent it from expiring."""
+    import warnings
+
+    warnings.warn(_TASK_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+    from drift.session import SessionManager
+
+    session = SessionManager.instance().get(session_id)
+    if session is None:
+        return _session_error_response(
+            "DRIFT-6001",
+            f"Session {session_id[:8]} not found or expired.",
+            session_id,
+        )
+
+    outcome = session.renew_lease(
+        agent_id=agent_id,
+        task_id=task_id,
+        extend_seconds=extend_seconds,
+    )
+    status = outcome.get("status", "not_found")
+    if status == "renewed":
+        outcome["session_id"] = session_id
+        outcome["agent_instruction"] = f"Lease for task {task_id} extended by {extend_seconds}s."
+    else:
+        outcome["session_id"] = session_id
+        outcome["agent_instruction"] = (
+            outcome.get("error", "Renewal failed.")
+            + " Call drift_task_status for current queue state."
+        )
+    return json.dumps(outcome, default=str)
+
+
+async def run_task_release(
+    *,
+    session_id: str,
+    agent_id: str,
+    task_id: str,
+    max_reclaim: int,
+) -> str:
+    """Release a claimed task back to the pending pool."""
+    import warnings
+
+    warnings.warn(_TASK_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+    from drift.session import SessionManager
+
+    session = SessionManager.instance().get(session_id)
+    if session is None:
+        return _session_error_response(
+            "DRIFT-6001",
+            f"Session {session_id[:8]} not found or expired.",
+            session_id,
+        )
+
+    outcome = session.release_task(
+        agent_id=agent_id,
+        task_id=task_id,
+        max_reclaim=max_reclaim,
+    )
+    state = outcome.get("status", "released")
+    if state == "released":
+        agent_instruction = (
+            f"Task {task_id} released back to the pending pool"
+            f" (reclaim count: {outcome.get('reclaim_count', 0)})."
+            " Another agent can now claim it."
+        )
+    elif state == "failed":
+        agent_instruction = (
+            f"Task {task_id} has reached max_reclaim={max_reclaim}"
+            " and is now marked as failed. It will not be re-queued."
+        )
+    else:
+        agent_instruction = (
+            outcome.get("error", "Release failed.")
+            + " Call drift_task_status for current queue state."
+        )
+    outcome["session_id"] = session_id
+    outcome["agent_instruction"] = agent_instruction
+    return json.dumps(outcome, default=str)
+
+
+async def run_task_complete(
+    *,
+    session_id: str,
+    agent_id: str,
+    task_id: str,
+    verify_evidence: Any,
+) -> str:
+    """Mark a claimed task as completed and release its lease."""
+    import warnings
+
+    warnings.warn(_TASK_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+    from drift.session import SessionManager
+
+    session = SessionManager.instance().get(session_id)
+    if session is None:
+        return _session_error_response(
+            "DRIFT-6001",
+            f"Session {session_id[:8]} not found or expired.",
+            session_id,
+        )
+
+    result = {"verify_evidence": verify_evidence} if verify_evidence is not None else None
+    outcome = session.complete_task(agent_id=agent_id, task_id=task_id, result=result)
+    state = outcome.get("status", "completed")
+    if state == "completed":
+        remaining = session.tasks_remaining()
+        agent_instruction = f"Task {task_id} completed. {remaining} task(s) remaining."
+        if remaining == 0:
+            agent_instruction += " All tasks done — call drift_session_end for final summary."
+    elif state == "already_completed":
+        agent_instruction = f"Task {task_id} was already completed."
+    elif state == "verify_plan_required":
+        agent_instruction = (
+            "Verification required before completing this task."
+            " Call drift_nudge on the changed files first, then pass the result"
+            " as verify_evidence (must contain safe_to_commit=true)."
+        )
+    else:
+        agent_instruction = (
+            outcome.get("error", "Completion failed.")
+            + " Call drift_task_status for current queue state."
+        )
+    outcome["session_id"] = session_id
+    outcome["tasks_remaining"] = session.tasks_remaining()
+    outcome["agent_instruction"] = agent_instruction
+    return json.dumps(outcome, default=str)
+
+
+async def run_task_status(
+    *,
+    session_id: str,
+) -> str:
+    """Return a full queue overview: pending, claimed, completed, failed tasks."""
+    import warnings
+
+    warnings.warn(_TASK_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+    from drift.session import SessionManager
+
+    session = SessionManager.instance().get(session_id)
+    if session is None:
+        return _session_error_response(
+            "DRIFT-6001",
+            f"Session {session_id[:8]} not found or expired.",
+            session_id,
+        )
+
+    status = session.queue_status()
+    status["session_id"] = session_id
+    status["tasks_remaining"] = session.tasks_remaining()
+    pending = status.get("pending_count", 0)
+    claimed = status.get("claimed_count", 0)
+    completed = status.get("completed_count", 0)
+    failed = status.get("failed_count", 0)
+    status["agent_instruction"] = (
+        f"Queue: {pending} pending, {claimed} claimed,"
+        f" {completed} completed, {failed} failed."
+        + (
+            " All tasks done — call drift_session_end."
+            if pending == 0 and claimed == 0 and completed > 0
+            else ""
+        )
+    )
+    return json.dumps(status, default=str)

--- a/packages/drift-mcp/src/drift_mcp/mcp_orchestration.py
+++ b/packages/drift-mcp/src/drift_mcp/mcp_orchestration.py
@@ -1,0 +1,930 @@
+"""MCP session orchestration, guardrails, hypothesis management and pre-call advisory.
+
+Extracted from ``mcp_server.py`` to separate session-management logic from
+MCP tool registration and transport wiring.
+
+Decision: ADR-022
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Brief staleness thresholds (Phase E2)
+# ---------------------------------------------------------------------------
+# Re-briefing is required when any of these hold since the last drift_brief:
+#   - baseline score delta exceeded ``_BRIEF_STALE_DELTA`` (primary trigger,
+#     catches significant structural change),
+#   - tool calls exceeded ``_BRIEF_STALE_TOOL_CALLS`` (heuristic fallback),
+#   - elapsed time exceeded ``_BRIEF_STALE_SECONDS`` (heuristic fallback).
+_BRIEF_STALE_DELTA: float = 0.10
+_BRIEF_STALE_TOOL_CALLS: int = 20
+_BRIEF_STALE_SECONDS: float = 30 * 60
+
+# ---------------------------------------------------------------------------
+# Session helpers — resolve session defaults and enrich responses
+# ---------------------------------------------------------------------------
+
+
+def _resolve_session(session_id: str | None) -> Any:
+    """Look up an active session. Returns ``DriftSession`` or ``None``."""
+    if not session_id:
+        return None
+    from drift.session import SessionManager
+
+    session = SessionManager.instance().get(session_id)
+    if session is not None:
+        session.begin_call()
+    return session
+
+
+@asynccontextmanager
+async def session_call_lock(session: Any):
+    """Async context manager that serialises state mutations for one session.
+
+    Acquires the per-session ``asyncio.Lock`` before yielding so that
+    concurrent tool calls on the same ``session_id`` cannot interleave
+    writes to shared fields such as ``last_scan_score``, ``phase``,
+    ``selected_tasks``, ``trace``, and ``completed_task_ids``.
+
+    Usage in MCP tool handlers::
+
+        async with session_call_lock(session):
+            raw = await _run_api_tool(...)
+            _update_session_from_xxx(session, json.loads(raw))
+            return _enrich_response_with_session(raw, session, ...)
+
+    When *session* is ``None`` the context manager is a no-op so callers
+    need not branch on the session being present.
+    """
+    if session is None:
+        yield
+        return
+    async with session.get_async_lock():
+        yield
+
+
+def _session_defaults(session: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Apply session scope defaults for params that the caller omitted."""
+    if session is None:
+        return kwargs
+    out = dict(kwargs)
+    if not out.get("path") or out["path"] == ".":
+        out["path"] = session.repo_path
+    if out.get("signals") is None and session.signals:
+        out["signals"] = session.signals
+    if out.get("exclude_signals") is None and session.exclude_signals:
+        out["exclude_signals"] = session.exclude_signals
+    if out.get("target_path") is None and session.target_path:
+        out["target_path"] = session.target_path
+    return out
+
+
+def _update_session_from_scan(session: Any, result: dict[str, Any]) -> None:
+    """Push scan results into the session state."""
+    if session is None:
+        return
+    session.last_scan_score = result.get("drift_score")
+    session.last_scan_top_signals = result.get("top_signals")
+    finding_count = result.get("finding_count")
+    if finding_count is None:
+        findings = result.get("findings")
+        if isinstance(findings, list):
+            finding_count = len(findings)
+    session.last_scan_finding_count = finding_count
+    if session.score_at_start is None:
+        session.score_at_start = result.get("drift_score")
+    # Agent-effectiveness: record snapshot for quality-drift detection
+    score = result.get("drift_score")
+    if score is not None and finding_count is not None:
+        session.snapshot_run(score, finding_count)
+    # Auto-advance phase from init → scan
+    if session.phase == "init":
+        session.advance_phase("scan")
+    session.touch()
+
+
+def _update_session_from_fix_plan(session: Any, result: dict[str, Any]) -> None:
+    """Push fix-plan tasks into the session state."""
+    if session is None:
+        return
+    tasks = result.get("tasks")
+    if tasks:
+        session.selected_tasks = tasks
+        # Persist plan to the append-only queue log so a future session can
+        # replay it after an MCP server restart (ADR-081).
+        try:
+            from drift.session_queue_log import QueueEvent, append_event
+
+            append_event(
+                session.repo_path,
+                QueueEvent(
+                    type="plan_created",
+                    session_id=session.session_id,
+                    payload={"tasks": list(tasks)},
+                ),
+            )
+        except Exception:  # pragma: no cover - defensive only
+            import logging
+
+            logging.getLogger("drift").debug("queue-log: plan_created emit failed", exc_info=True)
+    # Auto-advance phase from scan → fix
+    if session.phase in ("init", "scan"):
+        session.advance_phase("fix")
+    session.touch()
+
+
+def _update_session_from_brief(session: Any, result: dict[str, Any]) -> None:
+    """Push brief guardrails into the session state."""
+    if session is None:
+        return
+    import time as _t
+
+    session.guardrails = result.get("guardrails")
+    session.guardrails_prompt_block = result.get("guardrails_prompt_block")
+    session.last_brief_scope_gate = result.get("scope_gate")
+    session.last_brief_at = _t.time()
+    # Baseline score at brief time — used as staleness trigger when the
+    # analysis baseline diverges by more than ``_BRIEF_STALE_DELTA``.
+    landscape = result.get("landscape") or {}
+    score = landscape.get("drift_score")
+    if isinstance(score, (int, float)):
+        session.last_brief_score = float(score)
+    session.tool_calls_since_brief = 0
+    session.touch()
+
+
+def _update_session_from_diff(session: Any, result: dict[str, Any]) -> None:
+    """Track score delta from diff results."""
+    if session is None:
+        return
+    score_after = result.get("score_after")
+    if score_after is not None:
+        session.last_scan_score = score_after
+    # Auto-advance phase to verify
+    if session.phase in ("fix",):
+        session.advance_phase("verify")
+    # Record snapshot for quality-drift detection
+    finding_count = result.get("findings_after_count")
+    if score_after is not None and finding_count is not None:
+        session.snapshot_run(score_after, finding_count)
+    session.touch()
+
+
+def _update_session_from_verification_result(session: Any, result: dict[str, Any]) -> None:
+    """Record outcome-centric verification KPIs in session metrics.
+
+    Duplicate payloads are ignored to keep counters deterministic when callers
+    retry with identical verification data.
+    """
+    if session is None or not isinstance(result, dict):
+        return
+
+    changed_files = result.get("changed_files")
+    changed_file_count = result.get("changed_file_count")
+    if changed_file_count is None and isinstance(changed_files, list):
+        changed_file_count = len(changed_files)
+
+    payload_fingerprint = json.dumps(
+        {
+            "changed_files": (
+                sorted(changed_files) if isinstance(changed_files, list) else changed_files
+            ),
+            "changed_file_count": changed_file_count,
+            "changed_loc": result.get("changed_loc", result.get("loc_changed", 0)),
+            "resolved_count": result.get("resolved_count", 0),
+            "new_finding_count": result.get("new_finding_count", 0),
+        },
+        sort_keys=True,
+        default=str,
+    )
+
+    seen = getattr(session, "_seen_verification_payload_hashes", None)
+    if isinstance(seen, set):
+        if payload_fingerprint in seen:
+            return
+        seen.add(payload_fingerprint)
+
+    metrics = getattr(session, "metrics", None)
+    if metrics is None or not hasattr(metrics, "record_verification"):
+        return
+
+    metrics.record_verification(
+        changed_file_count=int(changed_file_count or 0),
+        loc_changed=int(result.get("changed_loc", result.get("loc_changed", 0)) or 0),
+        resolved_count=int(result.get("resolved_count", 0) or 0),
+        new_finding_count=int(result.get("new_finding_count", 0) or 0),
+    )
+    session.touch()
+
+
+def _session_called_tools(session: Any) -> set[str]:
+    """Return tools already executed or inferable from session state."""
+    if session is None:
+        return set()
+
+    called = {
+        str(item.get("tool"))
+        for item in (session.trace or [])
+        if isinstance(item, dict) and item.get("tool")
+    }
+
+    # Inference fallback for sessions where not all steps are traced
+    # (e.g. session_start autopilot or out-of-band updates).
+    if session.phase != "init":
+        called.add("drift_validate")
+    if session.guardrails is not None:
+        called.add("drift_brief")
+    if session.last_scan_score is not None or session.last_scan_finding_count is not None:
+        called.add("drift_scan")
+    if session.selected_tasks:
+        called.add("drift_fix_plan")
+
+    return called
+
+
+def _effective_profile(session: Any, explicit_profile: str | None) -> str | None:
+    """Resolve response profile from explicit input or session phase."""
+    if explicit_profile:
+        return explicit_profile
+    if session is None:
+        return None
+
+    phase = getattr(session, "phase", None)
+    if not isinstance(phase, str):
+        return None
+    phase_map: dict[str, str] = {
+        "init": "planner",
+        "scan": "planner",
+        "fix": "coder",
+        "verify": "verifier",
+        "done": "merge_readiness",
+    }
+    return phase_map.get(phase)
+
+
+# ---------------------------------------------------------------------------
+# Semantic pre-call advisory (SA-001 .. SA-004)
+# ---------------------------------------------------------------------------
+
+
+def _semantic_pre_call_advisory(tool_name: str, session: Any) -> str:
+    """Return semantic, workflow-aware advisory hints (SA-001..SA-004)."""
+    selected_tasks = getattr(session, "selected_tasks", None) or []
+    completed_task_ids = set(getattr(session, "completed_task_ids", []) or [])
+
+    # SA-001: blocker-awareness for unresolved dependencies.
+    if tool_name in {"drift_nudge", "drift_task_complete"} and selected_tasks:
+        unresolved: list[str] = []
+        for task in selected_tasks:
+            for dep in task.get("depends_on", []) or []:
+                if dep not in completed_task_ids:
+                    unresolved.append(str(dep))
+        if unresolved:
+            uniq = sorted(set(unresolved))
+            return f"Unresolved dependency detected: {', '.join(uniq)}."
+
+    trace = getattr(session, "trace", None) or []
+
+    # SA-002: repeated scan in fix phase deviates from canonical flow.
+    if tool_name == "drift_scan" and getattr(session, "phase", "") == "fix":
+        repeated_fix_scan = any(
+            isinstance(entry, dict)
+            and entry.get("tool") == "drift_scan"
+            and entry.get("phase") == "fix"
+            for entry in trace
+        )
+        if repeated_fix_scan:
+            return (
+                "Canonical-pattern deviation: repeated scan in fix phase. "
+                "Prefer drift_nudge for inner-loop feedback."
+            )
+
+    # SA-003: changed files outside diagnostic hypotheses.
+    if tool_name == "drift_nudge":
+        hypotheses = getattr(session, "diagnostic_hypotheses", {}) or {}
+        if hypotheses:
+            allowed_files: set[str] = set()
+            for hyp in hypotheses.values():
+                if isinstance(hyp, dict):
+                    for path in hyp.get("affected_files", []) or []:
+                        allowed_files.add(str(path))
+
+            changed_files: set[str] = set()
+            for entry in reversed(trace):
+                if not isinstance(entry, dict):
+                    continue
+                raw_changed = entry.get("changed_files")
+                if isinstance(raw_changed, str) and raw_changed:
+                    changed_files.add(raw_changed)
+                elif isinstance(raw_changed, list):
+                    changed_files.update(str(item) for item in raw_changed)
+                if changed_files:
+                    break
+
+            if (
+                changed_files
+                and allowed_files
+                and any(changed not in allowed_files for changed in changed_files)
+            ):
+                return (
+                    "Hypothesis scope creep detected: changed file outside diagnostic hypothesis."
+                )
+
+    # SA-004: warn on potential rework against completed task files.
+    if tool_name == "drift_nudge" and completed_task_ids and selected_tasks:
+        completed_files: set[str] = set()
+        for task in selected_tasks:
+            task_id = task.get("id", task.get("task_id", ""))
+            if task_id in completed_task_ids:
+                if task.get("file"):
+                    completed_files.add(str(task["file"]))
+                for path in task.get("affected_files_for_pattern", []) or []:
+                    completed_files.add(str(path))
+        if completed_files:
+            return "Potential rework on completed task files detected."
+
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic hypothesis management
+# ---------------------------------------------------------------------------
+
+_DIAGNOSTIC_REQUIRED_FIELDS = (
+    "affected_files",
+    "suspected_root_cause",
+    "minimal_intended_change",
+    "non_goals",
+)
+
+
+def _requires_diagnostic_hypothesis(session: Any) -> bool:
+    """Return True when the session is in a batch-fix verification context."""
+    if session is None:
+        return False
+    selected_tasks = getattr(session, "selected_tasks", None) or []
+    return any(bool(task.get("batch_eligible")) for task in selected_tasks)
+
+
+def _validate_diagnostic_hypothesis_payload(payload: Any) -> list[str]:
+    """Validate diagnostic hypothesis payload contract and return field errors."""
+    if not isinstance(payload, dict):
+        return ["diagnostic_hypothesis must be an object"]
+
+    errors: list[str] = []
+    affected_files = payload.get("affected_files")
+    if not isinstance(affected_files, list) or not affected_files:
+        errors.append("affected_files (non-empty list[str])")
+    elif not all(isinstance(item, str) and item.strip() for item in affected_files):
+        errors.append("affected_files items must be non-empty strings")
+
+    root_cause = payload.get("suspected_root_cause")
+    if not isinstance(root_cause, str) or not root_cause.strip():
+        errors.append("suspected_root_cause (non-empty string)")
+
+    intended_change = payload.get("minimal_intended_change")
+    if not isinstance(intended_change, str) or not intended_change.strip():
+        errors.append("minimal_intended_change (non-empty string)")
+
+    non_goals = payload.get("non_goals")
+    if not isinstance(non_goals, list) or not non_goals:
+        errors.append("non_goals (non-empty list[str])")
+    elif not all(isinstance(item, str) and item.strip() for item in non_goals):
+        errors.append("non_goals items must be non-empty strings")
+
+    return errors
+
+
+def _derive_diagnostic_hypothesis_id(payload: dict[str, Any]) -> str:
+    """Create a stable hypothesis ID from normalized payload content."""
+    normalized = {
+        "affected_files": sorted([str(item).strip() for item in payload.get("affected_files", [])]),
+        "suspected_root_cause": str(payload.get("suspected_root_cause", "")).strip(),
+        "minimal_intended_change": str(payload.get("minimal_intended_change", "")).strip(),
+        "non_goals": sorted([str(item).strip() for item in payload.get("non_goals", [])]),
+    }
+    digest = hashlib.sha256(
+        json.dumps(normalized, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:12]
+    return f"hyp-{digest}"
+
+
+def _diagnostic_hypothesis_block_response(
+    *,
+    tool_name: str,
+    session: Any,
+    reason: str,
+    details: list[str] | None = None,
+    missing_hypothesis_id: str | None = None,
+) -> str:
+    """Build a structured MCP error envelope for missing/invalid hypotheses."""
+    from drift.api_helpers import _error_response
+
+    message = f"{tool_name} requires a linked diagnostic hypothesis in batch-fix context."
+    if reason == "unknown_hypothesis_id":
+        message = (
+            f"{tool_name} received unknown hypothesis_id '{missing_hypothesis_id}'. "
+            "Register the full diagnostic_hypothesis first."
+        )
+
+    payload: dict[str, Any] = {
+        "blocked_tool": tool_name,
+        "reason": reason,
+        "required_fields": list(_DIAGNOSTIC_REQUIRED_FIELDS),
+    }
+    if details:
+        payload["validation_errors"] = details
+    if missing_hypothesis_id:
+        payload["hypothesis_id"] = missing_hypothesis_id
+
+    response = _error_response(
+        "DRIFT-6003",
+        message,
+        recoverable=True,
+        suggested_fix=payload,
+        recovery_tool_call={
+            "tool": tool_name,
+            "params": {
+                "session_id": session.session_id if session is not None else "",
+                "diagnostic_hypothesis": {
+                    "affected_files": ["src/example.py"],
+                    "suspected_root_cause": "Short root-cause hypothesis",
+                    "minimal_intended_change": "Minimal, bounded code change",
+                    "non_goals": ["No unrelated refactor", "No scoring changes"],
+                },
+            },
+        },
+    )
+    if session is not None:
+        response["session_id"] = session.session_id
+        session.record_trace(
+            tool_name,
+            advisory=f"diagnostic_hypothesis_block:{reason}",
+            metadata={"diagnostic_hypothesis_reason": reason},
+        )
+        session.touch()
+    response["blocked_tool"] = tool_name
+    response["diagnostic_hypothesis_reason"] = reason
+    response["agent_instruction"] = (
+        "Provide diagnostic_hypothesis with required fields or a known hypothesis_id, "
+        "then retry the blocked tool."
+    )
+    return json.dumps(response, default=str)
+
+
+def _resolve_diagnostic_hypothesis_context(
+    *,
+    tool_name: str,
+    session: Any,
+    hypothesis_id: str | None,
+    diagnostic_hypothesis: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Resolve and validate hypothesis context for nudge/diff tools."""
+    requires_hypothesis = _requires_diagnostic_hypothesis(session)
+
+    # Register payload-based hypothesis when provided.
+    if diagnostic_hypothesis is not None:
+        errors = _validate_diagnostic_hypothesis_payload(diagnostic_hypothesis)
+        if errors:
+            return {
+                "blocked_response": _diagnostic_hypothesis_block_response(
+                    tool_name=tool_name,
+                    session=session,
+                    reason="invalid_diagnostic_hypothesis",
+                    details=errors,
+                )
+            }
+
+        resolved_id = (hypothesis_id or diagnostic_hypothesis.get("hypothesis_id") or "").strip()
+        if not resolved_id:
+            resolved_id = _derive_diagnostic_hypothesis_id(diagnostic_hypothesis)
+
+        if session is not None:
+            session.register_diagnostic_hypothesis(resolved_id, diagnostic_hypothesis)
+
+        return {
+            "required": requires_hypothesis,
+            "hypothesis_id": resolved_id,
+            "hypothesis": diagnostic_hypothesis,
+        }
+
+    # Resolve ID-only reference against session state.
+    if hypothesis_id:
+        stored = session.get_diagnostic_hypothesis(hypothesis_id) if session is not None else None
+        if stored is None and requires_hypothesis:
+            return {
+                "blocked_response": _diagnostic_hypothesis_block_response(
+                    tool_name=tool_name,
+                    session=session,
+                    reason="unknown_hypothesis_id",
+                    missing_hypothesis_id=hypothesis_id,
+                )
+            }
+        return {
+            "required": requires_hypothesis,
+            "hypothesis_id": hypothesis_id,
+            "hypothesis": stored,
+        }
+
+    if requires_hypothesis:
+        return {
+            "blocked_response": _diagnostic_hypothesis_block_response(
+                tool_name=tool_name,
+                session=session,
+                reason="missing_diagnostic_hypothesis",
+            )
+        }
+
+    return {"required": False, "hypothesis_id": None, "hypothesis": None}
+
+
+def _trace_meta_from_hypothesis_result(
+    tool_name: str,
+    raw_json: str,
+) -> dict[str, Any] | None:
+    """Extract hypothesis and verification evidence for trace entries."""
+    try:
+        parsed = json.loads(raw_json)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+
+    hypothesis_id = parsed.get("hypothesis_id")
+    verification = parsed.get("verification_evidence")
+    if not hypothesis_id and not verification:
+        return None
+
+    trace_meta: dict[str, Any] = {"tool": tool_name}
+    if hypothesis_id:
+        trace_meta["hypothesis_id"] = hypothesis_id
+    if verification and isinstance(verification, dict):
+        trace_meta["verification_evidence"] = verification
+    return trace_meta
+
+
+# ---------------------------------------------------------------------------
+# Strict guardrails enforcement
+# ---------------------------------------------------------------------------
+
+
+def _strict_guardrails_enabled(session: Any) -> bool:
+    """Return True when agent.strict_guardrails is enabled in drift config."""
+    if session is None:
+        return False
+
+    call_token = (getattr(session, "_last_call_begin", None), getattr(session, "tool_calls", None))
+    cached = getattr(session, "_strict_guardrails_enabled_cache", None)
+    cached_token = getattr(session, "_strict_guardrails_enabled_cache_call_token", None)
+    if isinstance(cached, bool) and cached_token == call_token:
+        return cached
+
+    from drift.config import DriftConfig
+
+    enabled = False
+    try:
+        cfg = DriftConfig.load(Path(session.repo_path))
+    except Exception:
+        enabled = False
+    else:
+        agent_cfg = getattr(cfg, "agent", None)
+        enabled = bool(getattr(agent_cfg, "strict_guardrails", False))
+
+    # Cache once per tool call and invalidate between calls or after session updates.
+    session._strict_guardrails_enabled_cache = enabled
+    session._strict_guardrails_enabled_cache_call_token = call_token
+    return enabled
+
+
+def _strict_guardrail_violations(tool_name: str, session: Any) -> list[dict[str, Any]]:
+    """Return deterministic strict-guardrail violations for a tool transition."""
+    if session is None:
+        return []
+
+    called_tools = _session_called_tools(session)
+    violations: list[dict[str, Any]] = []
+
+    if tool_name == "drift_fix_plan":
+        if "drift_brief" not in called_tools:
+            violations.append(
+                {
+                    "rule_id": "SG-001",
+                    "reason": "missing_brief",
+                    "message": "drift_fix_plan requires drift_brief in strict mode.",
+                    "required": ["drift_brief"],
+                    "observed": sorted(called_tools),
+                }
+            )
+        if "drift_scan" not in called_tools:
+            violations.append(
+                {
+                    "rule_id": "SG-002",
+                    "reason": "missing_diagnosis",
+                    "message": "drift_fix_plan requires drift_scan diagnosis in strict mode.",
+                    "required": ["drift_scan"],
+                    "observed": sorted(called_tools),
+                }
+            )
+
+    if tool_name in {"drift_nudge", "drift_diff"} and "drift_scan" not in called_tools:
+        violations.append(
+            {
+                "rule_id": "SG-003",
+                "reason": "missing_scan_baseline",
+                "message": f"{tool_name} requires a prior drift_scan baseline in strict mode.",
+                "required": ["drift_scan"],
+                "observed": sorted(called_tools),
+            }
+        )
+
+    if tool_name == "drift_session_end" and session.tasks_remaining() > 0:
+        violations.append(
+            {
+                "rule_id": "SG-004",
+                "reason": "open_tasks_remaining",
+                "message": "drift_session_end is blocked while fix-plan tasks remain open.",
+                "required": ["session.tasks_remaining == 0"],
+                "observed": {"tasks_remaining": session.tasks_remaining()},
+            }
+        )
+
+    if tool_name == "drift_fix_apply" and "drift_brief" not in called_tools:
+        violations.append(
+            {
+                "rule_id": "SG-005",
+                "reason": "missing_brief",
+                "message": "drift_fix_apply requires drift_brief in strict mode.",
+                "required": ["drift_brief"],
+                "observed": sorted(called_tools),
+            }
+        )
+
+    if tool_name == "drift_patch_begin" and "drift_brief" not in called_tools:
+        violations.append(
+            {
+                "rule_id": "SG-006",
+                "reason": "missing_brief",
+                "message": "drift_patch_begin requires drift_brief in strict mode.",
+                "required": ["drift_brief"],
+                "observed": sorted(called_tools),
+            }
+        )
+
+    # SG-008 / SG-009: block fix/patch when the queue is empty, i.e. no
+    # drift_fix_plan has produced tasks yet.  This enforces queue-driven
+    # mutation: agents must either (a) call drift_fix_plan to pull tasks
+    # from prioritised diagnosis, or (b) use drift_nudge / drift_diff for
+    # ad-hoc regression feedback.  Consistent with ADR-081 queue
+    # persistence: a replayed queue restores selected_tasks, so a
+    # resumed session satisfies this gate automatically.
+    if tool_name in {"drift_fix_apply", "drift_patch_begin"}:
+        selected_tasks = getattr(session, "selected_tasks", None)
+        queue_empty = not bool(selected_tasks)
+        if queue_empty:
+            rule = "SG-008" if tool_name == "drift_fix_apply" else "SG-009"
+            violations.append(
+                {
+                    "rule_id": rule,
+                    "reason": "empty_queue",
+                    "message": (
+                        f"{tool_name} is blocked: no tasks in the session queue. "
+                        "Call drift_fix_plan first to pull prioritised tasks, or "
+                        "use drift_nudge / drift_diff for ad-hoc regression "
+                        "feedback without mutation."
+                    ),
+                    "required": ["drift_fix_plan"],
+                    "observed": {"selected_tasks_count": 0},
+                }
+            )
+
+    # SG-007: block fix/patch when the last brief raised a scope_gate.
+    # The agent must ask the user to confirm the scope before proceeding.
+    if tool_name in {"drift_fix_apply", "drift_patch_begin"}:
+        scope_gate = getattr(session, "last_brief_scope_gate", None)
+        if isinstance(scope_gate, dict) and scope_gate.get("action_required") == "ask_user":
+            violations.append(
+                {
+                    "rule_id": "SG-007",
+                    "reason": "scope_gate_unresolved",
+                    "message": (
+                        f"{tool_name} is blocked: last drift_brief raised a "
+                        "scope_gate (low scope confidence). Ask the user to "
+                        "confirm or provide an explicit scope path, then call "
+                        "drift_brief again."
+                    ),
+                    "required": ["ask_user", "drift_brief"],
+                    "observed": {"scope_gate": scope_gate},
+                }
+            )
+
+    # SG-005a / SG-006a: block fix/patch when the last brief is stale.
+    # Stale = baseline score drifted significantly OR too many tool calls
+    # since brief OR too much wall-clock time elapsed.  Forces re-briefing
+    # after meaningful change.
+    if tool_name in {"drift_fix_apply", "drift_patch_begin"}:
+        stale_reason = _brief_staleness_reason(session)
+        if stale_reason is not None:
+            rule = "SG-005a" if tool_name == "drift_fix_apply" else "SG-006a"
+            violations.append(
+                {
+                    "rule_id": rule,
+                    "reason": "stale_brief",
+                    "message": (
+                        f"{tool_name} is blocked: drift_brief is stale "
+                        f"({stale_reason}). Re-run drift_brief before editing."
+                    ),
+                    "required": ["drift_brief (fresh)"],
+                    "observed": {"stale_reason": stale_reason},
+                }
+            )
+
+    return violations
+
+
+def _brief_staleness_reason(session: Any) -> str | None:
+    """Return a human-readable staleness reason or ``None`` if brief is fresh.
+
+    Primary trigger is ``_BRIEF_STALE_DELTA`` on the baseline score —
+    catches meaningful structural change.  Falls back to time/call count.
+    """
+    import time as _t
+
+    if session is None:
+        return None
+
+    last_brief_at = getattr(session, "last_brief_at", None)
+    if last_brief_at is None:
+        return None  # no brief ever called — SG-005/SG-006 handle that
+
+    last_brief_score = getattr(session, "last_brief_score", None)
+    current_score = getattr(session, "last_scan_score", None)
+    if (
+        last_brief_score is not None
+        and isinstance(current_score, (int, float))
+        and abs(float(current_score) - last_brief_score) > _BRIEF_STALE_DELTA
+    ):
+        return (
+            f"baseline score drifted by "
+            f"{abs(float(current_score) - last_brief_score):.3f} "
+            f"(> {_BRIEF_STALE_DELTA})"
+        )
+
+    calls_since = int(getattr(session, "tool_calls_since_brief", 0) or 0)
+    if calls_since > _BRIEF_STALE_TOOL_CALLS:
+        return f"{calls_since} tool calls since brief (> {_BRIEF_STALE_TOOL_CALLS})"
+
+    if (_t.time() - last_brief_at) > _BRIEF_STALE_SECONDS:
+        mins = (_t.time() - last_brief_at) / 60.0
+        return f"{mins:.0f} min elapsed since brief (> {_BRIEF_STALE_SECONDS / 60.0:.0f} min)"
+
+    return None
+
+
+def _strict_guardrail_recovery_tool_call(
+    violations: list[dict[str, Any]],
+    session: Any,
+) -> dict[str, Any]:
+    """Return deterministic next-step hint for strict-guardrail blocks."""
+    reason_ids = {v.get("reason") for v in violations}
+    session_id = session.session_id
+
+    if "missing_brief" in reason_ids:
+        return {
+            "tool": "drift_brief",
+            "params": {
+                "session_id": session_id,
+                "task": "continue strict orchestration workflow",
+            },
+        }
+    if "missing_diagnosis" in reason_ids or "missing_scan_baseline" in reason_ids:
+        return {
+            "tool": "drift_scan",
+            "params": {"session_id": session_id},
+        }
+    if "open_tasks_remaining" in reason_ids:
+        return {
+            "tool": "drift_task_status",
+            "params": {"session_id": session_id},
+        }
+    return {
+        "tool": "drift_session_status",
+        "params": {"session_id": session_id},
+    }
+
+
+def _strict_guardrail_block_response(tool_name: str, session: Any) -> str | None:
+    """Return an MCP error envelope when strict guardrails block a transition."""
+    if session is None or not _strict_guardrails_enabled(session):
+        return None
+
+    violations = _strict_guardrail_violations(tool_name, session)
+    if not violations:
+        return None
+
+    from drift.api_helpers import _error_response
+
+    recovery = _strict_guardrail_recovery_tool_call(violations, session)
+    message = (
+        f"Strict guardrails blocked '{tool_name}' because required orchestration "
+        "preconditions were not met."
+    )
+    response = _error_response(
+        "DRIFT-6002",
+        message,
+        recoverable=True,
+        suggested_fix={
+            "strict_guardrails": True,
+            "blocked_tool": tool_name,
+            "block_reasons": violations,
+        },
+        recovery_tool_call=recovery,
+    )
+    response["session_id"] = session.session_id
+    response["blocked_tool"] = tool_name
+    response["block_reasons"] = violations
+    response["agent_instruction"] = (
+        "Follow recovery_tool_call exactly, then retry the blocked tool."
+    )
+
+    advisory = f"strict_guardrail_block:{tool_name};" + ",".join(
+        str(v.get("reason")) for v in violations
+    )
+    session.record_trace(tool_name, advisory=advisory)
+    session.touch()
+    return json.dumps(response, default=str)
+
+
+# ---------------------------------------------------------------------------
+# Pre-call advisory (soft guidance, not blocking)
+# ---------------------------------------------------------------------------
+
+
+def _pre_call_advisory(tool_name: str, session: Any) -> str:
+    """Generate a lightweight pre-call advisory for the given tool.
+
+    Returns an advisory string (empty if no concerns). This does NOT
+    block the call — it provides soft guidance to the consuming agent.
+    """
+    if session is None:
+        return ""
+
+    from drift.tool_metadata import TOOL_CATALOG
+
+    entry = TOOL_CATALOG.get(tool_name)
+    if entry is None:
+        return ""
+
+    parts: list[str] = []
+    try:
+        from drift_mcp.mcp_server import _EXPORTED_MCP_TOOLS
+    except ImportError:
+        exported_names: set[str] | None = None
+    else:
+        exported_names = {tool.__name__ for tool in _EXPORTED_MCP_TOOLS}
+
+    semantic_advisory = _semantic_pre_call_advisory(tool_name, session)
+    if semantic_advisory:
+        parts.append(semantic_advisory)
+
+    # Phase mismatch — tool not recommended for current phase
+    if entry.phases and session.phase not in entry.phases:
+        parts.append(
+            f"'{tool_name}' is typically used in phase(s) {', '.join(entry.phases)}"
+            f" but session is in phase '{session.phase}'."
+        )
+
+    # Redundancy check — warn if this exact tool was called recently
+    recent_tools = [t["tool"] for t in session.trace[-3:]] if session.trace else []
+    recent_count = recent_tools.count(tool_name)
+    if recent_count >= 2:
+        parts.append(
+            f"'{tool_name}' was called {recent_count} times in last 3 calls."
+            " Consider a different tool."
+        )
+
+    # Prerequisite check
+    if entry.context.prerequisite_tools and not semantic_advisory:
+        called_tools = _session_called_tools(session)
+        prerequisite_tools = list(entry.context.prerequisite_tools)
+        if exported_names is not None:
+            prerequisite_tools = [p for p in prerequisite_tools if p in exported_names]
+        missing = [p for p in prerequisite_tools if p not in called_tools]
+        if missing:
+            parts.append(f"Prerequisite tool(s) not yet called: {', '.join(missing)}.")
+
+    if _strict_guardrails_enabled(session):
+        violations = _strict_guardrail_violations(tool_name, session)
+        if violations:
+            reason_ids = ", ".join(str(v.get("reason")) for v in violations)
+            parts.append(
+                "Strict guardrails are enabled; this transition requires hard"
+                f" preconditions ({reason_ids})."
+            )
+
+    return " ".join(parts)

--- a/packages/drift-mcp/src/drift_mcp/mcp_router_analysis.py
+++ b/packages/drift-mcp/src/drift_mcp/mcp_router_analysis.py
@@ -1,0 +1,453 @@
+"""Bounded-context router for MCP analysis tools.
+
+Covers: scan, diff, nudge, explain, validate, brief, shadow_verify, negative_context.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+from typing import Any, cast
+
+from drift_mcp.mcp_enrichment import _enrich_response_with_session
+from drift_mcp.mcp_orchestration import (
+    _resolve_diagnostic_hypothesis_context,
+    _resolve_session,
+    _session_defaults,
+    _strict_guardrail_block_response,
+    _trace_meta_from_hypothesis_result,
+    _update_session_from_brief,
+    _update_session_from_diff,
+    _update_session_from_scan,
+)
+from drift_mcp.mcp_utils import (
+    _parse_csv_ids,
+    _run_api_tool,
+    _run_sync_in_thread,
+    _run_sync_with_timeout,
+)
+
+
+async def run_scan(
+    *,
+    path: str,
+    target_path: str | None,
+    since_days: int,
+    signals: str | None,
+    exclude_signals: str | None,
+    max_findings: int,
+    max_per_signal: int | None,
+    response_detail: str,
+    include_non_operational: bool,
+    response_profile: str | None,
+    session_id: str,
+) -> str:
+    from drift.api import scan
+
+    session = _resolve_session(session_id)
+    blocked = _strict_guardrail_block_response("drift_scan", session)
+    if blocked is not None:
+        return blocked
+    kwargs = _session_defaults(
+        session,
+        {
+            "path": path,
+            "target_path": target_path,
+            "signals": _parse_csv_ids(signals),
+            "exclude_signals": _parse_csv_ids(exclude_signals),
+        },
+    )
+
+    try:
+        raw = await _run_api_tool(
+            "drift_scan",
+            scan,
+            path=kwargs["path"],
+            target_path=kwargs["target_path"],
+            since_days=since_days,
+            signals=kwargs["signals"],
+            exclude_signals=kwargs["exclude_signals"],
+            max_findings=max_findings,
+            max_per_signal=max_per_signal,
+            response_detail=response_detail,
+            include_non_operational=include_non_operational,
+            response_profile=response_profile,
+        )
+        if session:
+            with contextlib.suppress(json.JSONDecodeError, TypeError):
+                _update_session_from_scan(session, json.loads(raw))
+        return _enrich_response_with_session(raw, session, "drift_scan")
+    except Exception as exc:
+        from drift.api_helpers import _error_response
+
+        error = _error_response("DRIFT-5001", str(exc), recoverable=True)
+        error["tool"] = "drift_scan"
+        return json.dumps(error, default=str)
+
+
+async def run_diff(
+    *,
+    path: str,
+    diff_ref: str,
+    uncommitted: bool,
+    staged_only: bool,
+    baseline_file: str | None,
+    max_findings: int,
+    response_detail: str,
+    signals: str | None,
+    exclude_signals: str | None,
+    response_profile: str | None,
+    hypothesis_id: str | None,
+    diagnostic_hypothesis: Any,
+    session_id: str,
+) -> str:
+    from drift.api import diff
+
+    session = _resolve_session(session_id)
+    blocked = _strict_guardrail_block_response("drift_diff", session)
+    if blocked is not None:
+        return blocked
+    hypothesis_ctx = _resolve_diagnostic_hypothesis_context(
+        tool_name="drift_diff",
+        session=session,
+        hypothesis_id=hypothesis_id,
+        diagnostic_hypothesis=diagnostic_hypothesis,
+    )
+    if hypothesis_ctx.get("blocked_response"):
+        return cast(str, hypothesis_ctx["blocked_response"])
+    kwargs = _session_defaults(
+        session,
+        {
+            "path": path,
+            "signals": _parse_csv_ids(signals),
+            "exclude_signals": _parse_csv_ids(exclude_signals),
+        },
+    )
+    bl_file = baseline_file
+    if bl_file is None and session and session.baseline_file:
+        bl_file = session.baseline_file
+
+    raw = await _run_api_tool(
+        "drift_diff",
+        diff,
+        path=kwargs["path"],
+        diff_ref=diff_ref,
+        uncommitted=uncommitted,
+        staged_only=staged_only,
+        baseline_file=bl_file,
+        max_findings=max_findings,
+        response_detail=response_detail,
+        signals=kwargs["signals"],
+        exclude_signals=kwargs["exclude_signals"],
+        response_profile=response_profile,
+    )
+    if session:
+        with contextlib.suppress(json.JSONDecodeError, TypeError):
+            _update_session_from_diff(session, json.loads(raw))
+    with contextlib.suppress(json.JSONDecodeError, TypeError):
+        parsed = json.loads(raw)
+        if isinstance(parsed, dict):
+            h_id = cast(str | None, hypothesis_ctx.get("hypothesis_id"))
+            if h_id:
+                parsed["hypothesis_id"] = h_id
+                parsed["verification_evidence"] = {
+                    "tool": "drift_diff",
+                    "accept_change": parsed.get("accept_change"),
+                    "blocking_reasons": parsed.get("blocking_reasons", []),
+                }
+                raw = json.dumps(parsed, default=str)
+    return _enrich_response_with_session(
+        raw,
+        session,
+        "drift_diff",
+        trace_meta=_trace_meta_from_hypothesis_result("drift_diff", raw),
+    )
+
+
+async def run_nudge(
+    *,
+    path: str,
+    changed_files: str | None,
+    uncommitted: bool,
+    response_profile: str | None,
+    hypothesis_id: str | None,
+    diagnostic_hypothesis: Any,
+    session_id: str,
+    task_signal: str | None,
+    task_edit_kind: str | None,
+    task_context_class: str | None,
+    timeout_ms: int | None = 1000,
+) -> str:
+    from drift.api import nudge
+
+    session = _resolve_session(session_id)
+    blocked = _strict_guardrail_block_response("drift_nudge", session)
+    if blocked is not None:
+        return blocked
+    hypothesis_ctx = _resolve_diagnostic_hypothesis_context(
+        tool_name="drift_nudge",
+        session=session,
+        hypothesis_id=hypothesis_id,
+        diagnostic_hypothesis=diagnostic_hypothesis,
+    )
+    if hypothesis_ctx.get("blocked_response"):
+        return cast(str, hypothesis_ctx["blocked_response"])
+    resolved_path = path
+    if session and (not path or path == "."):
+        resolved_path = session.repo_path
+
+    raw = await _run_api_tool(
+        "drift_nudge",
+        nudge,
+        path=resolved_path,
+        changed_files=_parse_csv_ids(changed_files),
+        uncommitted=uncommitted,
+        response_profile=response_profile,
+        task_signal=task_signal,
+        task_edit_kind=task_edit_kind,
+        task_context_class=task_context_class,
+        timeout_ms=timeout_ms,
+    )
+    if session:
+        try:
+            result = json.loads(raw)
+            score = result.get("score")
+            if score is not None:
+                session.last_scan_score = score
+        except (json.JSONDecodeError, TypeError):
+            pass
+        session.touch()
+    with contextlib.suppress(json.JSONDecodeError, TypeError):
+        parsed = json.loads(raw)
+        if isinstance(parsed, dict):
+            h_id = cast(str | None, hypothesis_ctx.get("hypothesis_id"))
+            if h_id:
+                parsed["hypothesis_id"] = h_id
+                parsed["verification_evidence"] = {
+                    "tool": "drift_nudge",
+                    "safe_to_commit": parsed.get("safe_to_commit"),
+                    "blocking_reasons": parsed.get("blocking_reasons", []),
+                    "changed_files": parsed.get("changed_files", []),
+                }
+                raw = json.dumps(parsed, default=str)
+    return _enrich_response_with_session(
+        raw,
+        session,
+        "drift_nudge",
+        trace_meta=_trace_meta_from_hypothesis_result("drift_nudge", raw),
+    )
+
+
+async def run_explain(
+    *,
+    topic: str,
+    response_profile: str | None,
+    session_id: str,
+) -> str:
+    from drift.api import explain
+
+    session = _resolve_session(session_id)
+    raw = await _run_api_tool(
+        "drift_explain",
+        explain,
+        topic=topic,
+        response_profile=response_profile,
+    )
+    if session:
+        session.touch()
+    return _enrich_response_with_session(raw, session, "drift_explain")
+
+
+async def run_validate(
+    *,
+    path: str,
+    config_file: str | None,
+    response_profile: str | None,
+    session_id: str,
+) -> str:
+    from drift.api import validate
+
+    session = _resolve_session(session_id)
+    resolved_path = path
+    if session and (not path or path == "."):
+        resolved_path = session.repo_path
+
+    raw = await _run_api_tool(
+        "drift_validate",
+        validate,
+        path=resolved_path,
+        config_file=config_file,
+        response_profile=response_profile,
+    )
+    if session:
+        session.touch()
+        if session.score_at_start is not None and session.last_scan_score is not None:
+            try:
+                parsed = json.loads(raw)
+                parsed["session_progress"] = {
+                    "score_at_start": session.score_at_start,
+                    "last_scan_score": session.last_scan_score,
+                    "score_delta": round(session.last_scan_score - session.score_at_start, 2),
+                    "tasks_total": len(session.selected_tasks or []),
+                    "tasks_completed": len(session.completed_task_ids),
+                    "tasks_remaining": session.tasks_remaining(),
+                }
+                raw = json.dumps(parsed, indent=2)
+            except (json.JSONDecodeError, TypeError):
+                pass
+    return _enrich_response_with_session(raw, session, "drift_validate")
+
+
+async def run_brief(
+    *,
+    path: str,
+    task: str,
+    scope: str | None,
+    max_guardrails: int,
+    response_detail: str,
+    response_profile: str | None,
+    session_id: str,
+) -> str:
+    session = _resolve_session(session_id)
+    resolved_path = path
+    if session and (not path or path == "."):
+        resolved_path = session.repo_path
+
+    def _sync() -> str:
+        from drift.api import brief
+
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                result = brief(
+                    resolved_path,
+                    task=task,
+                    scope_override=scope,
+                    max_guardrails=max_guardrails,
+                    response_profile=response_profile,
+                )
+            if response_detail == "concise":
+                result.pop("landscape", None)
+                result.pop("meta", None)
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            from drift.api_helpers import _error_response
+
+            error = _error_response("DRIFT-5010", str(exc), recoverable=True)
+            error["tool"] = "drift_brief"
+            error["agent_instruction"] = (
+                "Check that the repository path exists and the task string is not empty. "
+                "If the error persists, try passing an explicit --scope."
+            )
+            return json.dumps(error, default=str)
+
+    payload: str = cast(str, await _run_sync_in_thread(_sync, abandon_on_cancel=True))
+    if session:
+        with contextlib.suppress(json.JSONDecodeError, TypeError):
+            _update_session_from_brief(session, json.loads(payload))
+    return _enrich_response_with_session(payload, session, "drift_brief")
+
+
+async def run_shadow_verify(
+    *,
+    path: str,
+    scope_files: str | None,
+    uncommitted: bool,
+    response_profile: str | None,
+    session_id: str,
+) -> str:
+    from drift.api.shadow_verify import shadow_verify
+
+    session = _resolve_session(session_id)
+    resolved_path = path
+    if session and (not path or path == "."):
+        resolved_path = session.repo_path
+
+    raw = await _run_api_tool(
+        "drift_shadow_verify",
+        shadow_verify,
+        path=resolved_path,
+        scope_files=_parse_csv_ids(scope_files),
+        uncommitted=uncommitted,
+        response_profile=response_profile,
+    )
+    if session:
+        session.touch()
+    return _enrich_response_with_session(raw, session, "drift_shadow_verify")
+
+
+async def run_negative_context(
+    *,
+    path: str,
+    scope: str | None,
+    target_file: str | None,
+    max_items: int,
+    response_profile: str | None,
+    session_id: str,
+    timeout_seconds: float,
+) -> str:
+    session = _resolve_session(session_id)
+    resolved_path = path
+    if session and (not path or path == "."):
+        resolved_path = session.repo_path
+
+    def _sync() -> str:
+        from drift.api import negative_context
+
+        kwargs: dict[str, Any] = {
+            "scope": scope,
+            "target_file": target_file,
+            "max_items": max_items,
+            "disable_embeddings": True,
+        }
+        if response_profile is not None:
+            kwargs["response_profile"] = response_profile
+        with contextlib.redirect_stdout(io.StringIO()):
+            result = negative_context(resolved_path, **kwargs)
+        if not isinstance(result, dict):
+            return json.dumps(
+                {
+                    "status": "error",
+                    "error_code": "DRIFT-2032",
+                    "message": "MCP tool returned no structured response.",
+                    "recoverable": True,
+                    "agent_instruction": "Retry the call once; if it repeats, run drift_validate.",
+                },
+                default=str,
+            )
+        return json.dumps(result, default=str)
+
+    try:
+        raw = cast(str, await _run_sync_with_timeout(_sync, timeout_seconds))
+        if session:
+            session.touch()
+        return _enrich_response_with_session(raw, session, "drift_negative_context")
+    except TimeoutError:
+        return json.dumps(
+            {
+                "status": "error",
+                "error_code": "DRIFT-2031",
+                "message": (
+                    "MCP tool 'drift_negative_context' timed out before producing a "
+                    "response. This guard prevents silent chat hangs."
+                ),
+                "recoverable": True,
+                "timeout_seconds": timeout_seconds,
+                "path": path,
+                "scope": scope,
+                "target_file": target_file,
+                "max_items": max_items,
+                "agent_instruction": (
+                    "Retry with a narrower target_file or lower max_items. "
+                    "If timeout persists, run drift export-context offline and use the "
+                    "cached .drift-negative-context.md."
+                ),
+            },
+            default=str,
+        )
+    except Exception as exc:
+        from drift.api_helpers import _error_response
+
+        error = _error_response("DRIFT-5001", str(exc), recoverable=True)
+        error["tool"] = "drift_negative_context"
+        return json.dumps(error, default=str)

--- a/packages/drift-mcp/src/drift_mcp/mcp_router_architecture.py
+++ b/packages/drift-mcp/src/drift_mcp/mcp_router_architecture.py
@@ -1,0 +1,148 @@
+"""Bounded-context router for architecture & policy MCP tool implementations.
+
+Covers: steer, compile_policy, suggest_rules, generate_skills.
+"""
+
+from __future__ import annotations
+
+from drift_mcp.mcp_enrichment import _enrich_response_with_session
+from drift_mcp.mcp_orchestration import (
+    _resolve_session,
+    _session_defaults,
+    _strict_guardrail_block_response,
+)
+from drift_mcp.mcp_utils import _run_api_tool
+
+
+async def run_steer(
+    *,
+    path: str,
+    target: str,
+    max_abstractions: int,
+    response_profile: str | None,
+    session_id: str,
+) -> str:
+    from drift.api.steer import steer
+
+    session = _resolve_session(session_id)
+    blocked = _strict_guardrail_block_response("drift_steer", session)
+    if blocked is not None:
+        return blocked
+
+    kwargs = _session_defaults(
+        session,
+        {"path": path, "target_path": None, "signals": None, "exclude_signals": None},
+    )
+
+    raw = await _run_api_tool(
+        "drift_steer",
+        steer,
+        path=kwargs["path"],
+        target=target,
+        max_abstractions=max_abstractions,
+        response_profile=response_profile,
+    )
+    if session:
+        session.touch()
+    return _enrich_response_with_session(raw, session, "drift_steer")
+
+
+async def run_compile_policy(
+    *,
+    path: str,
+    task: str,
+    task_spec_path: str | None,
+    diff_ref: str | None,
+    max_rules: int,
+    response_profile: str | None,
+    session_id: str,
+) -> str:
+    from drift.api.compile_policy import compile_policy
+
+    session = _resolve_session(session_id)
+    blocked = _strict_guardrail_block_response("drift_compile_policy", session)
+    if blocked is not None:
+        return blocked
+
+    kwargs = _session_defaults(
+        session,
+        {"path": path, "target_path": None, "signals": None, "exclude_signals": None},
+    )
+
+    raw = await _run_api_tool(
+        "drift_compile_policy",
+        compile_policy,
+        path=kwargs["path"],
+        task=task,
+        task_spec_path=task_spec_path,
+        diff_ref=diff_ref,
+        max_rules=max_rules,
+        response_profile=response_profile,
+    )
+    if session:
+        session.touch()
+    return _enrich_response_with_session(raw, session, "drift_compile_policy")
+
+
+async def run_suggest_rules(
+    *,
+    path: str,
+    min_occurrences: int,
+    response_profile: str | None,
+    session_id: str,
+) -> str:
+    from drift.api.suggest_rules import suggest_rules
+
+    session = _resolve_session(session_id)
+    blocked = _strict_guardrail_block_response("drift_suggest_rules", session)
+    if blocked is not None:
+        return blocked
+
+    kwargs = _session_defaults(
+        session,
+        {"path": path, "target_path": None, "signals": None, "exclude_signals": None},
+    )
+
+    raw = await _run_api_tool(
+        "drift_suggest_rules",
+        suggest_rules,
+        path=kwargs["path"],
+        min_occurrences=min_occurrences,
+        response_profile=response_profile,
+    )
+    if session:
+        session.touch()
+    return _enrich_response_with_session(raw, session, "drift_suggest_rules")
+
+
+async def run_generate_skills(
+    *,
+    path: str,
+    min_occurrences: int,
+    min_confidence: float,
+    response_profile: str | None,
+    session_id: str,
+) -> str:
+    from drift.api.generate_skills import generate_skills
+
+    session = _resolve_session(session_id)
+    blocked = _strict_guardrail_block_response("drift_generate_skills", session)
+    if blocked is not None:
+        return blocked
+
+    kwargs = _session_defaults(
+        session,
+        {"path": path, "target_path": None, "signals": None, "exclude_signals": None},
+    )
+
+    raw = await _run_api_tool(
+        "drift_generate_skills",
+        generate_skills,
+        path=kwargs["path"],
+        min_occurrences=min_occurrences,
+        min_confidence=min_confidence,
+        response_profile=response_profile,
+    )
+    if session:
+        session.touch()
+    return _enrich_response_with_session(raw, session, "drift_generate_skills")

--- a/packages/drift-mcp/src/drift_mcp/mcp_router_calibration.py
+++ b/packages/drift-mcp/src/drift_mcp/mcp_router_calibration.py
@@ -1,0 +1,201 @@
+"""Bounded-context router for calibration MCP tool implementations.
+
+Handles the business logic for ``drift_feedback`` and ``drift_calibrate``
+tools, keeping them out of the transport/registration layer in mcp_server.py.
+"""
+
+from __future__ import annotations
+
+import json
+
+from drift_mcp.mcp_enrichment import _enrich_response_with_session
+from drift_mcp.mcp_orchestration import _resolve_session
+from drift_mcp.mcp_utils import _run_sync_in_thread
+
+
+def _build_feedback_response(
+    *,
+    resolved_signal: str,
+    file_path: str,
+    verdict: str,
+    finding_id: str,
+    feedback_path: object,
+) -> str:
+    """Build enriched JSON response for a recorded feedback event."""
+    from drift.calibration.feedback import load_feedback
+
+    events = load_feedback(feedback_path)  # type: ignore[arg-type]
+    pending_fp_count = sum(
+        1 for e in events if e.signal_type == resolved_signal and e.verdict == "fp"
+    )
+
+    return json.dumps(
+        {
+            "status": "recorded",
+            "signal": resolved_signal,
+            "file": file_path,
+            "verdict": verdict,
+            "finding_id": finding_id,
+            "pending_fp_count": pending_fp_count,
+            "next_tool_call": {"tool": "drift_calibrate", "params": {}},
+            "agent_instruction": (
+                "Feedback recorded. Run drift_calibrate to apply accumulated "
+                "feedback and update signal weights."
+            ),
+        }
+    )
+
+
+async def run_feedback(
+    *,
+    signal: str,
+    file_path: str,
+    verdict: str,
+    reason: str,
+    start_line: int,
+    path: str,
+    session_id: str,
+) -> str:
+    """Record TP/FP/FN feedback for a finding to improve signal calibration."""
+    from pathlib import Path as _Path
+
+    from drift.api_helpers import _error_response
+    from drift.calibration.feedback import FeedbackEvent, record_feedback, resolve_feedback_paths
+    from drift.config import SIGNAL_ABBREV, DriftConfig
+
+    session = _resolve_session(session_id)
+
+    def _sync() -> str:
+        repo = _Path(path).resolve()
+        cfg = DriftConfig.load(repo)
+        resolved = SIGNAL_ABBREV.get(signal.upper(), signal)
+        v = verdict.lower().strip()
+        if v not in ("tp", "fp", "fn"):
+            error = _error_response(
+                "DRIFT-1003",
+                f"Invalid verdict '{verdict}'. Use tp, fp, or fn.",
+                invalid_fields=[
+                    {
+                        "field": "verdict",
+                        "value": verdict,
+                        "expected": ["tp", "fp", "fn"],
+                    }
+                ],
+                suggested_fix={
+                    "verdict": "tp",
+                    "valid_values": ["tp", "fp", "fn"],
+                },
+                recoverable=True,
+            )
+            error["tool"] = "drift_feedback"
+            return json.dumps(error)
+        event = FeedbackEvent(
+            signal_type=resolved,
+            file_path=file_path,
+            verdict=v,  # type: ignore[arg-type]
+            source="user",
+            start_line=start_line if start_line > 0 else None,
+            evidence={"reason": reason} if reason else {},
+        )
+        feedback_path, _local_feedback_path, _shared_feedback_path = resolve_feedback_paths(
+            repo, cfg
+        )
+        record_feedback(feedback_path, event)
+        return _build_feedback_response(
+            resolved_signal=resolved,
+            file_path=file_path,
+            verdict=v,
+            finding_id=event.finding_id,
+            feedback_path=feedback_path,
+        )
+
+    raw = await _run_sync_in_thread(_sync, abandon_on_cancel=True)
+    if session:
+        session.touch()
+    return _enrich_response_with_session(raw, session, "drift_feedback")
+
+
+async def run_calibrate(
+    *,
+    path: str,
+    dry_run: bool,
+    session_id: str,
+) -> str:
+    """Compute calibrated signal weights from accumulated feedback evidence."""
+    from pathlib import Path as _Path
+
+    from drift.calibration.feedback import load_feedback, resolve_feedback_paths
+    from drift.calibration.profile_builder import build_profile
+    from drift.config import DriftConfig, SignalWeights
+
+    session = _resolve_session(session_id)
+
+    def _sync() -> str:
+        repo = _Path(path).resolve()
+        cfg = DriftConfig.load(repo)
+        feedback_path, _local_feedback_path, _shared_feedback_path = resolve_feedback_paths(
+            repo, cfg
+        )
+        events = load_feedback(feedback_path)
+
+        if not events:
+            return json.dumps(
+                {
+                    "status": "no_data",
+                    "message": "No feedback evidence found. Use drift_feedback to record evidence.",
+                    "agent_instruction": (
+                        "Record TP/FP/FN feedback for findings before calibrating."
+                    ),
+                }
+            )
+
+        result = build_profile(
+            events,
+            cfg.weights,
+            min_samples=cfg.calibration.min_samples,
+            fn_boost_factor=cfg.calibration.fn_boost_factor,
+        )
+        diff = result.weight_diff(SignalWeights())
+
+        if not dry_run and diff:
+            import yaml as _yaml  # type: ignore[import-untyped]
+
+            config_path = DriftConfig._find_config_file(repo) or repo / "drift.yaml"
+            if config_path.exists():
+                data = _yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            else:
+                data = {}
+            default_dict = SignalWeights().as_dict()
+            custom: dict[str, float] = {}
+            for key, val in result.calibrated_weights.as_dict().items():
+                if abs(val - default_dict.get(key, 0.0)) > 0.0001:
+                    custom[key] = round(val, 6)
+            if custom:
+                data["weights"] = custom
+            config_path.write_text(
+                _yaml.dump(data, default_flow_style=False, allow_unicode=True, sort_keys=False),
+                encoding="utf-8",
+            )
+
+        return json.dumps(
+            {
+                "status": "calibrated" if diff else "no_change",
+                "total_events": result.total_events,
+                "signals_with_data": result.signals_with_data,
+                "weight_changes": diff,
+                "dry_run": dry_run,
+                "written": not dry_run and bool(diff),
+                "agent_instruction": (
+                    "Review the weight changes. Use dry_run=false to apply, "
+                    "or record more feedback for higher confidence."
+                    if dry_run
+                    else "Weights written to drift.yaml."
+                ),
+            },
+            default=str,
+        )
+
+    raw = await _run_sync_in_thread(_sync, abandon_on_cancel=True)
+    if session:
+        session.touch()
+    return _enrich_response_with_session(raw, session, "drift_calibrate")

--- a/packages/drift-mcp/src/drift_mcp/mcp_router_intent.py
+++ b/packages/drift-mcp/src/drift_mcp/mcp_router_intent.py
@@ -1,0 +1,91 @@
+"""Bounded-context router for intent-loop MCP tool implementations.
+
+Handles the business logic for ``drift_capture_intent``,
+``drift_verify_intent``, and ``drift_feedback_for_agent`` tools, keeping
+them out of the transport/registration layer in mcp_server.py.
+"""
+
+from __future__ import annotations
+
+from drift_mcp.mcp_enrichment import _enrich_response_with_session
+from drift_mcp.mcp_orchestration import _resolve_session
+from drift_mcp.mcp_utils import _run_sync_in_thread
+
+
+async def run_capture_intent(
+    *,
+    raw: str,
+    path: str,
+    session_id: str,
+) -> str:
+    """Extract and persist a structured intent from a raw user input string."""
+    import json
+
+    from drift.api.capture_intent import capture_intent
+
+    session = _resolve_session(session_id)
+
+    def _sync() -> str:
+        result = capture_intent(raw=raw, path=path)
+        return json.dumps(result)
+
+    raw_resp = await _run_sync_in_thread(_sync, abandon_on_cancel=True)
+    if session:
+        session.touch()
+    return _enrich_response_with_session(raw_resp, session, "drift_capture_intent")
+
+
+async def run_verify_intent(
+    *,
+    intent_id: str,
+    artifact_path: str,
+    path: str,
+    session_id: str,
+) -> str:
+    """Verify that a build artifact fulfils a previously captured intent."""
+    import json
+
+    from drift.api.verify_intent import verify_intent
+
+    session = _resolve_session(session_id)
+
+    def _sync() -> str:
+        result = verify_intent(
+            intent_id=intent_id,
+            artifact_path=artifact_path,
+            path=path,
+        )
+        return json.dumps(result)
+
+    raw_resp = await _run_sync_in_thread(_sync, abandon_on_cancel=True)
+    if session:
+        session.touch()
+    return _enrich_response_with_session(raw_resp, session, "drift_verify_intent")
+
+
+async def run_feedback_for_agent(
+    *,
+    intent_id: str,
+    path: str,
+    artifact_path: str,
+    session_id: str,
+) -> str:
+    """Return a prioritised action list based on the current verify state."""
+    import json
+
+    from drift.api.feedback_for_agent import feedback_for_agent
+
+    session = _resolve_session(session_id)
+
+    def _sync() -> str:
+        result = feedback_for_agent(
+            intent_id=intent_id,
+            path=path,
+            artifact_path=artifact_path,
+        )
+        return json.dumps(result)
+
+    raw_resp = await _run_sync_in_thread(_sync, abandon_on_cancel=True)
+    if session:
+        session.touch()
+    return _enrich_response_with_session(raw_resp, session, "drift_feedback_for_agent")

--- a/packages/drift-mcp/src/drift_mcp/mcp_router_patch.py
+++ b/packages/drift-mcp/src/drift_mcp/mcp_router_patch.py
@@ -1,0 +1,143 @@
+"""Bounded-context router for patch engine MCP tool implementations."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from drift_mcp.mcp_enrichment import _enrich_response_with_session
+from drift_mcp.mcp_orchestration import _resolve_session
+from drift_mcp.mcp_utils import _parse_csv_ids, _run_api_tool
+
+
+def _store_patch_intent(session: Any, task_id: str, raw: str) -> None:
+    """Store the PatchIntent in session.active_patches if session exists."""
+    if session is None or not hasattr(session, "active_patches"):
+        return
+    try:
+        data = json.loads(raw)
+        intent = data.get("intent")
+        if intent:
+            session.active_patches[task_id] = {"intent": intent}
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+
+def _store_patch_verdict(session: Any, task_id: str, raw: str) -> None:
+    """Store the PatchVerdict in session.active_patches if session exists."""
+    if session is None or not hasattr(session, "active_patches"):
+        return
+    try:
+        data = json.loads(raw)
+        verdict = data.get("verdict")
+        if verdict and task_id in session.active_patches:
+            session.active_patches[task_id]["verdict"] = verdict
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+
+def _finalize_patch(session: Any, task_id: str, raw: str) -> None:
+    """Move completed patch from active_patches to patch_history."""
+    if session is None or not hasattr(session, "active_patches"):
+        return
+    try:
+        data = json.loads(raw)
+        evidence = data.get("evidence")
+        if evidence:
+            if hasattr(session, "patch_history"):
+                session.patch_history.append(evidence)
+            session.active_patches.pop(task_id, None)
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+
+async def run_patch_begin(
+    *,
+    task_id: str,
+    declared_files: str,
+    expected_outcome: str,
+    session_id: str,
+    blast_radius: str,
+    forbidden_paths: str | None,
+    max_diff_lines: int | None,
+) -> str:
+    from drift.api.patch import patch_begin
+
+    session = _resolve_session(session_id)
+
+    raw = await _run_api_tool(
+        "drift_patch_begin",
+        patch_begin,
+        task_id=task_id,
+        declared_files=_parse_csv_ids(declared_files) or [],
+        expected_outcome=expected_outcome,
+        session_id=session_id or None,
+        blast_radius=blast_radius,
+        forbidden_paths=_parse_csv_ids(forbidden_paths),
+        max_diff_lines=max_diff_lines,
+    )
+    if session:
+        _store_patch_intent(session, task_id, raw)
+        session.touch()
+    return _enrich_response_with_session(raw, session, "drift_patch_begin")
+
+
+async def run_patch_check(
+    *,
+    task_id: str,
+    declared_files: str,
+    path: str,
+    session_id: str,
+    forbidden_paths: str | None,
+    max_diff_lines: int | None,
+) -> str:
+    from drift.api.patch import patch_check
+
+    session = _resolve_session(session_id)
+    resolved_path = path
+    if session and (not path or path == "."):
+        resolved_path = session.repo_path
+
+    raw = await _run_api_tool(
+        "drift_patch_check",
+        patch_check,
+        task_id=task_id,
+        declared_files=_parse_csv_ids(declared_files) or [],
+        path=resolved_path,
+        forbidden_paths=_parse_csv_ids(forbidden_paths),
+        max_diff_lines=max_diff_lines,
+    )
+    if session:
+        _store_patch_verdict(session, task_id, raw)
+        session.touch()
+    return _enrich_response_with_session(raw, session, "drift_patch_check")
+
+
+async def run_patch_commit(
+    *,
+    task_id: str,
+    declared_files: str,
+    expected_outcome: str,
+    path: str,
+    session_id: str,
+) -> str:
+    from drift.api.patch import patch_commit
+
+    session = _resolve_session(session_id)
+    resolved_path = path
+    if session and (not path or path == "."):
+        resolved_path = session.repo_path
+
+    raw = await _run_api_tool(
+        "drift_patch_commit",
+        patch_commit,
+        task_id=task_id,
+        declared_files=_parse_csv_ids(declared_files) or [],
+        expected_outcome=expected_outcome,
+        path=resolved_path,
+        session_id=session_id or None,
+    )
+    if session:
+        _finalize_patch(session, task_id, raw)
+        session.touch()
+    return _enrich_response_with_session(raw, session, "drift_patch_commit")

--- a/packages/drift-mcp/src/drift_mcp/mcp_router_repair.py
+++ b/packages/drift-mcp/src/drift_mcp/mcp_router_repair.py
@@ -1,0 +1,263 @@
+"""Bounded-context router for fix-plan and verify MCP tool implementations."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from typing import Any
+
+from drift_mcp.mcp_enrichment import _enrich_response_with_session
+from drift_mcp.mcp_orchestration import (
+    _resolve_session,
+    _session_defaults,
+    _strict_guardrail_block_response,
+    _update_session_from_fix_plan,
+)
+from drift_mcp.mcp_utils import _parse_csv_ids, _run_api_tool
+
+
+def _can_use_session_fix_plan_fast_path(
+    *,
+    session: Any,
+    path: str,
+    signal: str | None,
+    automation_fit_min: str | None,
+    target_path: str | None,
+    exclude_paths: list[str] | None,
+    include_deferred: bool,
+    include_non_operational: bool,
+    response_profile: str | None,
+) -> bool:
+    """Return whether fix_plan can reuse the session queue without re-analysis.
+
+    Eligible response profiles for the cache fast-path are ``None``, ``planner``,
+    and ``coder``. Other profiles (for example ``verifier`` and
+    ``merge_readiness``) require the full API call so their shaped payload stays
+    consistent with profile-specific contracts.
+    """
+    if session is None or not session.selected_tasks:
+        return False
+    if path not in ("", "."):
+        return False
+    if signal is not None:
+        return False
+    if automation_fit_min is not None:
+        return False
+    if target_path is not None:
+        return False
+    if exclude_paths:
+        return False
+    if include_deferred:
+        return False
+    if include_non_operational:
+        return False
+    return response_profile in (None, "planner", "coder")
+
+
+def _session_fix_plan_fast_response(session: Any, *, max_tasks: int) -> dict[str, Any]:
+    selected_tasks = list(session.selected_tasks or [])
+    selected_by_id = {str(task.get("id", task.get("task_id", ""))): task for task in selected_tasks}
+
+    pending_tasks: list[dict[str, Any]]
+    queue_status = getattr(session, "queue_status", None)
+    if callable(queue_status):
+        queue = queue_status() or {}
+        pending_entries = list(queue.get("pending_tasks") or [])
+        pending_tasks = []
+        for entry in pending_entries:
+            task_id = str(entry.get("id", entry.get("task_id", "")))
+            if task_id in selected_by_id:
+                pending_tasks.append(selected_by_id[task_id])
+            else:
+                pending_tasks.append(entry)
+    else:
+        completed_ids = {str(task_id) for task_id in (session.completed_task_ids or [])}
+        pending_tasks = [
+            task
+            for task in selected_tasks
+            if str(task.get("id", task.get("task_id", ""))) not in completed_ids
+        ]
+
+    limit = max(0, int(max_tasks))
+    limited = pending_tasks[:limit] if limit else []
+
+    remaining_by_signal: dict[str, int] = {}
+    for task in pending_tasks:
+        signal = str(task.get("signal", "UNKNOWN"))
+        remaining_by_signal[signal] = remaining_by_signal.get(signal, 0) + 1
+
+    return {
+        "status": "ok",
+        "drift_score": round(float(session.last_scan_score), 3)
+        if session.last_scan_score is not None
+        else None,
+        "drift_score_scope": "context:fix-plan,signals:session,path:session-default",
+        "tasks": limited,
+        "task_count": len(limited),
+        "total_available": len(pending_tasks),
+        "remaining_by_signal": remaining_by_signal,
+        "recommended_next_actions": [
+            "drift_nudge after each fix for fast directional feedback",
+            "drift_diff(uncommitted=True) before final accept/commit",
+        ],
+        "agent_instruction": (
+            "Served fix-plan from session task queue cache (no full re-analysis). "
+            "Call drift_nudge after applying the selected task, then request the next "
+            "task with drift_fix_plan(max_tasks=1)."
+        ),
+        "next_tool_call": {
+            "tool": "drift_nudge",
+        },
+        "fallback_tool_call": {
+            "tool": "drift_diff",
+            "params": {"uncommitted": True},
+        },
+        "done_when": "accept_change == true OR (drift_detected == false AND score_delta <= 0)",
+        "cache": {
+            "hit": True,
+            "source": "session.fix_plan_queue",
+        },
+    }
+
+
+async def run_fix_plan(
+    *,
+    path: str,
+    signal: str | None,
+    max_tasks: int,
+    automation_fit_min: str | None,
+    target_path: str | None,
+    exclude_paths: str | None,
+    include_deferred: bool,
+    include_non_operational: bool,
+    response_profile: str | None,
+    session_id: str,
+) -> str:
+    from drift.api import fix_plan
+
+    session = _resolve_session(session_id)
+    blocked = _strict_guardrail_block_response("drift_fix_plan", session)
+    if blocked is not None:
+        return blocked
+    parsed_exclude_paths = _parse_csv_ids(exclude_paths)
+
+    if _can_use_session_fix_plan_fast_path(
+        session=session,
+        path=path,
+        signal=signal,
+        automation_fit_min=automation_fit_min,
+        target_path=target_path,
+        exclude_paths=parsed_exclude_paths,
+        include_deferred=include_deferred,
+        include_non_operational=include_non_operational,
+        response_profile=response_profile,
+    ):
+        cached_result = _session_fix_plan_fast_response(session, max_tasks=max_tasks)
+        _update_session_from_fix_plan(session, cached_result)
+        return _enrich_response_with_session(
+            json.dumps(cached_result, default=str),
+            session,
+            "drift_fix_plan",
+        )
+
+    kwargs = _session_defaults(
+        session,
+        {
+            "path": path,
+            "target_path": target_path,
+            "signals": None,
+            "exclude_signals": None,
+        },
+    )
+
+    raw = await _run_api_tool(
+        "drift_fix_plan",
+        fix_plan,
+        path=kwargs["path"],
+        signal=signal,
+        max_tasks=max_tasks,
+        automation_fit_min=automation_fit_min,
+        target_path=kwargs["target_path"],
+        exclude_paths=parsed_exclude_paths,
+        include_deferred=include_deferred,
+        include_non_operational=include_non_operational,
+        response_profile=response_profile,
+    )
+    if session:
+        with contextlib.suppress(json.JSONDecodeError, TypeError):
+            _update_session_from_fix_plan(session, json.loads(raw))
+    return _enrich_response_with_session(raw, session, "drift_fix_plan")
+
+
+async def run_verify(
+    *,
+    path: str,
+    fail_on: str,
+    scope_files: str | None,
+    uncommitted: bool,
+    response_profile: str | None,
+    session_id: str,
+) -> str:
+    from drift.api.verify import verify
+
+    session = _resolve_session(session_id)
+    resolved_path = path
+    if session and (not path or path == "."):
+        resolved_path = session.repo_path
+
+    raw = await _run_api_tool(
+        "drift_verify",
+        verify,
+        path=resolved_path,
+        fail_on=fail_on,
+        scope_files=_parse_csv_ids(scope_files),
+        uncommitted=uncommitted,
+        response_profile=response_profile,
+    )
+    if session:
+        session.touch()
+    return _enrich_response_with_session(raw, session, "drift_verify")
+
+
+async def run_fix_apply(
+    *,
+    path: str,
+    signal: str | None,
+    max_tasks: int,
+    dry_run: bool,
+    target_path: str | None,
+    exclude_paths: str | None,
+    session_id: str,
+) -> str:
+    from drift.api.fix_apply import fix_apply
+
+    session = _resolve_session(session_id)
+    blocked = _strict_guardrail_block_response("drift_fix_apply", session)
+    if blocked is not None:
+        return blocked
+
+    parsed_exclude_paths = _parse_csv_ids(exclude_paths)
+
+    kwargs = _session_defaults(
+        session,
+        {
+            "path": path,
+            "target_path": target_path,
+            "signals": None,
+            "exclude_signals": None,
+        },
+    )
+
+    raw = await _run_api_tool(
+        "drift_fix_apply",
+        fix_apply,
+        path=kwargs["path"],
+        signal=signal,
+        max_tasks=max_tasks,
+        dry_run=dry_run,
+        target_path=kwargs["target_path"],
+        exclude_paths=parsed_exclude_paths,
+    )
+    if session:
+        session.touch()
+    return _enrich_response_with_session(raw, session, "drift_fix_apply")

--- a/packages/drift-mcp/src/drift_mcp/mcp_router_retrieval.py
+++ b/packages/drift-mcp/src/drift_mcp/mcp_router_retrieval.py
@@ -1,0 +1,9 @@
+"""Compatibility shim — moved to `drift.retrieval.mcp` (ADR-099).
+
+The real implementation now lives in the retrieval slice. This module is a
+thin re-export so legacy importers (`from drift_mcp.mcp_router_retrieval import
+run_retrieve` etc.) keep working. New code should import from
+`drift.retrieval.mcp` directly.
+"""
+
+from drift.retrieval.mcp import *  # noqa: F401,F403

--- a/packages/drift-mcp/src/drift_mcp/mcp_router_session.py
+++ b/packages/drift-mcp/src/drift_mcp/mcp_router_session.py
@@ -1,0 +1,889 @@
+"""Bounded-context router for MCP session lifecycle tools."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from drift_mcp.mcp_autopilot import AUTOPILOT_PAYLOAD_MODES, build_autopilot_summary
+from drift_mcp.mcp_orchestration import _strict_guardrail_block_response
+from drift_mcp.mcp_utils import _parse_csv_ids, _run_sync_in_thread
+
+# ---------------------------------------------------------------------------
+# ADR-081 Nachschärfung (Q2): plan-staleness threshold
+# ---------------------------------------------------------------------------
+# A queue log whose newest ``plan_created`` event is older than this many
+# seconds is treated as stale: the session_start response still replays the
+# plan so no work is lost, but ``resumed_plan_stale`` becomes True, the
+# agent_instruction warns the agent, and ``next_tool_call`` is redirected to
+# ``drift_fix_plan`` so prioritisation can happen against the current scan.
+# Default 24 h matches the "next working day" heuristic; override via the
+# ``DRIFT_QUEUE_STALE_SECONDS`` environment variable for tests or projects
+# with very fast cadence.
+_QUEUE_PLAN_STALE_SECONDS_DEFAULT: float = 86_400.0
+
+
+def _queue_plan_stale_threshold() -> float:
+    """Return the current staleness threshold in seconds.
+
+    Reads ``DRIFT_QUEUE_STALE_SECONDS`` at call time so tests can override
+    it via ``monkeypatch.setenv`` without reloading the module.  Invalid
+    or non-positive values fall back to the default.
+    """
+    raw = os.environ.get("DRIFT_QUEUE_STALE_SECONDS")
+    if not raw:
+        return _QUEUE_PLAN_STALE_SECONDS_DEFAULT
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return _QUEUE_PLAN_STALE_SECONDS_DEFAULT
+    if value <= 0.0:
+        return _QUEUE_PLAN_STALE_SECONDS_DEFAULT
+    return value
+
+
+async def run_session_start(
+    *,
+    path: str,
+    signals: str | None,
+    exclude_signals: str | None,
+    target_path: str | None,
+    exclude_paths: str | None,
+    ttl_seconds: int,
+    autopilot: bool,
+    autopilot_payload: str,
+    response_profile: str | None,
+    fresh_start: bool = False,
+) -> str:
+    from drift.api_helpers import _error_response
+    from drift.session import SessionManager
+    from drift.session_queue_log import reduce_events, replay_events
+    from drift_mcp.mcp_enrichment import _enrich_response_with_session
+
+    payload_mode = str(autopilot_payload).strip().lower()
+    if payload_mode not in AUTOPILOT_PAYLOAD_MODES:
+        error = _error_response(
+            "DRIFT-1003",
+            f"Invalid autopilot_payload '{autopilot_payload}'",
+            invalid_fields=[
+                {
+                    "field": "autopilot_payload",
+                    "value": autopilot_payload,
+                    "reason": "Expected one of: summary, full",
+                }
+            ],
+            suggested_fix={
+                "action": "Use a supported autopilot payload mode.",
+                "valid_values": ["summary", "full"],
+                "example_call": {
+                    "tool": "drift_session_start",
+                    "params": {
+                        "path": path,
+                        "autopilot": True,
+                        "autopilot_payload": "summary",
+                    },
+                },
+            },
+        )
+        return json.dumps(error, default=str)
+
+    mgr = SessionManager.instance()
+    try:
+        session_id = mgr.create(
+            repo_path=str(Path(path).resolve()),
+            signals=_parse_csv_ids(signals),
+            exclude_signals=_parse_csv_ids(exclude_signals),
+            target_path=target_path,
+            exclude_paths=_parse_csv_ids(exclude_paths),
+            ttl_seconds=ttl_seconds,
+        )
+    except RuntimeError as exc:
+        if "DRIFT-4000" not in str(exc):
+            raise
+        error = _error_response(
+            "DRIFT-4000",
+            str(exc),
+            invalid_fields=[
+                {
+                    "field": "session_pool",
+                    "value": "exhausted",
+                    "reason": "maximum number of active sessions reached",
+                }
+            ],
+            suggested_fix={
+                "action": "End inactive sessions or retry later.",
+                "example_call": {
+                    "tool": "drift_session_end",
+                    "params": {"session_id": "<active-session-id>"},
+                },
+            },
+            recoverable=True,
+        )
+        return json.dumps(error, default=str)
+
+    session = mgr.get(session_id)
+
+    # ADR-081 Nachschärfung (Q3): best-effort concurrent-writer detection.
+    # Read any existing writer-advisory lock *before* we take ownership so
+    # we can surface a live previous holder in the response.  ADR-081 keeps
+    # the cooperative single-writer contract, so we do not hard-block.
+    from drift.session_writer_lock import (
+        acquire_writer_advisory,
+        read_current_holder,
+    )
+
+    concurrent_writer: dict[str, object] | None = None
+    concurrent_sessions_detected = False
+    repo_for_lock: Path | str | None = None
+    if session is not None:
+        repo_candidate = getattr(session, "repo_path", None)
+        if isinstance(repo_candidate, (str, Path)):
+            repo_for_lock = repo_candidate
+    if repo_for_lock is not None:
+        try:
+            holder = read_current_holder(repo_for_lock)
+        except Exception as exc:  # noqa: BLE001 - best-effort advisory
+            logging.getLogger("drift").debug("concurrent-writer probe failed: %s", exc)
+            holder = None
+        if holder is not None and holder.session_id != session_id:
+            concurrent_sessions_detected = True
+            concurrent_writer = holder.to_dict()
+        try:
+            acquire_writer_advisory(repo_for_lock, session_id=session_id)
+        except OSError as exc:
+            logging.getLogger("drift").debug("writer-advisory acquire failed: %s", exc)
+
+    # Queue-log replay: rehydrate selected_tasks / completed / failed from a
+    # previous session's append-only log so agent work survives MCP server
+    # restarts and session TTL expiry.  ADR-081.
+    resumed_from_log = False
+    resumed_tasks = 0
+    resumed_completed = 0
+    resumed_failed = 0
+    resumed_plan_created_at: float | None = None
+    resumed_plan_age_seconds: float | None = None
+    resumed_plan_stale = False
+    resumed_older_plans_discarded = 0
+    resumed_next_task_id: str | None = None
+    if session is not None and not fresh_start:
+        events = replay_events(session.repo_path)
+        if events:
+            state = reduce_events(events)
+            # ADR-081 Nachschärfung (Q4): count any ``plan_created`` events
+            # older than the one that wins the replay; purely informational
+            # so reviewers can audit that replan semantics are intentional.
+            if state.plan_created_at is not None:
+                resumed_older_plans_discarded = sum(
+                    1
+                    for evt in events
+                    if evt.type == "plan_created"
+                    and float(evt.timestamp) < float(state.plan_created_at)
+                )
+            if state.selected_tasks:
+                # Session was just created and is not yet exposed to other
+                # tool calls, so direct field assignment is safe.
+                session.selected_tasks = list(state.selected_tasks)
+                for tid in state.completed_task_ids:
+                    if tid not in session.completed_task_ids:
+                        session.completed_task_ids.append(tid)
+                for tid in state.failed_task_ids:
+                    if tid not in session.failed_task_ids:
+                        session.failed_task_ids.append(tid)
+                resumed_from_log = True
+                resumed_tasks = len(state.selected_tasks)
+                resumed_completed = len(state.completed_task_ids)
+                resumed_failed = len(state.failed_task_ids)
+                # ADR-081 Nachschärfung (Q2): surface plan age so agents
+                # can decide to re-plan rather than follow a stale queue.
+                if state.plan_created_at is not None:
+                    resumed_plan_created_at = float(state.plan_created_at)
+                    age = max(0.0, time.time() - resumed_plan_created_at)
+                    resumed_plan_age_seconds = age
+                    if age > _queue_plan_stale_threshold():
+                        resumed_plan_stale = True
+                # ADR-081 Nachschärfung (Q5): pick the first pending task so
+                # the response can route the agent straight to
+                # ``drift_fix_apply`` instead of a generic ``drift_scan``.
+                # Pending = in selected_tasks and not in completed/failed.
+                # Order: ``priority_score`` DESC (from drift_fix_plan) with
+                # original index as deterministic tiebreaker.
+                completed_set = set(state.completed_task_ids)
+                failed_set = set(state.failed_task_ids)
+                pending: list[tuple[int, dict[str, Any]]] = []
+                for idx, task in enumerate(state.selected_tasks):
+                    candidate = task.get("id") or task.get("task_id")
+                    if not isinstance(candidate, str) or not candidate:
+                        continue
+                    if candidate in completed_set or candidate in failed_set:
+                        continue
+                    pending.append((idx, task))
+
+                def _score(entry: tuple[int, dict[str, Any]]) -> tuple[float, int]:
+                    idx, task = entry
+                    raw = task.get("priority_score")
+                    try:
+                        score = float(raw) if raw is not None else 0.0
+                    except (TypeError, ValueError):
+                        score = 0.0
+                    # DESC on score, ASC on idx — invert score sign so the
+                    # built-in ASC sort gives DESC on score.
+                    return (-score, idx)
+
+                pending.sort(key=_score)
+                if pending:
+                    first = pending[0][1]
+                    first_tid = first.get("id") or first.get("task_id")
+                    if isinstance(first_tid, str) and first_tid:
+                        resumed_next_task_id = first_tid
+
+    result: dict[str, Any] = {
+        "status": "ok",
+        "session_id": session_id,
+        "repo_path": str(Path(path).resolve()),
+        "scope": session.scope_label() if session else "all",
+        "ttl_seconds": ttl_seconds,
+        "created_at": session.created_at if session else None,
+        "resumed_from_log": resumed_from_log,
+        "resumed_tasks": resumed_tasks,
+        "resumed_completed": resumed_completed,
+        "resumed_failed": resumed_failed,
+        "resumed_plan_created_at": resumed_plan_created_at,
+        "resumed_plan_age_seconds": resumed_plan_age_seconds,
+        "resumed_plan_stale": resumed_plan_stale,
+        "resumed_older_plans_discarded": resumed_older_plans_discarded,
+        "resumed_next_task_id": resumed_next_task_id,
+        "concurrent_sessions_detected": concurrent_sessions_detected,
+        "concurrent_writer": concurrent_writer,
+        "agent_instruction": (
+            f'Session {session_id[:8]} created. Pass session_id="{session_id}" '
+            "to subsequent drift tools to use session defaults and track state. "
+            "Recommended next: drift_validate, then drift_scan with this session_id."
+        ),
+        "recommended_next_actions": [
+            f'drift_validate(session_id="{session_id}")',
+            f'drift_scan(session_id="{session_id}")',
+        ],
+        "next_tool_call": {
+            "tool": "drift_scan",
+            "params": {"session_id": session_id},
+        },
+        "fallback_tool_call": {
+            "tool": "drift_validate",
+            "params": {"session_id": session_id},
+        },
+        "done_when": "session.tasks_remaining == 0",
+    }
+
+    # ADR-081 Nachschärfung (Q2): when the replayed plan is older than the
+    # staleness threshold, override agent_instruction and next_tool_call so
+    # the agent re-prioritises against the current codebase instead of
+    # following a zombie plan.
+    if resumed_plan_stale and resumed_plan_age_seconds is not None:
+        age_hours = resumed_plan_age_seconds / 3600.0
+        result["agent_instruction"] = (
+            f"Session {session_id[:8]} resumed a queued plan that is "
+            f"{age_hours:.1f}h old ({resumed_tasks} pending tasks). "
+            "Plan may be stale — run drift_fix_plan again to re-prioritise "
+            "against the current scan before applying fixes."
+        )
+        result["next_tool_call"] = {
+            "tool": "drift_fix_plan",
+            "params": {"session_id": session_id},
+        }
+        result["fallback_tool_call"] = {
+            "tool": "drift_scan",
+            "params": {"session_id": session_id},
+        }
+    elif resumed_from_log and resumed_next_task_id is not None and resumed_tasks > 0:
+        # ADR-081 Nachschärfung (Q5): fresh resume with pending work —
+        # route the agent straight to ``drift_fix_apply`` so the queue is
+        # worked off instead of re-scanning.  Only applies when the plan
+        # is NOT stale (P2 override above wins otherwise) and fresh_start
+        # is not in effect (resumed_from_log remains False then).
+        result["agent_instruction"] = (
+            f"Session {session_id[:8]} resumed with {resumed_tasks} pending "
+            f"tasks. Address the queue with drift_fix_apply "
+            f"(task_id={resumed_next_task_id!r}) before launching new scans."
+        )
+        result["next_tool_call"] = {
+            "tool": "drift_fix_apply",
+            "params": {
+                "session_id": session_id,
+                "task_id": resumed_next_task_id,
+            },
+        }
+        result["fallback_tool_call"] = {
+            "tool": "drift_fix_plan",
+            "params": {"session_id": session_id},
+        }
+
+    # ADR-081 Nachschärfung (Q3): if a live previous writer was detected
+    # (before replay), annotate the agent_instruction so the operator
+    # knows to pause the other session.  Advisory only — ADR-081 stays
+    # cooperative.
+    if concurrent_sessions_detected and concurrent_writer is not None:
+        holder_pid = concurrent_writer.get("pid")
+        holder_sid = concurrent_writer.get("session_id", "unknown")
+        existing = result.get("agent_instruction", "")
+        result["agent_instruction"] = (
+            f"{existing} Concurrent writer detected (pid={holder_pid}, "
+            f"session={str(holder_sid)[:8]}) — pause the other session or "
+            "queue writes may interleave."
+        ).strip()
+
+    if autopilot:
+        from drift.analyzer import analyze_repo
+        from drift.api import validate
+        from drift.api._config import _load_config_cached, _warn_config_issues
+        from drift.api.brief import brief_from_analysis
+        from drift.api.fix_plan import _build_fix_plan_response_from_analysis
+        from drift.api.scan import _format_scan_response
+        from drift.api_helpers import (
+            build_drift_score_scope,
+            shape_for_profile,
+            signal_scope_label,
+        )
+        from drift.config import apply_signal_filter, resolve_signal_names
+
+        loop = asyncio.get_running_loop()
+        resolved = str(Path(path).resolve())
+        sig_list = _parse_csv_ids(signals) or None
+        excl_sig_list = _parse_csv_ids(exclude_signals) or None
+        excl_paths = _parse_csv_ids(exclude_paths) or None
+
+        val_result = await loop.run_in_executor(
+            None,
+            lambda: validate(
+                path=resolved,
+                response_profile=response_profile,
+            ),
+        )
+
+        def _autopilot_from_shared_analysis() -> tuple[
+            dict[str, Any], dict[str, Any], dict[str, Any], bool
+        ]:
+            repo_path = Path(resolved)
+            cfg = _load_config_cached(repo_path)
+            cfg_warnings = _warn_config_issues(cfg)
+
+            warnings: list[str] = list(cfg_warnings)
+            if target_path and not (repo_path / target_path).exists():
+                warnings.append(f"target_path '{target_path}' does not exist in repository")
+
+            active_signals: set[str] | None = None
+            select_csv = ",".join(sig_list) if sig_list else None
+            ignore_csv = ",".join(excl_sig_list) if excl_sig_list else None
+            if select_csv or ignore_csv:
+                apply_signal_filter(cfg, select_csv, ignore_csv)
+                if select_csv:
+                    active_signals = set(resolve_signal_names(select_csv))
+
+            file_hashes: dict[str, str] = {}
+            analysis = analyze_repo(
+                repo_path,
+                config=cfg,
+                since_days=90,
+                target_path=target_path,
+                active_signals=active_signals,
+                file_hashes_out=file_hashes,
+            )
+
+            # Pre-warm the nudge baseline so the first drift_nudge call
+            # is fast (no cold-start latency). Issue #544 — Friction 2.
+            nudge_primed = False
+            try:
+                from drift.incremental import BaselineManager, BaselineSnapshot
+
+                ttl = getattr(cfg, "nudge_baseline_ttl_seconds", 900)
+                nudge_baseline = BaselineSnapshot(
+                    file_hashes=file_hashes,
+                    score=analysis.drift_score,
+                    ttl_seconds=ttl,
+                )
+                BaselineManager.instance().store(
+                    repo_path,
+                    nudge_baseline,
+                    list(analysis.findings),
+                    {},
+                    config=cfg,
+                )
+                nudge_primed = True
+            except Exception:  # pragma: no cover — pre-warm must never break session_start
+                pass
+
+            brief_result = brief_from_analysis(
+                path=resolved,
+                task="autopilot session start",
+                analysis=analysis,
+                cfg=cfg,
+                scope_override=target_path,
+                signals=sig_list,
+                max_guardrails=10,
+                include_non_operational=False,
+            )
+
+            scan_result = _format_scan_response(
+                analysis,
+                config=cfg,
+                max_findings=10,
+                max_per_signal=None,
+                detail="concise",
+                strategy="diverse",
+                signal_filter=set(s.upper() for s in sig_list) if sig_list else None,
+                include_non_operational=False,
+                drift_score_scope=build_drift_score_scope(
+                    context="repo",
+                    path=target_path,
+                    signal_scope=signal_scope_label(selected=sig_list),
+                ),
+            )
+            if warnings:
+                scan_result["warnings"] = list(warnings)
+
+            fix_plan_result = _build_fix_plan_response_from_analysis(
+                analysis=analysis,
+                cfg=cfg,
+                repo_path=repo_path,
+                finding_id=None,
+                signal=None,
+                max_tasks=5,
+                automation_fit_min=None,
+                target_path=target_path,
+                exclude_paths=excl_paths,
+                include_deferred=False,
+                include_non_operational=False,
+                warnings=list(warnings),
+            )
+            return (
+                shape_for_profile(brief_result, response_profile),
+                shape_for_profile(scan_result, response_profile),
+                shape_for_profile(fix_plan_result, response_profile),
+                nudge_primed,
+            )
+
+        brief_result, scan_result, fp_result, _nudge_primed = await loop.run_in_executor(
+            None,
+            _autopilot_from_shared_analysis,
+        )
+        if payload_mode == "full":
+            result["autopilot"] = {
+                "validate": val_result,
+                "brief": brief_result,
+                "scan": scan_result,
+                "fix_plan": fp_result,
+            }
+        else:
+            result["autopilot"] = build_autopilot_summary(
+                session_id=session_id,
+                validate_result=val_result,
+                brief_result=brief_result,
+                scan_result=scan_result,
+                fix_plan_result=fp_result,
+            )
+        result["nudge_ready"] = _nudge_primed
+        result["agent_instruction"] = "Autopilot ready. Next: drift_fix_plan(session_id)."
+        result["recommended_next_actions"] = [
+            f'drift_fix_plan(session_id="{session_id}", max_tasks=1)',
+            f'drift_session_status(session_id="{session_id}")',
+        ]
+        result["next_tool_call"] = {
+            "tool": "drift_fix_plan",
+            "params": {"session_id": session_id},
+        }
+
+        # Intent capture hint for high-AI-attributed-ratio repositories (Issue 537)
+        _ai_ratio = float(scan_result.get("ai_ratio", 0.0))
+        if _ai_ratio > 0.7:
+            result["intent_capture_hint"] = {
+                "reason": "high_ai_attributed_ratio",
+                "ai_attributed_ratio": round(_ai_ratio, 3),
+                "threshold": 0.7,
+                "suggested_tool": "drift_capture_intent",
+                "suggested_command": "drift intent run",
+                "message": (
+                    f"AI-attributed commit ratio is {_ai_ratio:.0%} (>70%). "
+                    "Consider capturing intent before making code changes: "
+                    "drift_capture_intent(path='.')"
+                ),
+            }
+            result["agent_instruction"] = (
+                f"Autopilot ready. AI-attributed commit ratio is {_ai_ratio:.0%} (>70%) — "
+                "run drift_capture_intent(path='.') before code changes. "
+                "Next: drift_fix_plan(session_id)."
+            )
+            result["recommended_next_actions"] = [
+                'drift_capture_intent(path=".")',
+                f'drift_fix_plan(session_id="{session_id}", max_tasks=1)',
+                f'drift_session_status(session_id="{session_id}")',
+            ]
+
+    raw = json.dumps(result, default=str)
+    return _enrich_response_with_session(raw, session, "drift_session_start")
+
+
+async def run_session_status(
+    *,
+    session_id: str,
+    session_error_response: Callable[[str, str, str], str],
+) -> str:
+    from drift.session import SessionManager
+
+    session = SessionManager.instance().get(session_id)
+    if session is None:
+        return session_error_response(
+            "DRIFT-6001",
+            f"Session {session_id[:8]} not found or expired.",
+            session_id,
+        )
+
+    result = session.summary()
+    result["status"] = "ok"
+    result["agent_instruction"] = (
+        f"Session {session_id[:8]} is active with {session.tasks_remaining()} tasks remaining."
+    )
+    return json.dumps(result, default=str)
+
+
+async def run_session_update(
+    *,
+    session_id: str,
+    signals: str | None,
+    exclude_signals: str | None,
+    target_path: str | None,
+    mark_tasks_complete: str | None,
+    save_to_disk: bool,
+    session_error_response: Callable[[str, str, str], str],
+) -> str:
+    import warnings
+
+    from drift.session import SessionManager
+
+    warnings.warn(
+        "drift_session_update is deprecated and will be removed in v3.0. "
+        "Use drift_session_start(autopilot=true) for automatic session orchestration.",
+        DeprecationWarning,
+        stacklevel=1,
+    )
+
+    mgr = SessionManager.instance()
+    session = mgr.get(session_id)
+    if session is None:
+        return session_error_response(
+            "DRIFT-6001",
+            f"Session {session_id[:8]} not found or expired.",
+            session_id,
+        )
+
+    updates: dict[str, Any] = {}
+    if signals is not None:
+        updates["signals"] = _parse_csv_ids(signals)
+    if exclude_signals is not None:
+        updates["exclude_signals"] = _parse_csv_ids(exclude_signals)
+    if target_path is not None:
+        updates["target_path"] = target_path
+
+    if mark_tasks_complete:
+        task_ids = _parse_csv_ids(mark_tasks_complete) or []
+        existing = list(session.completed_task_ids)
+        existing.extend(tid for tid in task_ids if tid not in existing)
+        updates["completed_task_ids"] = existing
+
+    if updates:
+        mgr.update(session_id, **updates)
+
+    saved_path: str | None = None
+    if save_to_disk:
+        disk_path = mgr.save_to_disk(session_id)
+        saved_path = str(disk_path) if disk_path else None
+
+    result = session.summary()
+    result["status"] = "ok"
+    if saved_path:
+        result["saved_to"] = saved_path
+    result["agent_instruction"] = (
+        f"Session {session_id[:8]} updated. Scope: {session.scope_label()}."
+    )
+    return json.dumps(result, default=str)
+
+
+async def run_session_end(
+    *,
+    session_id: str,
+    session_error_response: Callable[[str, str, str], str],
+    force: bool = False,
+    bypass_reason: str | None = None,
+    session_md_path: str | None = None,
+    evidence_path: str | None = None,
+    adr_path: str | None = None,
+) -> str:
+    from drift.api_helpers import _error_response
+    from drift.session import DriftSession, SessionManager
+    from drift.session_handover import (
+        MAX_HANDOVER_RETRIES,
+        ChangeClass,
+        classify_session,
+        validate,
+        validate_bypass_reason,
+    )
+
+    mgr = SessionManager.instance()
+    session = mgr.get(session_id)
+    if session is not None:
+        blocked = _strict_guardrail_block_response("drift_session_end", session)
+        if blocked is not None:
+            return blocked
+
+    # ADR-079: Handover-Artefakt-Gate.
+    # Only run the gate for real DriftSession instances; test fakes bypass it.
+    gate_payload: dict[str, Any] | None = None
+    if isinstance(session, DriftSession):
+        change_class = classify_session(session)
+        empty_session = (
+            not session.completed_task_ids
+            and not session.selected_tasks
+            and session.tool_calls < 3
+            and change_class is ChangeClass.CHORE
+        )
+        retries = session.handover_retries
+        if not empty_session and not force:
+            overrides: dict[str, str] = {}
+            if session_md_path:
+                overrides["session_md"] = session_md_path
+            if evidence_path:
+                overrides["evidence"] = evidence_path
+            if adr_path:
+                overrides["adr"] = adr_path
+
+            result = validate(
+                session,
+                change_class=change_class,
+                path_overrides=overrides or None,
+            )
+            if not result.ok:
+                session.handover_retries = retries + 1
+                session.last_activity = session.last_activity  # keep alive
+                session.record_trace(
+                    tool="drift_session_end",
+                    advisory="session_handover.blocked",
+                    metadata={
+                        "change_class": str(change_class.value),
+                        "retry": session.handover_retries,
+                        "missing": [a.kind for a in result.missing],
+                        "shape_error_count": len(result.shape_errors),
+                        "placeholder_count": len(result.placeholder_flags),
+                    },
+                )
+                # Bounded retry: after the limit, agent must use force=true.
+                if session.handover_retries > MAX_HANDOVER_RETRIES:
+                    pass  # fall through to unblock via force instruction
+                else:
+                    error = _error_response(
+                        "DRIFT-6100",
+                        "Session handover artifacts are missing or invalid.",
+                        recoverable=True,
+                        suggested_fix={
+                            "action": (
+                                "Author the missing handover artifacts per "
+                                "ADR-079 / docs/session_handover_template.md, "
+                                "then retry drift_session_end."
+                            ),
+                            "max_retries": MAX_HANDOVER_RETRIES,
+                            "remaining_retries": max(
+                                MAX_HANDOVER_RETRIES - session.handover_retries, 0
+                            ),
+                        },
+                    )
+                    error["session_id"] = session_id
+                    error["status"] = "blocked"
+                    error.update(result.to_dict())
+                    error["agent_instruction"] = (
+                        f"Session {session_id[:8]} blocked by handover gate "
+                        f"(change_class={change_class.value}). "
+                        "Fill missing artifacts, then retry drift_session_end."
+                    )
+                    return json.dumps(error, default=str)
+            gate_payload = result.to_dict()
+
+        if force:
+            reason_err = validate_bypass_reason(bypass_reason)
+            if reason_err is not None:
+                error = _error_response(
+                    "DRIFT-6101",
+                    f"force=true requires a valid bypass_reason: {reason_err}",
+                    recoverable=True,
+                    suggested_fix={
+                        "action": (
+                            "Provide bypass_reason with a human-meaningful "
+                            "explanation of why the handover gate is being "
+                            "bypassed. Do not use placeholder text."
+                        ),
+                    },
+                )
+                error["session_id"] = session_id
+                error["status"] = "blocked"
+                return json.dumps(error, default=str)
+            logging.getLogger("drift").warning(
+                "Session handover gate bypassed via force=true: session=%s reason=%s",
+                session_id[:8],
+                bypass_reason,
+            )
+
+    # ADR-081 Nachschärfung (Q3): release the writer-advisory lock so a
+    # subsequent session on the same repo does not see us as a live holder.
+    # Real DriftSessions always expose ``repo_path``; test fakes may not,
+    # so we probe via ``getattr`` and skip the release cleanly.
+    repo_for_release: Path | str | None = None
+    if session is not None:
+        repo_candidate = getattr(session, "repo_path", None)
+        if isinstance(repo_candidate, (str, Path)):
+            repo_for_release = repo_candidate
+
+    # Auto-persist session snapshot before destroying so agents can resume
+    # after an MCP server restart.  Errors are non-fatal — a failed save
+    # must never block a clean session end.
+    if session is not None:
+        _try_autosave_session(session, session_id)
+
+    summary = mgr.destroy(session_id)
+    if repo_for_release is not None:
+        from drift.session_writer_lock import release_writer_advisory
+
+        try:
+            release_writer_advisory(repo_for_release, session_id=session_id)
+        except OSError as exc:
+            logging.getLogger("drift").debug("writer-advisory release failed: %s", exc)
+    if summary is None:
+        from drift.api_helpers import _error_response
+
+        error = _error_response(
+            "DRIFT-6001",
+            f"Session {session_id[:8]} not found or already ended.",
+            recoverable=False,
+            suggested_fix={"action": "Check the session_id and retry."},
+        )
+        error["session_id"] = session_id
+        return json.dumps(error, default=str)
+
+    summary["status"] = "ok"
+    if gate_payload is not None:
+        summary["handover_gate"] = gate_payload
+    if force:
+        summary["handover_bypass"] = {
+            "forced": True,
+            "reason": bypass_reason,
+        }
+    summary["agent_instruction"] = (
+        f"Session {session_id[:8]} ended. "
+        f"Duration: {summary.get('duration_seconds', 0)}s, "
+        f"tool calls: {summary.get('tool_calls', 0)}."
+    )
+    return json.dumps(summary, default=str)
+
+
+async def run_session_trace(
+    *,
+    session_id: str,
+    last_n: int,
+    session_error_response: Callable[[str, str, str], str],
+) -> str:
+    from drift.session import SessionManager
+
+    session = SessionManager.instance().get(session_id)
+    if session is None:
+        return session_error_response(
+            "DRIFT-6001",
+            f"Session {session_id[:8]} not found or expired.",
+            session_id,
+        )
+
+    session_trace = getattr(session, "trace", [])
+    session_phase = getattr(session, "phase", "unknown")
+    entries = session_trace[-last_n:] if last_n > 0 else session_trace
+    result: dict[str, Any] = {
+        "session_id": session_id,
+        "total_entries": len(session_trace),
+        "returned_entries": len(entries),
+        "trace": entries,
+        "current_phase": session_phase,
+        "agent_instruction": (
+            f"Trace contains {len(session_trace)} entries. Session phase: {session_phase}."
+        ),
+    }
+    return json.dumps(result, default=str)
+
+
+async def run_map(
+    *,
+    path: str,
+    target_path: str | None,
+    max_modules: int,
+    session_id: str | None,
+) -> str:
+    from drift.api import drift_map as api_drift_map
+    from drift_mcp.mcp_enrichment import _enrich_response_with_session
+    from drift_mcp.mcp_orchestration import _resolve_session, _session_defaults
+
+    session = _resolve_session(session_id)
+    kwargs = _session_defaults(session, {"path": path, "target_path": target_path})
+
+    try:
+        result = await _run_sync_in_thread(
+            lambda: api_drift_map(
+                kwargs.get("path", path),
+                target_path=kwargs.get("target_path"),
+                max_modules=max_modules,
+            ),
+            abandon_on_cancel=True,
+        )
+        raw = json.dumps(result, default=str)
+        if session is not None:
+            raw = _enrich_response_with_session(raw, session, "drift_map")
+        return raw
+    except Exception as exc:  # noqa: BLE001
+        from drift.api_helpers import _error_response
+
+        error = _error_response("DRIFT-7001", str(exc), recoverable=True)
+        # Keep MCP consumers compatible with both error discriminators.
+        error["status"] = "error"
+        error["tool"] = "drift_map"
+        error["agent_instruction"] = (
+            "Verify that the repository path exists and target_path points to a valid "
+            "subdirectory. Retry drift_map with a corrected path."
+        )
+        return json.dumps(error, default=str)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _try_autosave_session(session: Any, session_id: str) -> None:
+    """Persist *session* to ``.drift-cache/sessions/`` before destruction.
+
+    Failures are silently swallowed — a failed save must never block a
+    clean session end (non-fatal by design).
+    """
+    try:
+        repo_path = getattr(session, "repo_path", None)
+        if not repo_path:
+            return
+        save_dir = Path(repo_path) / ".drift-cache" / "sessions"
+        save_dir.mkdir(parents=True, exist_ok=True)
+        save_path = save_dir / f"session-{session_id[:8]}.json"
+        to_dict = getattr(session, "to_dict", None)
+        if callable(to_dict):
+            save_path.write_text(
+                json.dumps(to_dict(), default=str, indent=2),
+                encoding="utf-8",
+            )
+    except Exception:  # noqa: BLE001
+        logging.getLogger("drift").debug(
+            "auto-save of session %s failed (non-fatal)", session_id[:8]
+        )

--- a/packages/drift-mcp/src/drift_mcp/mcp_server.py
+++ b/packages/drift-mcp/src/drift_mcp/mcp_server.py
@@ -1,0 +1,2033 @@
+"""Drift MCP server — exposes drift analysis as MCP tools for VS Code / Copilot.
+
+Requires the optional ``mcp`` extra: ``pip install drift-analyzer[mcp]``
+
+The server uses stdio transport (no network listener) and is started via
+``drift mcp --serve``.  VS Code discovers it through ``.vscode/mcp.json``.
+
+Tool surface (v3 — sessions):
+    drift_scan            — Full repo analysis (concise/detailed)
+    drift_diff            — Diff-based change detection
+    drift_explain         — Signal/rule/error explanations
+    drift_fix_plan        — Prioritised repair tasks with constraints
+    drift_fix_apply       — Auto-patch high-confidence findings (dry_run default)
+    drift_validate        — Preflight config & environment check
+    drift_brief           — Pre-task structural briefing with guardrails
+    drift_nudge           — Fast directional feedback after edits
+    drift_verify          — Binary pass/fail coherence check after edits (ADR-070)
+    drift_shadow_verify   — Scope-bounded full re-scan for cross-file-risky edits
+    drift_negative_context — Anti-pattern warnings
+    drift_steer           — Location-centric architecture context (layer, neighbors)
+    drift_compile_policy  — Task-specific operative policy compilation
+    drift_suggest_rules   — Propose architecture rules from recurring patterns
+    drift_generate_skills — Generate skill briefings for recurring drift
+    drift_session_start   — Create a stateful session (scope, baseline, tasks)
+    drift_session_status  — Show current session state
+    drift_session_update  — Modify session scope, mark tasks complete
+    drift_session_end     — End session with summary
+    drift_session_trace   — Return chronological session trace
+    drift_map             — Lightweight module/dependency architecture map
+    drift_feedback        — Record TP/FP/FN feedback for calibration
+    drift_calibrate       — Compute calibrated signal weights from feedback
+    drift_capture_intent  — Extract and persist a structured intent from user input
+    drift_verify_intent   — Verify a build artifact against a captured intent
+    drift_feedback_for_agent — Prioritised action list from verify state
+    drift_guard_contract  — Pre-edit architectural constraints for a target file
+    drift_patch_begin     — Begin a structured patch sequence
+    drift_patch_check     — Check an in-progress patch for coherence
+    drift_patch_commit    — Commit a verified patch with evidence
+    drift_retrieve        — Semantic retrieval over drift's own fact corpus
+    drift_cite            — Expand a Fact-ID to verbatim text with SHA anchor
+    drift_task_claim      — (deprecated, unregistered) Claim a task from the fix-plan queue
+    drift_task_renew      — (deprecated, unregistered) Extend an active task lease
+    drift_task_release    — (deprecated, unregistered) Release a claimed task
+    drift_task_complete   — (deprecated, unregistered) Mark a claimed task as completed
+    drift_task_status     — (deprecated, unregistered) Show full task queue status
+
+Decision: ADR-022
+Refactored: Issue #378 — business logic extracted to router modules
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Annotated, Any
+
+from drift_mcp.mcp_catalog import get_tool_catalog  # noqa: F401
+
+_LOGGER = logging.getLogger(__name__)
+
+MCPFastMCPImpl: Any
+
+try:
+    from mcp.server.fastmcp import FastMCP as _ImportedFastMCP
+    from pydantic import Field
+
+    _MCP_AVAILABLE = True
+    MCPFastMCPImpl = _ImportedFastMCP
+except ImportError:
+    _MCP_AVAILABLE = False
+
+    def Field(**_kwargs: object) -> Any:  # type: ignore[misc,no-redef]  # noqa: N802
+        """Fallback when pydantic is unavailable; preserves kwargs for catalog introspection."""
+        import types as _types
+
+        return _types.SimpleNamespace(**_kwargs)
+
+    class _FallbackFastMCP:
+        """Minimal fallback so helper functions stay importable without mcp extra."""
+
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def tool(self):
+            def _decorator(func):
+                return func
+
+            return _decorator
+
+        def run(self, **_kwargs: object) -> None:
+            msg = "MCP server requires optional dependency 'mcp'."
+            raise RuntimeError(msg)
+
+    MCPFastMCPImpl = _FallbackFastMCP
+
+
+# ---------------------------------------------------------------------------
+# Negative-context timeout (env-configurable)
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# MCP instructions builder — see src/drift/mcp_instructions.py (Issue #378)
+# ---------------------------------------------------------------------------
+from drift_mcp.mcp_instructions import (  # noqa: E402
+    _BASE_INSTRUCTIONS,  # noqa: F401 — re-exported; tests may import from drift_mcp.mcp_server
+    _NEGATIVE_CONTEXT_TIMEOUT_SECONDS,
+    _load_negative_context_instructions,
+    _load_negative_context_timeout_seconds,  # noqa: F401 — re-exported for backward compat
+)
+
+# ---------------------------------------------------------------------------
+# Server instance
+# ---------------------------------------------------------------------------
+
+mcp = MCPFastMCPImpl(
+    "drift",
+    instructions=_load_negative_context_instructions(),
+)
+
+# ---------------------------------------------------------------------------
+# Session orchestration, guardrails, enrichment — delegated to submodules
+# ---------------------------------------------------------------------------
+from drift_mcp.mcp_enrichment import (  # noqa: E402
+    _enrich_response_with_session,  # noqa: F401
+    _session_error_response,
+)
+from drift_mcp.mcp_orchestration import (  # noqa: E402
+    _effective_profile,  # noqa: F401
+    _pre_call_advisory,  # noqa: F401
+    _resolve_session,  # noqa: F401
+    _session_defaults,  # noqa: F401
+    _strict_guardrail_block_response,  # noqa: F401
+    _update_session_from_verification_result,  # noqa: F401
+)
+from drift_mcp.mcp_utils import (  # noqa: E402
+    _AUTOMATION_FIT_MIN_VALUES,  # noqa: F401
+    _FAIL_ON_VALUES,  # noqa: F401
+    _RESPONSE_DETAIL_VALUES,  # noqa: F401
+    _RESPONSE_PROFILE_VALUES,  # noqa: F401
+    _run_sync_in_thread,  # noqa: F401
+    _validate_enum_param,  # noqa: F401
+)
+
+# Keep legacy re-exports visible to static analyzers and test imports.
+_MCP_SERVER_LEGACY_REEXPORTS = (
+    _effective_profile,
+    _update_session_from_verification_result,
+)
+
+# ---------------------------------------------------------------------------
+# MCP Tools — Analysis (scan / diff / explain / validate / brief / nudge)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()  # drift:ignore[DCA]
+async def drift_scan(
+    path: Annotated[str, Field(description="Repository path to analyze.")] = ".",
+    target_path: Annotated[
+        str | None,
+        Field(description="Restrict analysis to this subdirectory (relative to repo root)."),
+    ] = None,
+    since_days: Annotated[int, Field(description="Days of git history to consider.")] = 90,
+    signals: Annotated[
+        str | None,
+        Field(description="Comma-separated signal IDs to include, e.g. 'PFS,AVS'. Omit for all."),
+    ] = None,
+    exclude_signals: Annotated[
+        str | None,
+        Field(description="Comma-separated signal IDs to exclude, e.g. 'MDS,DIA'."),
+    ] = None,
+    max_findings: Annotated[int, Field(description="Maximum number of findings to return.")] = 10,
+    max_per_signal: Annotated[
+        int | None,
+        Field(description="Optional cap of findings per signal in returned results."),
+    ] = None,
+    response_detail: Annotated[
+        str,
+        Field(description="Detail level: 'concise' (token-efficient) or 'detailed' (all fields)."),
+    ] = "concise",
+    include_non_operational: Annotated[
+        bool,
+        Field(
+            description=(
+                "Include findings from non-operational contexts (fixtures, generated code)."
+            ),
+        ),
+    ] = False,
+    response_profile: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Response profile: 'planner' (tasks/graph/phases),"
+                " 'coder' (findings/actions), 'verifier' (deltas/criteria),"
+                " 'merge_readiness' (score/blocking). Omit for full response."
+            ),
+        ),
+    ] = None,
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start for stateful workflows."),
+    ] = "",
+) -> str:
+    """Analyze a repository for architectural drift."""
+    import json
+
+    for _field, _val, _vals in [
+        ("response_detail", response_detail, _RESPONSE_DETAIL_VALUES),
+        ("response_profile", response_profile, _RESPONSE_PROFILE_VALUES),
+    ]:
+        _err = _validate_enum_param(_field, _val, _vals, "drift_scan")
+        if _err:
+            _err["tool"] = "drift_scan"
+            return json.dumps(_err)
+
+    from drift_mcp.mcp_router_analysis import run_scan
+
+    return await run_scan(
+        path=path,
+        target_path=target_path,
+        since_days=since_days,
+        signals=signals,
+        exclude_signals=exclude_signals,
+        max_findings=max_findings,
+        max_per_signal=max_per_signal,
+        response_detail=response_detail,
+        include_non_operational=include_non_operational,
+        response_profile=response_profile,
+        session_id=session_id,
+    )
+
+
+@mcp.tool()  # drift:ignore[DCA]
+async def drift_diff(
+    path: Annotated[str, Field(description="Repository path to analyze.")] = ".",
+    diff_ref: Annotated[
+        str, Field(description="Git ref to diff against, e.g. 'HEAD~1', 'main', or a commit SHA.")
+    ] = "HEAD~1",
+    uncommitted: Annotated[
+        bool, Field(description="Compare current working-tree changes against HEAD.")
+    ] = False,
+    staged_only: Annotated[
+        bool, Field(description="Compare only staged (git add) changes.")
+    ] = False,
+    baseline_file: Annotated[
+        str | None,
+        Field(description="Path to .drift-baseline.json file for snapshot comparison."),
+    ] = None,
+    max_findings: Annotated[int, Field(description="Maximum number of findings to return.")] = 10,
+    response_detail: Annotated[
+        str,
+        Field(description="Detail level: 'concise' (token-efficient) or 'detailed' (all fields)."),
+    ] = "concise",
+    signals: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Comma-separated signal abbreviations to include "
+                "(e.g. 'PFS,BEM'). If omitted, all signals."
+            ),
+        ),
+    ] = None,
+    exclude_signals: Annotated[
+        str | None,
+        Field(description="Comma-separated signal abbreviations to exclude (e.g. 'MDS,DIA')."),
+    ] = None,
+    response_profile: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Response profile: 'planner' (tasks/graph/phases),"
+                " 'coder' (findings/actions), 'verifier' (deltas/criteria),"
+                " 'merge_readiness' (score/blocking). Omit for full response."
+            ),
+        ),
+    ] = None,
+    hypothesis_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Diagnostic hypothesis ID to link this verification result "
+                "to the underlying cause/change hypothesis."
+            ),
+        ),
+    ] = None,
+    diagnostic_hypothesis: Annotated[
+        Any,
+        Field(
+            description=(
+                "Optional full diagnostic hypothesis payload. Required in batch-fix "
+                "context if no hypothesis_id is provided. Must include: "
+                "affected_files, suspected_root_cause, minimal_intended_change, non_goals."
+            ),
+        ),
+    ] = None,
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start for stateful workflows."),
+    ] = "",
+) -> str:
+    """Detect drift changes since a git ref or baseline."""
+    import json
+
+    for _field, _val, _vals in [
+        ("response_detail", response_detail, _RESPONSE_DETAIL_VALUES),
+        ("response_profile", response_profile, _RESPONSE_PROFILE_VALUES),
+    ]:
+        _err = _validate_enum_param(_field, _val, _vals, "drift_diff")
+        if _err:
+            _err["tool"] = "drift_diff"
+            return json.dumps(_err)
+
+    from drift_mcp.mcp_router_analysis import run_diff
+
+    return await run_diff(
+        path=path,
+        diff_ref=diff_ref,
+        uncommitted=uncommitted,
+        staged_only=staged_only,
+        baseline_file=baseline_file,
+        max_findings=max_findings,
+        response_detail=response_detail,
+        signals=signals,
+        exclude_signals=exclude_signals,
+        response_profile=response_profile,
+        hypothesis_id=hypothesis_id,
+        diagnostic_hypothesis=diagnostic_hypothesis,
+        session_id=session_id,
+    )
+
+
+@mcp.tool()  # drift:ignore[DCA]
+async def drift_explain(
+    topic: Annotated[
+        str,
+        Field(
+            description=(
+                "Signal abbreviation ('PFS'), signal name"
+                " ('pattern_fragmentation'), or error code ('DRIFT-1003')."
+            ),
+        ),
+    ],
+    response_profile: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Response profile: 'planner', 'coder', 'verifier',"
+                " 'merge_readiness'. Omit for full response."
+            ),
+        ),
+    ] = None,
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start."),
+    ] = "",
+) -> str:
+    """Explain a drift signal, rule, or error code."""
+    from drift_mcp.mcp_router_analysis import run_explain
+
+    return await run_explain(
+        topic=topic,
+        response_profile=response_profile,
+        session_id=session_id,
+    )
+
+
+@mcp.tool()  # drift:ignore[DCA]
+async def drift_fix_plan(
+    path: Annotated[str, Field(description="Repository path to analyze.")] = ".",
+    signal: Annotated[
+        str | None,
+        Field(description="Filter tasks by signal abbreviation (e.g. 'PFS'). Omit for all."),
+    ] = None,
+    max_tasks: Annotated[int, Field(description="Maximum number of repair tasks to return.")] = 5,
+    automation_fit_min: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Minimum automation fit level: 'low', 'medium', or 'high'."
+                " Omit to include all tasks."
+            ),
+        ),
+    ] = None,
+    target_path: Annotated[
+        str | None,
+        Field(description="Restrict tasks to this subpath (relative to repo root)."),
+    ] = None,
+    exclude_paths: Annotated[
+        str | None,
+        Field(description="Comma-separated paths to exclude from the fix plan."),
+    ] = None,
+    include_deferred: Annotated[
+        bool,
+        Field(description="Include tasks that have been deferred/dismissed."),
+    ] = False,
+    include_non_operational: Annotated[
+        bool,
+        Field(description="Include tasks from non-operational contexts (fixtures, tests)."),
+    ] = False,
+    response_profile: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Response profile: 'planner' (tasks/graph/phases),"
+                " 'coder' (findings/actions). Omit for full response."
+            ),
+        ),
+    ] = None,
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start for stateful workflows."),
+    ] = "",
+) -> str:
+    """Get prioritised repair tasks with constraints."""
+    import json
+
+    for _field, _val, _vals in [
+        ("automation_fit_min", automation_fit_min, _AUTOMATION_FIT_MIN_VALUES),
+        ("response_profile", response_profile, _RESPONSE_PROFILE_VALUES),
+    ]:
+        _err = _validate_enum_param(_field, _val, _vals, "drift_fix_plan")
+        if _err:
+            _err["tool"] = "drift_fix_plan"
+            return json.dumps(_err)
+
+    from drift_mcp.mcp_router_repair import run_fix_plan
+
+    return await run_fix_plan(
+        path=path,
+        signal=signal,
+        max_tasks=max_tasks,
+        automation_fit_min=automation_fit_min,
+        target_path=target_path,
+        exclude_paths=exclude_paths,
+        include_deferred=include_deferred,
+        include_non_operational=include_non_operational,
+        response_profile=response_profile,
+        session_id=session_id,
+    )
+
+
+@mcp.tool()  # drift:ignore[DCA]
+async def drift_validate(
+    path: Annotated[str, Field(description="Repository path to validate.")] = ".",
+    config_file: Annotated[
+        str | None,
+        Field(description="Path to a custom drift.yaml config file."),
+    ] = None,
+    response_profile: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Response profile: 'planner', 'coder', 'verifier',"
+                " 'merge_readiness'. Omit for full response."
+            ),
+        ),
+    ] = None,
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start."),
+    ] = "",
+) -> str:
+    """Preflight config and environment check."""
+    from drift_mcp.mcp_router_analysis import run_validate
+
+    return await run_validate(
+        path=path,
+        config_file=config_file,
+        response_profile=response_profile,
+        session_id=session_id,
+    )
+
+
+@mcp.tool()  # drift:ignore[DCA]
+async def drift_nudge(
+    path: Annotated[str, Field(description="Repository path to analyze.")] = ".",
+    changed_files: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Comma-separated changed file paths"
+                " (posix, relative to repo root)."
+                " Auto-detected via git if omitted."
+            ),
+        ),
+    ] = None,
+    uncommitted: Annotated[
+        bool,
+        Field(
+            description=(
+                "When auto-detecting changes, use uncommitted"
+                " working-tree changes (True) vs staged-only (False)."
+            ),
+        ),
+    ] = True,
+    response_profile: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Response profile: 'planner' (tasks/graph/phases),"
+                " 'coder' (findings/actions), 'verifier' (deltas/criteria),"
+                " 'merge_readiness' (score/blocking). Omit for full response."
+            ),
+        ),
+    ] = None,
+    hypothesis_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Diagnostic hypothesis ID to link this nudge result "
+                "to the underlying cause/change hypothesis."
+            ),
+        ),
+    ] = None,
+    diagnostic_hypothesis: Annotated[
+        Any,
+        Field(
+            description=(
+                "Optional full diagnostic hypothesis payload. Required in batch-fix "
+                "context if no hypothesis_id is provided. Must include: "
+                "affected_files, suspected_root_cause, minimal_intended_change, non_goals."
+            ),
+        ),
+    ] = None,
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start for stateful workflows."),
+    ] = "",
+    task_signal: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Signal type of the repair task being verified (e.g. 'mutant_duplicate'). "
+                "When set with task_edit_kind, the outcome is recorded in the "
+                "repair template registry for template-confidence learning."
+            ),
+        ),
+    ] = None,
+    task_edit_kind: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Edit kind applied in the repair (e.g. 'merge_function_body'). "
+                "Must also set task_signal to trigger outcome recording."
+            ),
+        ),
+    ] = None,
+    task_context_class: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Context class for registry lookup (e.g. 'production' or 'test'). "
+                "Defaults to 'production' when task_signal and task_edit_kind are set."
+            ),
+        ),
+    ] = None,
+    timeout_ms: Annotated[
+        int | None,
+        Field(
+            description=(
+                "Wall-clock budget in milliseconds for this nudge call (default: 1000). "
+                "When actual latency exceeds this value the response includes "
+                "latency_exceeded=true so agents can skip future nudge calls. "
+                "No early abort is performed; a full result is always returned. "
+                "Set to null to disable the latency gate."
+            ),
+        ),
+    ] = 1000,
+) -> str:
+    """Get directional feedback after a file change (experimental).
+
+    Args:
+        task_signal: Optional signal ID for the repaired finding (for example
+            `mutant_duplicate`). Accepts known signal names used by fix-plan tasks.
+            Combined with `task_edit_kind`, this enables template outcome recording
+            used to refine nudge template-confidence scoring.
+        task_edit_kind: Optional edit pattern label (for example
+            `merge_function_body`). Accepts registry edit-kind identifiers.
+            Must be paired with `task_signal`; together they map this nudge result
+            to the matching repair template confidence bucket.
+        task_context_class: Optional context bucket (`production` or `test`).
+            Accepts registry context classes and defaults to `production` when
+            outcome recording is active. This scopes confidence updates to the
+            correct context during nudge scoring feedback.
+    """
+    from drift_mcp.mcp_router_analysis import run_nudge
+
+    return await run_nudge(
+        path=path,
+        changed_files=changed_files,
+        uncommitted=uncommitted,
+        response_profile=response_profile,
+        hypothesis_id=hypothesis_id,
+        diagnostic_hypothesis=diagnostic_hypothesis,
+        session_id=session_id,
+        task_signal=task_signal,
+        task_edit_kind=task_edit_kind,
+        task_context_class=task_context_class,
+        timeout_ms=timeout_ms,
+    )
+
+
+@mcp.tool()  # drift:ignore[DCA]
+async def drift_shadow_verify(
+    path: Annotated[str, Field(description="Repository path to analyze.")] = ".",
+    scope_files: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Comma-separated posix-relative file paths to include in the comparison. "
+                "Use the shadow_verify_scope value from the task contract. "
+                "When omitted, all findings are compared (full-repo shadow verify)."
+            ),
+        ),
+    ] = None,
+    uncommitted: Annotated[
+        bool,
+        Field(
+            description=(
+                "Passed through for baseline freshness context. "
+                "The analysis always covers the current working-tree state."
+            ),
+        ),
+    ] = True,
+    response_profile: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Response profile: 'verifier' (deltas/criteria),"
+                " 'merge_readiness' (score/blocking). Omit for full response."
+            ),
+        ),
+    ] = None,
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start for stateful workflows."),
+    ] = "",
+) -> str:
+    """Scope-bounded full re-scan for cross-file-risky edits (ADR-064)."""
+    from drift_mcp.mcp_router_analysis import run_shadow_verify
+
+    return await run_shadow_verify(
+        path=path,
+        scope_files=scope_files,
+        uncommitted=uncommitted,
+        response_profile=response_profile,
+        session_id=session_id,
+    )
+
+
+@mcp.tool()  # drift:ignore[DCA]
+async def drift_verify(
+    path: Annotated[str, Field(description="Repository path to analyze.")] = ".",
+    fail_on: Annotated[
+        str,
+        Field(
+            description=(
+                "Severity threshold for FAIL verdict. "
+                "One of: critical, high, medium, low, none. Default: high."
+            ),
+        ),
+    ] = "high",
+    scope_files: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Comma-separated posix-relative file paths to restrict "
+                "verification scope. When omitted, all findings are compared."
+            ),
+        ),
+    ] = None,
+    uncommitted: Annotated[
+        bool,
+        Field(
+            description="Analyze working-tree changes vs HEAD (default: true).",
+        ),
+    ] = True,
+    response_profile: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Response profile: 'verifier' (deltas/criteria),"
+                " 'merge_readiness' (score/blocking). Omit for full response."
+            ),
+        ),
+    ] = None,
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start for stateful workflows."),
+    ] = "",
+) -> str:
+    """Verify structural coherence after edits — binary pass/fail verdict (ADR-070)."""
+    import json
+
+    for _field, _val, _vals in [
+        ("fail_on", fail_on, _FAIL_ON_VALUES),
+        ("response_profile", response_profile, _RESPONSE_PROFILE_VALUES),
+    ]:
+        _err = _validate_enum_param(_field, _val, _vals, "drift_verify")
+        if _err:
+            _err["tool"] = "drift_verify"
+            return json.dumps(_err)
+
+    from drift_mcp.mcp_router_repair import run_verify
+
+    return await run_verify(
+        path=path,
+        fail_on=fail_on,
+        scope_files=scope_files,
+        uncommitted=uncommitted,
+        response_profile=response_profile,
+        session_id=session_id,
+    )
+
+
+@mcp.tool()  # drift:ignore[DCA]
+async def drift_brief(
+    path: Annotated[str, Field(description="Repository path to analyze.")] = ".",
+    task: Annotated[
+        str,
+        Field(
+            description=(
+                "Natural-language task description, e.g. 'add payment integration to checkout'."
+            ),
+        ),
+    ] = "",
+    scope: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Manual scope override (path, e.g. 'src/checkout/')."
+                " Auto-resolved from task if omitted."
+            ),
+        ),
+    ] = None,
+    max_guardrails: Annotated[
+        int, Field(description="Maximum number of guardrails to return.")
+    ] = 10,
+    response_detail: Annotated[
+        str,
+        Field(
+            description=(
+                "Detail level: 'concise' (guardrails + risk only) or 'detailed' (full landscape)."
+            ),
+        ),
+    ] = "concise",
+    response_profile: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Response profile: 'planner' (tasks/graph/phases),"
+                " 'coder' (findings/actions), 'verifier' (deltas/criteria),"
+                " 'merge_readiness' (score/blocking). Omit for full response."
+            ),
+        ),
+    ] = None,
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start for stateful workflows."),
+    ] = "",
+) -> str:
+    """Get a pre-task structural briefing before writing code."""
+    from drift_mcp.mcp_router_analysis import run_brief
+
+    return await run_brief(
+        path=path,
+        task=task,
+        scope=scope,
+        max_guardrails=max_guardrails,
+        response_detail=response_detail,
+        response_profile=response_profile,
+        session_id=session_id,
+    )
+
+
+@mcp.tool()  # drift:ignore[DCA]
+async def drift_negative_context(
+    path: Annotated[str, Field(description="Repository path to analyze.")] = ".",
+    scope: Annotated[
+        str | None,
+        Field(description="Filter by scope: 'file', 'module', or 'repo'. Omit for all scopes."),
+    ] = None,
+    target_file: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Restrict to anti-patterns affecting this file path (posix, relative to repo root)."
+            ),
+        ),
+    ] = None,
+    max_items: Annotated[
+        int, Field(description="Maximum number of anti-pattern items to return.")
+    ] = 10,
+    response_profile: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Response profile: 'planner' (tasks/graph/phases),"
+                " 'coder' (findings/actions), 'verifier' (deltas/criteria),"
+                " 'merge_readiness' (score/blocking). Omit for full response."
+            ),
+        ),
+    ] = None,
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start for stateful workflows."),
+    ] = "",
+) -> str:
+    """Get anti-pattern warnings derived from drift analysis."""
+    from drift_mcp.mcp_router_analysis import run_negative_context
+
+    return await run_negative_context(
+        path=path,
+        scope=scope,
+        target_file=target_file,
+        max_items=max_items,
+        response_profile=response_profile,
+        session_id=session_id,
+        timeout_seconds=_NEGATIVE_CONTEXT_TIMEOUT_SECONDS,
+    )
+
+
+# ---------------------------------------------------------------------------
+# MCP Tools — Session management (v3)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()  # drift:ignore[DCA]
+async def drift_session_start(
+    path: Annotated[str, Field(description="Repository path for the session.")] = ".",
+    signals: Annotated[
+        str | None,
+        Field(description="Comma-separated default signal filter for this session."),
+    ] = None,
+    exclude_signals: Annotated[
+        str | None,
+        Field(description="Comma-separated signals to exclude by default."),
+    ] = None,
+    target_path: Annotated[
+        str | None,
+        Field(description="Default target subdirectory for all session tools."),
+    ] = None,
+    exclude_paths: Annotated[
+        str | None,
+        Field(description="Comma-separated paths to exclude by default."),
+    ] = None,
+    ttl_seconds: Annotated[
+        int,
+        Field(description="Session time-to-live in seconds (default: 1800 = 30 min)."),
+    ] = 1800,
+    autopilot: Annotated[
+        bool,
+        Field(
+            description=(
+                "When true, automatically runs validate → brief → scan → fix_plan "
+                "after session creation and returns combined results."
+            ),
+        ),
+    ] = False,
+    autopilot_payload: Annotated[
+        str,
+        Field(
+            description=(
+                "Autopilot payload mode: 'summary' (default, compact with previews) "
+                "or 'full' (embedded validate/brief/scan/fix_plan)."
+            ),
+        ),
+    ] = "summary",
+    response_profile: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Response profile: 'planner', 'coder', 'verifier', "
+                "'merge_readiness', or null for full response."
+            ),
+        ),
+    ] = None,
+    fresh_start: Annotated[
+        bool,
+        Field(
+            description=(
+                "When true, skip queue-log replay and start with an empty "
+                "queue even if a previous session's .drift-cache/queue.jsonl "
+                "exists. Default: false (resume from log when available)."
+            ),
+        ),
+    ] = False,
+) -> str:
+    """Start a new stateful session for multi-step agent workflows."""
+    from drift_mcp.mcp_router_session import run_session_start
+
+    return await run_session_start(
+        path=path,
+        signals=signals,
+        exclude_signals=exclude_signals,
+        target_path=target_path,
+        exclude_paths=exclude_paths,
+        ttl_seconds=ttl_seconds,
+        autopilot=autopilot,
+        autopilot_payload=autopilot_payload,
+        response_profile=response_profile,
+        fresh_start=fresh_start,
+    )
+
+
+@mcp.tool()  # drift:ignore[DCA]
+async def drift_session_status(
+    session_id: Annotated[
+        str, Field(description="The session ID returned by drift_session_start.")
+    ],
+) -> str:
+    """Show the current state of an active session."""
+    from drift_mcp.mcp_router_session import run_session_status
+
+    return await run_session_status(
+        session_id=session_id,
+        session_error_response=_session_error_response,
+    )
+
+
+@mcp.tool()  # drift:ignore[DCA]
+async def drift_session_update(
+    session_id: Annotated[str, Field(description="The session ID to update.")],
+    signals: Annotated[
+        str | None,
+        Field(description="New signal filter (replaces current). Omit to keep."),
+    ] = None,
+    exclude_signals: Annotated[
+        str | None,
+        Field(description="New exclude filter (replaces current). Omit to keep."),
+    ] = None,
+    target_path: Annotated[
+        str | None,
+        Field(description="New target path. Omit to keep current."),
+    ] = None,
+    mark_tasks_complete: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Comma-separated task IDs to mark as completed in the session's fix-plan queue."
+            ),
+        ),
+    ] = None,
+    save_to_disk: Annotated[
+        bool, Field(description="Persist session to .drift-session-{id}.json.")
+    ] = False,
+) -> str:
+    """Update session scope, mark tasks complete, or save to disk."""
+    from drift_mcp.mcp_router_session import run_session_update
+
+    return await run_session_update(
+        session_id=session_id,
+        signals=signals,
+        exclude_signals=exclude_signals,
+        target_path=target_path,
+        mark_tasks_complete=mark_tasks_complete,
+        save_to_disk=save_to_disk,
+        session_error_response=_session_error_response,
+    )
+
+
+@mcp.tool()  # drift:ignore[DCA]
+async def drift_session_end(
+    session_id: Annotated[str, Field(description="The session ID to end.")],
+    force: Annotated[
+        bool,
+        Field(
+            description=(
+                "Bypass the handover-artifact gate (ADR-079). Requires "
+                "bypass_reason. Emits a warning log entry and is recorded in "
+                "session trace. Do not use routinely."
+            )
+        ),
+    ] = False,
+    bypass_reason: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Human-meaningful justification for force=true (>= 40 chars, "
+                "no placeholder tokens)."
+            )
+        ),
+    ] = None,
+    session_md_path: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Explicit path to work_artifacts/session_<id>.md if the agent "
+                "wrote it outside the default location."
+            )
+        ),
+    ] = None,
+    evidence_path: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Explicit path to the benchmark_results evidence JSON for "
+                "signal/architecture classes."
+            )
+        ),
+    ] = None,
+    adr_path: Annotated[
+        str | None,
+        Field(description=("Explicit path to the ADR draft for signal/architecture classes.")),
+    ] = None,
+) -> str:
+    """End a session and return a final summary.
+
+    ADR-079: Before the session is destroyed the handover-artifact gate runs.
+    It verifies existence, shape, and placeholder-freedom of the required
+    handover artifacts derived from the session's change class. Blocked
+    sessions return DRIFT-6100 with a ``missing_artifacts`` / ``shape_errors``
+    payload and remain alive for retry. Use ``force=true`` with a meaningful
+    ``bypass_reason`` only as a last resort.
+    """
+    from drift_mcp.mcp_router_session import run_session_end
+
+    return await run_session_end(
+        session_id=session_id,
+        session_error_response=_session_error_response,
+        force=force,
+        bypass_reason=bypass_reason,
+        session_md_path=session_md_path,
+        evidence_path=evidence_path,
+        adr_path=adr_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Legacy task-queue functions (unregistered; backward compatibility)
+# DEPRECATED: These tools will be removed in v3.0.
+# Removed from @mcp.tool() registration to reduce default MCP surface (Issue #545).
+# The underlying functions remain callable for backward compatibility.
+# ---------------------------------------------------------------------------
+
+
+async def drift_task_claim(
+    session_id: Annotated[
+        str, Field(description="The active session ID from drift_session_start.")
+    ],
+    agent_id: Annotated[
+        str, Field(description="Unique identifier for the claiming agent instance.")
+    ],
+    task_id: Annotated[
+        str | None,
+        Field(description="Specific task ID to claim. Omit to claim next available."),
+    ] = None,
+    lease_ttl_seconds: Annotated[
+        int,
+        Field(description="Lease time-to-live in seconds (default: 300 = 5 min)."),
+    ] = 300,
+    max_reclaim: Annotated[
+        int,
+        Field(description="Maximum number of times a task can be reclaimed (default: 3)."),
+    ] = 3,
+) -> str:
+    """(Deprecated) Claim a pending task from the session's fix-plan queue."""
+    from drift_mcp.mcp_legacy import run_task_claim
+
+    return await run_task_claim(
+        session_id=session_id,
+        agent_id=agent_id,
+        task_id=task_id,
+        lease_ttl_seconds=lease_ttl_seconds,
+        max_reclaim=max_reclaim,
+    )
+
+
+async def drift_task_renew(
+    session_id: Annotated[
+        str, Field(description="The active session ID from drift_session_start.")
+    ],
+    agent_id: Annotated[str, Field(description="Agent ID that holds the lease.")],
+    task_id: Annotated[str, Field(description="Task ID whose lease to extend.")],
+    extend_seconds: Annotated[
+        int,
+        Field(description="Seconds to extend the lease by (default: 300)."),
+    ] = 300,
+) -> str:
+    """(Deprecated) Extend an active task lease to prevent it from expiring."""
+    from drift_mcp.mcp_legacy import run_task_renew
+
+    return await run_task_renew(
+        session_id=session_id,
+        agent_id=agent_id,
+        task_id=task_id,
+        extend_seconds=extend_seconds,
+    )
+
+
+async def drift_task_release(
+    session_id: Annotated[
+        str, Field(description="The active session ID from drift_session_start.")
+    ],
+    agent_id: Annotated[str, Field(description="Agent ID that holds the lease.")],
+    task_id: Annotated[str, Field(description="Task ID to release back to the pending pool.")],
+    max_reclaim: Annotated[
+        int,
+        Field(description="Maximum number of times a task can be reclaimed (default: 3)."),
+    ] = 3,
+) -> str:
+    """(Deprecated) Release a claimed task back to the pending pool."""
+    from drift_mcp.mcp_legacy import run_task_release
+
+    return await run_task_release(
+        session_id=session_id,
+        agent_id=agent_id,
+        task_id=task_id,
+        max_reclaim=max_reclaim,
+    )
+
+
+async def drift_task_complete(
+    session_id: Annotated[
+        str, Field(description="The active session ID from drift_session_start.")
+    ],
+    agent_id: Annotated[str, Field(description="Agent ID that holds the lease.")],
+    task_id: Annotated[str, Field(description="Task ID to mark as completed.")],
+    verify_evidence: Annotated[
+        Any,
+        Field(
+            description=(
+                "Optional verification evidence (e.g. nudge result with safe_to_commit=true)."
+            ),
+        ),
+    ] = None,
+) -> str:
+    """(Deprecated) Mark a claimed task as completed and release its lease."""
+    from drift_mcp.mcp_legacy import run_task_complete
+
+    return await run_task_complete(
+        session_id=session_id,
+        agent_id=agent_id,
+        task_id=task_id,
+        verify_evidence=verify_evidence,
+    )
+
+
+async def drift_task_status(
+    session_id: Annotated[
+        str, Field(description="The active session ID from drift_session_start.")
+    ],
+) -> str:
+    """(Deprecated) Return a full queue overview: pending, claimed, completed, failed tasks."""
+    from drift_mcp.mcp_legacy import run_task_status
+
+    return await run_task_status(
+        session_id=session_id,
+    )
+
+
+@mcp.tool()  # drift:ignore[DCA]
+async def drift_session_trace(
+    session_id: Annotated[str, Field(description="Active session ID from drift_session_start.")],
+    last_n: Annotated[
+        int, Field(description="Number of most recent trace entries to return.")
+    ] = 20,
+) -> str:
+    """Return the session trace log — a chronological record of tool calls."""
+    from drift_mcp.mcp_router_session import run_session_trace
+
+    return await run_session_trace(
+        session_id=session_id,
+        last_n=last_n,
+        session_error_response=_session_error_response,
+    )
+
+
+@mcp.tool()  # drift:ignore[DCA]
+async def drift_guard_contract(
+    path: Annotated[str, Field(description="Repository path.")] = ".",
+    target: Annotated[
+        str,
+        Field(
+            description="File or module path to generate the guard contract for"
+            " (relative to repo root).",
+        ),
+    ] = "",
+    include_findings: Annotated[
+        bool,
+        Field(description="Include existing drift findings for the target."),
+    ] = False,
+    max_findings: Annotated[
+        int,
+        Field(description="Maximum findings to include (only with include_findings=true)."),
+    ] = 10,
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start."),
+    ] = "",
+) -> str:
+    """Pre-edit guard contract: architectural constraints and boundaries for a target.
+
+    Call BEFORE editing a file to learn invariants, layer boundaries,
+    forbidden imports, related tests, and active architectural decisions.
+    """
+    from drift.api.guard_contract import guard_contract
+    from drift_mcp.mcp_utils import _run_api_tool
+
+    session = _resolve_session(session_id)
+    resolved_path = path
+    if session and (not path or path == "."):
+        resolved_path = session.repo_path
+
+    return await _run_api_tool(
+        "drift_guard_contract",
+        guard_contract,
+        path=resolved_path,
+        target=target,
+        include_findings=include_findings,
+        max_findings=max_findings,
+    )
+
+
+@mcp.tool()
+async def drift_map(
+    path: Annotated[str, Field(description="Repository path to map.")] = ".",
+    target_path: Annotated[
+        str | None,
+        Field(description="Optional subpath scope inside repository."),
+    ] = None,
+    max_modules: Annotated[
+        int,
+        Field(description="Maximum number of modules to return."),
+    ] = 50,
+    session_id: Annotated[
+        str | None,
+        Field(description="Optional session ID for context enrichment."),
+    ] = None,
+) -> str:
+    """Return a lightweight module/dependency architecture map."""
+    from drift_mcp.mcp_router_session import run_map
+
+    return await run_map(
+        path=path,
+        target_path=target_path,
+        max_modules=max_modules,
+        session_id=session_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Calibration tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def drift_feedback(
+    signal: Annotated[
+        str,
+        Field(description="Signal type or abbreviation (e.g. 'PFS', 'pattern_fragmentation')."),
+    ],
+    file_path: Annotated[
+        str,
+        Field(description="File path the finding relates to."),
+    ],
+    verdict: Annotated[
+        str,
+        Field(
+            description=(
+                "Feedback verdict: 'tp' (true positive),"
+                " 'fp' (false positive), or 'fn' (false negative)."
+            ),
+        ),
+    ],
+    reason: Annotated[
+        str,
+        Field(description="Optional reason for the verdict."),
+    ] = "",
+    start_line: Annotated[
+        int,
+        Field(description="Start line of the finding for line-precise feedback (0 = not set)."),
+    ] = 0,
+    path: Annotated[
+        str,
+        Field(description="Repository path."),
+    ] = ".",
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start."),
+    ] = "",
+) -> str:
+    """Record TP/FP/FN feedback for a finding to improve signal calibration."""
+    from drift_mcp.mcp_router_calibration import run_feedback
+
+    return await run_feedback(
+        signal=signal,
+        file_path=file_path,
+        verdict=verdict,
+        reason=reason,
+        start_line=start_line,
+        path=path,
+        session_id=session_id,
+    )
+
+
+@mcp.tool()
+async def drift_calibrate(
+    path: Annotated[
+        str,
+        Field(description="Repository path to calibrate."),
+    ] = ".",
+    dry_run: Annotated[
+        bool,
+        Field(description="If true, show proposed changes without writing to config."),
+    ] = True,
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start."),
+    ] = "",
+) -> str:
+    """Compute calibrated signal weights from accumulated feedback evidence."""
+    from drift_mcp.mcp_router_calibration import run_calibrate
+
+    return await run_calibrate(
+        path=path,
+        dry_run=dry_run,
+        session_id=session_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Intent-loop tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def drift_capture_intent(
+    raw: Annotated[
+        str,
+        Field(description="Natural-language user input describing the intent."),
+    ],
+    path: Annotated[
+        str,
+        Field(description="Repository root path used for local intent storage."),
+    ] = ".",
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start."),
+    ] = "",
+) -> str:
+    """Extract and persist a structured intent from a raw user input string."""
+    from drift_mcp.mcp_router_intent import run_capture_intent
+
+    return await run_capture_intent(
+        raw=raw,
+        path=path,
+        session_id=session_id,
+    )
+
+
+@mcp.tool()
+async def drift_verify_intent(
+    intent_id: Annotated[
+        str,
+        Field(description="The intent ID returned by drift_capture_intent."),
+    ],
+    artifact_path: Annotated[
+        str,
+        Field(description="Path to the built artifact (file or directory) to verify."),
+    ],
+    path: Annotated[
+        str,
+        Field(description="Repository root path used for intent storage lookup."),
+    ] = ".",
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start."),
+    ] = "",
+) -> str:
+    """Verify that a build artifact fulfils a previously captured intent."""
+    from drift_mcp.mcp_router_intent import run_verify_intent
+
+    return await run_verify_intent(
+        intent_id=intent_id,
+        artifact_path=artifact_path,
+        path=path,
+        session_id=session_id,
+    )
+
+
+@mcp.tool()
+async def drift_feedback_for_agent(
+    intent_id: Annotated[
+        str,
+        Field(description="The intent ID returned by drift_capture_intent."),
+    ],
+    artifact_path: Annotated[
+        str,
+        Field(description="Path to the current build artifact."),
+    ],
+    path: Annotated[
+        str,
+        Field(description="Repository root path."),
+    ] = ".",
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start."),
+    ] = "",
+) -> str:
+    """Return a prioritised action list based on the current verify state."""
+    from drift_mcp.mcp_router_intent import run_feedback_for_agent
+
+    return await run_feedback_for_agent(
+        intent_id=intent_id,
+        path=path,
+        artifact_path=artifact_path,
+        session_id=session_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Patch Engine tools (ADR-074)
+# ---------------------------------------------------------------------------
+
+_BLAST_RADIUS_VALUES = frozenset({"local", "module", "repo"})
+
+
+@mcp.tool()
+async def drift_patch_begin(
+    task_id: Annotated[
+        str,
+        Field(description="Unique identifier for the agent task."),
+    ],
+    declared_files: Annotated[
+        str,
+        Field(
+            description=("Comma-separated posix-relative file paths the agent intends to edit."),
+        ),
+    ],
+    expected_outcome: Annotated[
+        str,
+        Field(description="Short description of what the edit should achieve."),
+    ],
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start."),
+    ] = "",
+    blast_radius: Annotated[
+        str,
+        Field(
+            description=(
+                "Expected blast radius: 'local' (single file), 'module' (package), "
+                "'repo' (cross-module). Default: local."
+            ),
+        ),
+    ] = "local",
+    forbidden_paths: Annotated[
+        str | None,
+        Field(
+            description="Comma-separated paths the agent must NOT touch.",
+        ),
+    ] = None,
+    max_diff_lines: Annotated[
+        int | None,
+        Field(description="Maximum total diff lines before review is required."),
+    ] = None,
+) -> str:
+    """Declare patch intent before editing files (ADR-074 phase 1)."""
+    import json
+
+    _err = _validate_enum_param(
+        "blast_radius", blast_radius, _BLAST_RADIUS_VALUES, "drift_patch_begin"
+    )
+    if _err:
+        _err["tool"] = "drift_patch_begin"
+        return json.dumps(_err)
+
+    from drift_mcp.mcp_router_patch import run_patch_begin
+
+    return await run_patch_begin(
+        task_id=task_id,
+        declared_files=declared_files,
+        expected_outcome=expected_outcome,
+        session_id=session_id,
+        blast_radius=blast_radius,
+        forbidden_paths=forbidden_paths,
+        max_diff_lines=max_diff_lines,
+    )
+
+
+@mcp.tool()
+async def drift_patch_check(
+    task_id: Annotated[
+        str,
+        Field(description="Task ID matching a prior drift_patch_begin call."),
+    ],
+    declared_files: Annotated[
+        str,
+        Field(
+            description="Comma-separated posix-relative file paths from the intent.",
+        ),
+    ],
+    path: Annotated[str, Field(description="Repository path to analyze.")] = ".",
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start."),
+    ] = "",
+    forbidden_paths: Annotated[
+        str | None,
+        Field(description="Comma-separated paths the agent must NOT touch."),
+    ] = None,
+    max_diff_lines: Annotated[
+        int | None,
+        Field(description="Maximum total diff lines before review is required."),
+    ] = None,
+) -> str:
+    """Validate scope compliance after editing (ADR-074 phase 2)."""
+    from drift_mcp.mcp_router_patch import run_patch_check
+
+    return await run_patch_check(
+        task_id=task_id,
+        declared_files=declared_files,
+        path=path,
+        session_id=session_id,
+        forbidden_paths=forbidden_paths,
+        max_diff_lines=max_diff_lines,
+    )
+
+
+@mcp.tool()
+async def drift_patch_commit(
+    task_id: Annotated[
+        str,
+        Field(description="Task ID matching a prior drift_patch_begin call."),
+    ],
+    declared_files: Annotated[
+        str,
+        Field(
+            description="Comma-separated posix-relative file paths from the intent.",
+        ),
+    ],
+    expected_outcome: Annotated[
+        str,
+        Field(description="Short description of what the edit should achieve."),
+    ],
+    path: Annotated[str, Field(description="Repository path to analyze.")] = ".",
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start."),
+    ] = "",
+) -> str:
+    """Generate evidence record for a completed patch (ADR-074 phase 3)."""
+    from drift_mcp.mcp_router_patch import run_patch_commit
+
+    return await run_patch_commit(
+        task_id=task_id,
+        declared_files=declared_files,
+        expected_outcome=expected_outcome,
+        path=path,
+        session_id=session_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Repair: fix_apply (ADR-076) — auto-patch with dry_run=True default
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def drift_fix_apply(
+    path: Annotated[str, Field(description="Repository path to analyze.")] = ".",
+    signal: Annotated[
+        str | None,
+        Field(description="Filter to a single signal abbreviation (e.g. 'EDS'). Omit for all."),
+    ] = None,
+    max_tasks: Annotated[
+        int,
+        Field(description="Maximum number of tasks to consider from the fix plan."),
+    ] = 10,
+    dry_run: Annotated[
+        bool,
+        Field(
+            description=(
+                "When true (default), generate and preview patches without writing files. "
+                "Set to false to apply patches to disk (requires clean git state)."
+            ),
+        ),
+    ] = True,
+    target_path: Annotated[
+        str | None,
+        Field(description="Restrict to findings inside this subpath (relative to repo root)."),
+    ] = None,
+    exclude_paths: Annotated[
+        str | None,
+        Field(description="Comma-separated paths to exclude."),
+    ] = None,
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start for stateful workflows."),
+    ] = "",
+) -> str:
+    """Generate and optionally apply high-confidence auto-patches (ADR-076).
+
+    Default is dry_run=true (preview only). Only HIGH automation_fit,
+    LOCAL scope, LOW risk tasks are eligible for auto-patching.
+    """
+    from drift_mcp.mcp_router_repair import run_fix_apply
+
+    return await run_fix_apply(
+        path=path,
+        signal=signal,
+        max_tasks=max_tasks,
+        dry_run=dry_run,
+        target_path=target_path,
+        exclude_paths=exclude_paths,
+        session_id=session_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Architecture: steer, compile_policy, suggest_rules, generate_skills
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def drift_steer(
+    path: Annotated[str, Field(description="Repository path.")] = ".",
+    target: Annotated[
+        str,
+        Field(
+            description=(
+                "File or module path to get architecture context for "
+                "(relative to repo root, e.g. 'src/api' or 'src/api/auth.py')."
+            ),
+        ),
+    ] = "",
+    max_abstractions: Annotated[
+        int,
+        Field(description="Maximum number of reusable abstractions to return."),
+    ] = 20,
+    response_profile: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Response profile: 'planner', 'coder', 'verifier', "
+                "'merge_readiness'. Omit for full response."
+            ),
+        ),
+    ] = None,
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start."),
+    ] = "",
+) -> str:
+    """Location-centric architecture context: layer, neighbors, hotspots, policies.
+
+    Pre-edit tool — call BEFORE editing a file to understand the architecture
+    at that location.  Fast (<500ms), reads from persisted ArchGraph.
+    """
+    import json
+
+    _err = _validate_enum_param(
+        "response_profile", response_profile, _RESPONSE_PROFILE_VALUES, "drift_steer"
+    )
+    if _err:
+        _err["tool"] = "drift_steer"
+        return json.dumps(_err)
+
+    from drift_mcp.mcp_router_architecture import run_steer
+
+    return await run_steer(
+        path=path,
+        target=target,
+        max_abstractions=max_abstractions,
+        response_profile=response_profile,
+        session_id=session_id,
+    )
+
+
+@mcp.tool()
+async def drift_compile_policy(
+    path: Annotated[str, Field(description="Repository path.")] = ".",
+    task: Annotated[
+        str,
+        Field(
+            description="Natural-language task description to compile policy for.",
+        ),
+    ] = "",
+    task_spec_path: Annotated[
+        str | None,
+        Field(description="Optional path to a TaskSpec YAML file for structured boundaries."),
+    ] = None,
+    diff_ref: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Git ref for diff-based scope detection (e.g. 'HEAD'). "
+                "If omitted, git context is skipped."
+            ),
+        ),
+    ] = None,
+    max_rules: Annotated[
+        int,
+        Field(description="Maximum number of rules in the output."),
+    ] = 15,
+    response_profile: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Response profile: 'planner', 'coder', 'verifier', "
+                "'merge_readiness'. Omit for full response."
+            ),
+        ),
+    ] = None,
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start."),
+    ] = "",
+) -> str:
+    """Compile task-specific operative policy: scope boundaries, prohibitions, invariants.
+
+    Assembles a compact, agent-consumable policy package from repository state
+    so the agent knows what rules apply before writing code.
+    """
+    import json
+
+    _err = _validate_enum_param(
+        "response_profile", response_profile, _RESPONSE_PROFILE_VALUES, "drift_compile_policy"
+    )
+    if _err:
+        _err["tool"] = "drift_compile_policy"
+        return json.dumps(_err)
+
+    from drift_mcp.mcp_router_architecture import run_compile_policy
+
+    return await run_compile_policy(
+        path=path,
+        task=task,
+        task_spec_path=task_spec_path,
+        diff_ref=diff_ref,
+        max_rules=max_rules,
+        response_profile=response_profile,
+        session_id=session_id,
+    )
+
+
+@mcp.tool()
+async def drift_suggest_rules(
+    path: Annotated[str, Field(description="Repository path.")] = ".",
+    min_occurrences: Annotated[
+        int,
+        Field(description="Minimum signal recurrence in a module to trigger a proposal."),
+    ] = 4,
+    response_profile: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Response profile: 'planner', 'coder', 'verifier', "
+                "'merge_readiness'. Omit for full response."
+            ),
+        ),
+    ] = None,
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start."),
+    ] = "",
+) -> str:
+    """Propose architecture rules from recurring drift patterns.
+
+    Reads the ArchGraph and detects recurring signal patterns in hotspots,
+    returning proposed ArchDecision rules for maintainer review.
+    """
+    import json
+
+    _err = _validate_enum_param(
+        "response_profile", response_profile, _RESPONSE_PROFILE_VALUES, "drift_suggest_rules"
+    )
+    if _err:
+        _err["tool"] = "drift_suggest_rules"
+        return json.dumps(_err)
+
+    from drift_mcp.mcp_router_architecture import run_suggest_rules
+
+    return await run_suggest_rules(
+        path=path,
+        min_occurrences=min_occurrences,
+        response_profile=response_profile,
+        session_id=session_id,
+    )
+
+
+@mcp.tool()
+async def drift_generate_skills(
+    path: Annotated[str, Field(description="Repository path.")] = ".",
+    min_occurrences: Annotated[
+        int,
+        Field(description="Minimum signal recurrence to trigger a skill briefing."),
+    ] = 4,
+    min_confidence: Annotated[
+        float,
+        Field(description="Minimum confidence score to include a briefing (0.0–1.0)."),
+    ] = 0.6,
+    response_profile: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Response profile: 'planner', 'coder', 'verifier', "
+                "'merge_readiness'. Omit for full response."
+            ),
+        ),
+    ] = None,
+    session_id: Annotated[
+        str,
+        Field(description="Optional session ID from drift_session_start."),
+    ] = "",
+) -> str:
+    """Generate agent-prompt skill briefings for modules with recurring drift.
+
+    Returns structured SkillBriefing data with agent_instruction for creating
+    .github/skills/<name>/SKILL.md files.
+    """
+    import json
+
+    _err = _validate_enum_param(
+        "response_profile", response_profile, _RESPONSE_PROFILE_VALUES, "drift_generate_skills"
+    )
+    if _err:
+        _err["tool"] = "drift_generate_skills"
+        return json.dumps(_err)
+
+    from drift_mcp.mcp_router_architecture import run_generate_skills
+
+    return await run_generate_skills(
+        path=path,
+        min_occurrences=min_occurrences,
+        min_confidence=min_confidence,
+        response_profile=response_profile,
+        session_id=session_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# MCP Tools — Retrieval (ADR-091: fact-grounded agent retrieval)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def drift_retrieve(
+    query: Annotated[
+        str,
+        Field(
+            description=(
+                "Natural-language question or keywords. Retrieval searches"
+                " drift's own verified fact sources (POLICY, ROADMAP, ADRs,"
+                " audit artefacts, signal docstrings, benchmark evidence)."
+            ),
+        ),
+    ],
+    path: Annotated[str, Field(description="Repository path that hosts the fact corpus.")] = ".",
+    top_k: Annotated[
+        int,
+        Field(description="Maximum number of fact chunks to return (1-20 recommended)."),
+    ] = 5,
+    kind: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Filter by chunk kind: 'policy', 'roadmap', 'adr', 'audit',"
+                " 'signal', or 'evidence'. Omit for all kinds."
+            ),
+        ),
+    ] = None,
+    signal_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Filter signal chunks by signal identifier (e.g."
+                " 'pattern_fragmentation'). Implies kind='signal' when set."
+            ),
+        ),
+    ] = None,
+    session_id: Annotated[
+        str | None,
+        Field(description="Optional session ID for telemetry and context tracking (ADR-022)."),
+    ] = None,
+) -> str:
+    """Retrieve verified fact chunks from drift's own documentation corpus.
+
+    Agents MUST use this tool before making claims about drift's policy,
+    signals, ADR decisions, audit results, or benchmark evidence. Each hit
+    carries a stable ``fact_id`` and ``sha256`` anchor for verbatim citation;
+    see ``drift_cite`` to expand a fact_id to its full text.
+    """
+    from drift.retrieval.mcp import run_retrieve
+
+    return await run_retrieve(
+        path=path,
+        query=query,
+        top_k=top_k,
+        kind=kind,
+        signal_id=signal_id,
+    )
+
+
+@mcp.tool()
+async def drift_cite(
+    fact_id: Annotated[
+        str,
+        Field(
+            description=(
+                "Stable Fact-ID returned by drift_retrieve, e.g."
+                " 'POLICY#S8.p3' or 'ADR-091#decision'."
+            ),
+        ),
+    ],
+    path: Annotated[str, Field(description="Repository path that hosts the fact corpus.")] = ".",
+    session_id: Annotated[
+        str | None,
+        Field(description="Optional session ID for telemetry and context tracking (ADR-022)."),
+    ] = None,
+) -> str:
+    """Expand a Fact-ID to its verbatim chunk text with a SHA-256 anchor.
+
+    Resolves migrated IDs transitively via
+    ``decisions/fact_id_migrations.jsonl``. Use the returned text verbatim
+    when grounding claims about drift in agent responses.
+    """
+    from drift.retrieval.mcp import run_cite
+
+    return await run_cite(path=path, fact_id=fact_id)
+
+
+_EXPORTED_MCP_TOOLS = (
+    drift_scan,
+    drift_diff,
+    drift_verify,
+    drift_explain,
+    drift_fix_plan,
+    drift_validate,
+    drift_nudge,
+    drift_shadow_verify,
+    drift_brief,
+    drift_negative_context,
+    drift_session_start,
+    drift_session_status,
+    drift_session_update,
+    drift_session_end,
+    # drift_task_claim, drift_task_renew, drift_task_release, drift_task_complete,
+    # drift_task_status removed from MCP surface (Issue #545). Functions remain
+    # callable for backward compatibility; will be deleted in v3.0.
+    drift_session_trace,
+    drift_map,
+    drift_guard_contract,
+    drift_feedback,
+    drift_calibrate,
+    drift_capture_intent,
+    drift_verify_intent,
+    drift_feedback_for_agent,
+    drift_patch_begin,
+    drift_patch_check,
+    drift_patch_commit,
+    drift_fix_apply,
+    drift_steer,
+    drift_compile_policy,
+    drift_suggest_rules,
+    drift_generate_skills,
+    drift_retrieve,
+    drift_cite,
+)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def _assert_mcp_tools_registered() -> None:
+    """Verify all expected MCP tools are registered in the FastMCP runtime registry.
+
+    Runs synchronously before the event loop starts (called from main()).  Raises
+    ``RuntimeError`` if any tool declared in ``_EXPORTED_MCP_TOOLS`` is absent from
+    the FastMCP tool registry so that silent schema-generation failures are surfaced
+    immediately at server startup rather than discovered only when a tool is invoked.
+    """
+    if not _MCP_AVAILABLE:
+        return
+
+    expected = {f.__name__ for f in _EXPORTED_MCP_TOOLS}
+    _LOGGER.debug("Verifying %d expected MCP tools in FastMCP registry…", len(expected))
+
+    try:
+        registered_tools = asyncio.run(mcp.list_tools())
+        registered = {t.name for t in registered_tools}
+    except Exception as exc:
+        raise RuntimeError(
+            f"MCP tool registry introspection failed: {exc!r}. "
+            "The server cannot guarantee all tools are available. "
+            "Try reinstalling: pip install --upgrade 'drift-analyzer[mcp]'"
+        ) from exc
+
+    missing = expected - registered
+    if missing:
+        missing_str = ", ".join(sorted(missing))
+        raise RuntimeError(
+            f"MCP tool registration incomplete: {len(missing)} tool(s) not in FastMCP "
+            f"registry: {missing_str}. This may indicate a FastMCP schema-generation "
+            f"failure. Try reinstalling: pip install --upgrade 'drift-analyzer[mcp]'"
+        )
+    _LOGGER.info(
+        "MCP server startup: %d/%d tools verified in FastMCP registry.",
+        len(registered),
+        len(expected),
+    )
+
+
+def _eager_imports() -> None:
+    """Pre-import heavy modules before the event loop starts.
+
+    On Windows the IOCP proactor holds handles that conflict with the
+    OS DLL-loader lock.  If a worker thread triggers a first-time import
+    of C-extension modules (numpy, torch, faiss …) while the event loop
+    owns an IOCP handle, a deadlock occurs.  Importing everything that
+    the tool functions need *before* ``mcp.run()`` avoids this entirely.
+    """
+    import drift.analyzer  # noqa: F401 — pulls in signals, pipeline, scoring
+    import drift.api  # noqa: F401 — registers public surface
+    import drift.pipeline  # noqa: F401 — pulls in embeddings (numpy/torch)
+
+
+def main() -> None:
+    """Run the drift MCP server on stdio transport."""
+    from drift.plugins import load_all_plugins
+
+    if not _MCP_AVAILABLE:
+        msg = "MCP server requires optional dependency 'mcp'."
+        raise RuntimeError(msg)
+
+    # Ensure plugin signals are registered before API tools are exercised.
+    load_all_plugins()
+    _eager_imports()
+    _assert_mcp_tools_registered()
+    mcp.run(transport="stdio")

--- a/packages/drift-mcp/src/drift_mcp/mcp_utils.py
+++ b/packages/drift-mcp/src/drift_mcp/mcp_utils.py
@@ -1,0 +1,230 @@
+"""Shared utility functions used by all MCP tool routers.
+
+This module consolidates helpers that were previously duplicated across
+mcp_server.py, mcp_router_analysis.py, mcp_router_repair.py, and
+mcp_router_session.py.  Import from here instead of defining local copies.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import io
+import json
+import logging
+import uuid
+from typing import Any, cast
+
+try:
+    import anyio
+
+    _ANYIO_AVAILABLE = True
+except ImportError:
+    anyio = None  # type: ignore[assignment]
+    _ANYIO_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# Enum / constant sets for parameter validation
+# ---------------------------------------------------------------------------
+
+_RESPONSE_DETAIL_VALUES = frozenset({"concise", "detailed"})
+_RESPONSE_PROFILE_VALUES = frozenset({"planner", "coder", "verifier", "merge_readiness"})
+_FAIL_ON_VALUES = frozenset({"critical", "high", "medium", "low", "none"})
+_AUTOMATION_FIT_MIN_VALUES = frozenset({"low", "medium", "high"})
+
+logger = logging.getLogger("drift")
+
+
+# ---------------------------------------------------------------------------
+# CSV parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_csv_ids(raw: str | None) -> list[str] | None:
+    """Split a comma-separated string into a list of non-empty stripped values."""
+    if not raw:
+        return None
+    values = [part.strip() for part in raw.split(",") if part.strip()]
+    return values or None
+
+
+# ---------------------------------------------------------------------------
+# Async thread helpers (anyio-aware for proper MCP client cancellation)
+# ---------------------------------------------------------------------------
+
+
+async def _run_sync_in_thread(
+    fn: Any,
+    *args: object,
+    abandon_on_cancel: bool = False,
+) -> Any:
+    """Run a sync callable in a worker thread with optional anyio support.
+
+    When ``abandon_on_cancel=True``, a disconnecting MCP client triggers
+    CancelledError immediately instead of blocking the event loop until the
+    worker thread finishes.
+    """
+    if _ANYIO_AVAILABLE and anyio is not None:
+        return await anyio.to_thread.run_sync(fn, *args, abandon_on_cancel=abandon_on_cancel)
+    return await asyncio.to_thread(fn, *args)
+
+
+async def _run_sync_with_timeout(
+    fn: Any,
+    timeout_seconds: float,
+    *args: object,
+) -> Any:
+    """Run a sync callable with timeout, even when anyio is unavailable."""
+    if _ANYIO_AVAILABLE and anyio is not None:
+        with anyio.fail_after(timeout_seconds):
+            return await anyio.to_thread.run_sync(fn, *args, abandon_on_cancel=True)
+    return await asyncio.wait_for(
+        asyncio.to_thread(fn, *args),
+        timeout=timeout_seconds,
+    )
+
+
+def _is_broken_internal_drift_module(exc: BaseException) -> bool:
+    """Return True when an ImportError refers to an internal drift.* module.
+
+    This distinguishes broken-installation errors (e.g. ``No module named
+    'drift.output'``) from missing-optional-extra errors (e.g. ``No module
+    named 'mcp'``) so callers can produce a more actionable message.
+    """
+    if not isinstance(exc, ImportError):
+        return False
+    missing = getattr(exc, "name", None) or ""
+    return missing.startswith("drift.") or missing == "drift"
+
+
+def _broken_internal_module_error(tool_name: str, exc: ImportError) -> dict[str, Any]:
+    """Build a user-friendly DRIFT-5001 payload for a broken internal module."""
+    from drift.api_helpers import _error_response
+
+    missing = getattr(exc, "name", None) or str(exc)
+    error = _error_response(
+        "DRIFT-5001",
+        (
+            f"Drift installation appears incomplete: module '{missing}' "
+            f"is not importable. "
+            f"Please reinstall: pip install --upgrade 'drift-analyzer[mcp]'"
+        ),
+        recoverable=False,
+    )
+    error["tool"] = tool_name
+    error["broken_module"] = missing
+    error["agent_instruction"] = (
+        f"The tool '{tool_name}' failed because a required Drift internal module "
+        f"('{missing}') could not be imported. "
+        "Ask the user to reinstall Drift: pip install --upgrade 'drift-analyzer[mcp]'"
+    )
+    return error
+
+
+async def _run_api_tool(tool_name: str, api_fn: Any, **kwargs: Any) -> str:
+    """Run an API function in a thread and return a JSON string.
+
+    Uses abandon_on_cancel so MCP client disconnects propagate immediately.
+    """
+
+    request_id = str(uuid.uuid4())
+    logger.debug("[%s] %s called params=%s", request_id, tool_name, kwargs)
+
+    def _sync() -> str:
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                result = api_fn(**kwargs)
+            if isinstance(result, dict):
+                result.setdefault("request_id", request_id)
+            else:
+                result = {
+                    "type": "ok",
+                    "tool": tool_name,
+                    "request_id": request_id,
+                    "result": result,
+                }
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            logger.warning(
+                "[%s] DRIFT-5001 from %s: %r",
+                request_id,
+                tool_name,
+                exc,
+                exc_info=True,
+            )
+            if isinstance(exc, ImportError) and _is_broken_internal_drift_module(exc):
+                error = _broken_internal_module_error(tool_name, exc)
+                error["request_id"] = request_id
+                return json.dumps(error, default=str)
+            from drift.api_helpers import _error_response
+
+            error = _error_response("DRIFT-5001", str(exc), recoverable=True)
+            error["tool"] = tool_name
+            error["request_id"] = request_id
+            return json.dumps(error, default=str)
+
+    return cast(str, await _run_sync_in_thread(_sync, abandon_on_cancel=True))
+
+
+# ---------------------------------------------------------------------------
+# Parameter validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_enum_param(
+    param_name: str,
+    value: str | None,
+    valid_values: frozenset[str],
+    tool_name: str,
+    *,
+    required: bool = False,
+) -> dict[str, Any] | None:
+    """Validate a single enum parameter at the MCP tool boundary.
+
+    Returns a structured DRIFT-1003 error dict if invalid, or None if valid.
+    Allows None when ``required=False``.
+    """
+    if value is None:
+        if required:
+            from drift.api_helpers import _error_response
+
+            return _error_response(
+                "DRIFT-1003",
+                f"Missing required parameter '{param_name}' in {tool_name}",
+                invalid_fields=[
+                    {
+                        "field": param_name,
+                        "value": None,
+                        "reason": f"Required. Expected one of: {', '.join(sorted(valid_values))}",
+                    }
+                ],
+                suggested_fix={
+                    "action": f"Supply a valid value for '{param_name}'.",
+                    "valid_values": sorted(valid_values),
+                },
+            )
+        return None
+    normalised = str(value).strip().lower()
+    if normalised not in valid_values:
+        from drift.api_helpers import _error_response
+
+        return _error_response(
+            "DRIFT-1003",
+            f"Invalid value '{value}' for '{param_name}' in {tool_name}",
+            invalid_fields=[
+                {
+                    "field": param_name,
+                    "value": value,
+                    "reason": f"Expected one of: {', '.join(sorted(valid_values))}",
+                }
+            ],
+            suggested_fix={
+                "action": f"Use a supported value for '{param_name}'.",
+                "valid_values": sorted(valid_values),
+                "example_call": {
+                    "tool": tool_name,
+                    "params": {param_name: next(iter(sorted(valid_values)))},
+                },
+            },
+        )
+    return None

--- a/packages/drift-mcp/tests/test_drift_mcp_smoke.py
+++ b/packages/drift-mcp/tests/test_drift_mcp_smoke.py
@@ -1,0 +1,31 @@
+"""Smoke tests for drift-mcp package structure."""
+
+import importlib
+
+
+def test_drift_mcp_importable() -> None:
+    import drift_mcp  # noqa: F401
+
+
+def test_core_modules_importable() -> None:
+    importlib.import_module("drift_mcp.mcp_server")
+    importlib.import_module("drift_mcp.mcp_catalog")
+    importlib.import_module("drift_mcp.mcp_orchestration")
+    importlib.import_module("drift_mcp.mcp_utils")
+
+
+def test_stubs_alias_to_drift_mcp() -> None:
+    import sys
+
+
+    assert sys.modules.get("drift.mcp_server") is sys.modules.get("drift_mcp.mcp_server")
+    assert sys.modules.get("drift.mcp_catalog") is sys.modules.get("drift_mcp.mcp_catalog")
+    assert sys.modules.get("drift.mcp_orchestration") is sys.modules.get(
+        "drift_mcp.mcp_orchestration"
+    )
+
+
+def test_mcp_server_has_main() -> None:
+    from drift_mcp.mcp_server import main
+
+    assert callable(main)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "drift-analyzer"
-version = "2.50.0"
+version = "2.49.0"
 description = "Catches structural erosion from AI-generated code — the bugs that pass all your tests"
 readme = "README.md"
 license = "MIT"
@@ -65,7 +65,21 @@ dependencies = [
     "pydantic>=2.0",
     "gitpython>=3.1",
     "networkx>=3.0",
+    "drift-config",
+    "drift-sdk",
+    "drift-engine",
+    "drift-output",
+    "drift-session",
+    "drift-mcp",
 ]
+
+[tool.uv.sources]
+drift-config = { workspace = true }
+drift-sdk = { workspace = true }
+drift-engine = { workspace = true }
+drift-output = { workspace = true }
+drift-session = { workspace = true }
+drift-mcp = { workspace = true }
 
 [project.urls]
 Homepage = "https://mick-gsk.github.io/drift/"
@@ -147,6 +161,10 @@ drift-analyzer = "drift.cli:safe_main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/drift"]
+
+[tool.uv.workspace]
+members = ["packages/*"]
+exclude = ["packages/drift", "packages/drift-cli"]
 
 [tool.hatch.build.targets.sdist]
 exclude = [

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,17 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[manifest]
+members = [
+    "drift-analyzer",
+    "drift-config",
+    "drift-engine",
+    "drift-mcp",
+    "drift-output",
+    "drift-sdk",
+    "drift-session",
+]
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -638,10 +649,16 @@ wheels = [
 
 [[package]]
 name = "drift-analyzer"
-version = "2.48.5"
+version = "2.49.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "drift-config" },
+    { name = "drift-engine" },
+    { name = "drift-mcp" },
+    { name = "drift-output" },
+    { name = "drift-sdk" },
+    { name = "drift-session" },
     { name = "gitpython" },
     { name = "networkx" },
     { name = "pydantic" },
@@ -730,6 +747,12 @@ watch = [
 requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "drift-analyzer", extras = ["typescript", "embeddings", "markdown", "mcp", "llm", "dev"], marker = "extra == 'all'" },
+    { name = "drift-config", editable = "packages/drift-config" },
+    { name = "drift-engine", editable = "packages/drift-engine" },
+    { name = "drift-mcp", editable = "packages/drift-mcp" },
+    { name = "drift-output", editable = "packages/drift-output" },
+    { name = "drift-sdk", editable = "packages/drift-sdk" },
+    { name = "drift-session", editable = "packages/drift-session" },
     { name = "faiss-cpu", marker = "extra == 'embeddings'", specifier = ">=1.7" },
     { name = "gitpython", specifier = ">=3.1" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100" },
@@ -768,6 +791,126 @@ requires-dist = [
     { name = "watchfiles", marker = "extra == 'watch'", specifier = ">=1.0" },
 ]
 provides-extras = ["typescript", "embeddings", "markdown", "mcp", "autopatch", "watch", "fast-json", "llm", "dev", "all"]
+
+[[package]]
+name = "drift-config"
+version = "2.49.0"
+source = { editable = "packages/drift-config" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+]
+
+[[package]]
+name = "drift-engine"
+version = "2.49.0"
+source = { editable = "packages/drift-engine" }
+dependencies = [
+    { name = "drift-config" },
+    { name = "drift-sdk" },
+    { name = "gitpython" },
+    { name = "mistune" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "pydantic" },
+    { name = "pygments" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-typescript" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "drift-config", editable = "packages/drift-config" },
+    { name = "drift-sdk", editable = "packages/drift-sdk" },
+    { name = "gitpython", specifier = ">=3.1" },
+    { name = "mistune", specifier = ">=3.0" },
+    { name = "networkx", specifier = ">=3.0" },
+    { name = "numpy", specifier = ">=1.24" },
+    { name = "pydantic", specifier = ">=2.0" },
+    { name = "pygments", specifier = ">=2.0" },
+    { name = "tree-sitter", specifier = ">=0.21" },
+    { name = "tree-sitter-typescript", specifier = ">=0.21" },
+]
+
+[[package]]
+name = "drift-mcp"
+version = "2.49.0"
+source = { editable = "packages/drift-mcp" }
+dependencies = [
+    { name = "drift-config" },
+    { name = "drift-engine" },
+    { name = "drift-output" },
+    { name = "drift-sdk" },
+    { name = "drift-session" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "drift-config", editable = "packages/drift-config" },
+    { name = "drift-engine", editable = "packages/drift-engine" },
+    { name = "drift-output", editable = "packages/drift-output" },
+    { name = "drift-sdk", editable = "packages/drift-sdk" },
+    { name = "drift-session", editable = "packages/drift-session" },
+]
+
+[[package]]
+name = "drift-output"
+version = "2.49.0"
+source = { editable = "packages/drift-output" }
+dependencies = [
+    { name = "drift-config" },
+    { name = "drift-engine" },
+    { name = "drift-sdk" },
+    { name = "rich" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "drift-config", editable = "packages/drift-config" },
+    { name = "drift-engine", editable = "packages/drift-engine" },
+    { name = "drift-sdk", editable = "packages/drift-sdk" },
+    { name = "rich", specifier = ">=13.0" },
+]
+
+[[package]]
+name = "drift-sdk"
+version = "2.49.0"
+source = { editable = "packages/drift-sdk" }
+dependencies = [
+    { name = "drift-config" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "drift-config", editable = "packages/drift-config" },
+    { name = "pydantic", specifier = ">=2.0" },
+]
+
+[[package]]
+name = "drift-session"
+version = "2.49.0"
+source = { editable = "packages/drift-session" }
+dependencies = [
+    { name = "drift-config" },
+    { name = "drift-engine" },
+    { name = "drift-output" },
+    { name = "drift-sdk" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "drift-config", editable = "packages/drift-config" },
+    { name = "drift-engine", editable = "packages/drift-engine" },
+    { name = "drift-output", editable = "packages/drift-output" },
+    { name = "drift-sdk", editable = "packages/drift-sdk" },
+]
 
 [[package]]
 name = "execnet"


### PR DESCRIPTION
Split from #576 (ADR-100 monorepo migration). Part of the PR decomposition into atomic, reviewable units.