### PR TITLE
feat: add drift-engine signals A-M (package skeleton + base + arch/broad/bypass to fan_out, ADR-100)

### DIFF
--- a/packages/drift-engine/pyproject.toml
+++ b/packages/drift-engine/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "drift-engine"
+version = "2.49.0"
+description = "Signal detection, scoring, and ingestion engine for drift-analyzer"
+requires-python = ">=3.11"
+dependencies = [
+    "drift-sdk",
+    "drift-config",
+    "pydantic>=2.0",
+    "networkx>=3.0",
+    "numpy>=1.24",
+    "mistune>=3.0",
+    "tree-sitter>=0.21",
+    "tree-sitter-typescript>=0.21",
+    "gitpython>=3.1",
+    "pygments>=2.0",
+]
+
+[tool.uv.sources]
+drift-sdk = { workspace = true }
+drift-config = { workspace = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/drift_engine"]

--- a/packages/drift-engine/src/drift_engine/__init__.py
+++ b/packages/drift-engine/src/drift_engine/__init__.py
@@ -1,0 +1,9 @@
+"""drift-engine: signal detection, scoring, and ingestion engine for drift-analyzer.
+
+This package contains the core analysis engine:
+- signals/    — 24 detection signals (BaseSignal subclasses)
+- scoring/    — weighted composite score engine
+- ingestion/  — file discovery, AST/git parsing
+- pipeline    — analysis pipeline orchestration
+- analyzer    — high-level analyzer entry point
+"""

--- a/packages/drift-engine/src/drift_engine/signals/__init__.py
+++ b/packages/drift-engine/src/drift_engine/signals/__init__.py
@@ -1,0 +1,49 @@
+"""Detection signals for Drift analysis."""
+
+from drift_engine.signals.architecture_violation import ArchitectureViolationSignal
+from drift_engine.signals.base import BaseSignal
+from drift_engine.signals.broad_exception_monoculture import BroadExceptionMonocultureSignal
+from drift_engine.signals.bypass_accumulation import BypassAccumulationSignal
+from drift_engine.signals.circular_import import CircularImportSignal
+from drift_engine.signals.co_change_coupling import CoChangeCouplingSignal
+from drift_engine.signals.cognitive_complexity import CognitiveComplexitySignal
+from drift_engine.signals.cohesion_deficit import CohesionDeficitSignal
+from drift_engine.signals.dead_code_accumulation import DeadCodeAccumulationSignal
+from drift_engine.signals.doc_impl_drift import DocImplDriftSignal
+from drift_engine.signals.exception_contract_drift import ExceptionContractDriftSignal
+from drift_engine.signals.explainability_deficit import ExplainabilityDeficitSignal
+from drift_engine.signals.fan_out_explosion import FanOutExplosionSignal
+from drift_engine.signals.guard_clause_deficit import GuardClauseDeficitSignal
+from drift_engine.signals.mutant_duplicates import MutantDuplicateSignal
+from drift_engine.signals.naming_contract_violation import NamingContractViolationSignal
+from drift_engine.signals.pattern_fragmentation import PatternFragmentationSignal
+from drift_engine.signals.phantom_reference import PhantomReferenceSignal
+from drift_engine.signals.system_misalignment import SystemMisalignmentSignal
+from drift_engine.signals.temporal_volatility import TemporalVolatilitySignal
+from drift_engine.signals.test_polarity_deficit import TestPolarityDeficitSignal
+from drift_engine.signals.ts_architecture import TypeScriptArchitectureSignal
+
+__all__ = [
+    "BaseSignal",
+    "PatternFragmentationSignal",
+    "ArchitectureViolationSignal",
+    "MutantDuplicateSignal",
+    "ExplainabilityDeficitSignal",
+    "TemporalVolatilitySignal",
+    "SystemMisalignmentSignal",
+    "DocImplDriftSignal",
+    "BroadExceptionMonocultureSignal",
+    "TestPolarityDeficitSignal",
+    "GuardClauseDeficitSignal",
+    "CoChangeCouplingSignal",
+    "CohesionDeficitSignal",
+    "NamingContractViolationSignal",
+    "BypassAccumulationSignal",
+    "ExceptionContractDriftSignal",
+    "TypeScriptArchitectureSignal",
+    "CognitiveComplexitySignal",
+    "FanOutExplosionSignal",
+    "CircularImportSignal",
+    "DeadCodeAccumulationSignal",
+    "PhantomReferenceSignal",
+]

--- a/packages/drift-engine/src/drift_engine/signals/_ts_support.py
+++ b/packages/drift-engine/src/drift_engine/signals/_ts_support.py
@@ -1,0 +1,48 @@
+"""Tree-sitter helpers for TypeScript/JavaScript signal analysis.
+
+Centralises the dependency on ``drift.ingestion.ts_parser`` so that the
+shared ``_utils`` module (which is a high-fan-in stable module) does not
+carry an unstable-dependency edge.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+
+def ts_parse_source(source: str, language: str = "typescript") -> tuple[Any, bytes] | None:
+    """Parse *source* with tree-sitter.  Returns ``(root_node, source_bytes)`` or *None*."""
+    try:
+        from drift_engine.ingestion.ts_parser import _get_parser, tree_sitter_available
+
+        if not tree_sitter_available():
+            return None
+        ts_lang = "tsx" if language in ("tsx", "jsx") else "typescript"
+        parser = _get_parser(ts_lang)
+        source_bytes = source.encode("utf-8")
+        tree = parser.parse(source_bytes)
+        return tree.root_node, source_bytes
+    except ImportError:
+        return None
+    except Exception:
+        logging.getLogger("drift").debug(
+            "tree-sitter parse failed for %s source", language, exc_info=True,
+        )
+        return None
+
+
+def ts_walk(node: Any) -> list[Any]:
+    """Depth-first walk of all descendants of a tree-sitter node."""
+    result: list[Any] = []
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        result.append(n)
+        stack.extend(reversed(n.children))
+    return result
+
+
+def ts_node_text(node: Any, source: bytes) -> str:
+    """Extract the UTF-8 text of a tree-sitter node."""
+    return source[node.start_byte : node.end_byte].decode("utf-8", errors="replace")

--- a/packages/drift-engine/src/drift_engine/signals/_utils.py
+++ b/packages/drift-engine/src/drift_engine/signals/_utils.py
@@ -1,0 +1,72 @@
+"""Shared utilities for signal implementations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from drift_engine.ingestion.test_detection import is_test_file as _is_test_file
+
+_TS_LANGUAGES: frozenset[str] = frozenset(
+    {"typescript", "tsx", "javascript", "jsx"},
+)
+
+_SUPPORTED_LANGUAGES: frozenset[str] = frozenset({"python"}) | _TS_LANGUAGES
+
+_LIBRARY_ROOT_DIRS: frozenset[str] = frozenset({"src", "lib", "packages"})
+_APPLICATION_ROOT_DIRS: frozenset[str] = frozenset(
+    {"app", "apps", "backend", "frontend", "service", "services", "server", "web"}
+)
+
+
+def is_test_file(file_path: Path) -> bool:
+    """Return True if *file_path* looks like a test file (by name / path).
+
+    Covers Python, TypeScript / JavaScript and common JS test directories.
+    """
+    return _is_test_file(file_path)
+
+
+def is_library_finding_path(file_path: Path | None) -> bool:
+    """Return True when *file_path* matches common library source layouts."""
+    if file_path is None:
+        return False
+    parts = file_path.as_posix().lower().split("/")
+    if not parts:
+        return False
+    if any(part in _LIBRARY_ROOT_DIRS for part in parts):
+        return True
+    # Monorepo layout: packages/<pkg>/(src|lib)/...
+    return any(
+        parts[idx] == "packages" and idx + 2 < len(parts) and parts[idx + 2] in {"src", "lib"}
+        for idx in range(len(parts))
+    )
+
+
+def is_likely_library_repo(parse_results: list[Any]) -> bool:
+    """Heuristic repository profile detection for library-style layouts.
+
+    Conservative by design: requires at least one library-style root and no
+    strong application root markers.
+    """
+    path_tokens: set[str] = set()
+    for pr in parse_results:
+        file_path = getattr(pr, "file_path", None)
+        if not isinstance(file_path, Path):
+            continue
+        if is_test_file(file_path):
+            continue
+        parts = file_path.as_posix().lower().split("/")
+        path_tokens.update(part for part in parts if part)
+
+    has_library_layout = any(token in _LIBRARY_ROOT_DIRS for token in path_tokens)
+    has_application_layout = any(token in _APPLICATION_ROOT_DIRS for token in path_tokens)
+    return has_library_layout and not has_application_layout
+
+
+# ---------------------------------------------------------------------------
+# Tree-sitter helpers live in _ts_support to avoid pulling the unstable
+# ts_parser dependency into this high-fan-in utility module.
+# Signals should import ts_parse_source / ts_walk / ts_node_text from
+# drift.signals._ts_support directly.
+# ---------------------------------------------------------------------------

--- a/packages/drift-engine/src/drift_engine/signals/architecture_violation.py
+++ b/packages/drift-engine/src/drift_engine/signals/architecture_violation.py
@@ -1,0 +1,1274 @@
+"""Signal 2: Architecture Violation Score (AVS).
+
+Detects imports that violate layer boundaries — e.g. a route handler
+importing directly from a database module instead of going through
+a service layer.
+
+Enhancements over v0.1:
+- Omnilayer recognition: config/utils/types modules are cross-cutting
+  and never generate violations.
+- Hub-module dampening: high-centrality targets get reduced scores.
+- Embedding-based layer inference (optional): uses semantic similarity
+  to layer-prototype descriptions when sentence-transformers is installed.
+- Policy ``allowed_cross_layer`` patterns suppress matching findings.
+- Configurable lazy-import policy rules detect module-level heavy imports.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import posixpath
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import networkx as nx
+
+from drift.config import DriftConfig
+from drift.models import (
+    FileHistory,
+    Finding,
+    ImportInfo,
+    ParseResult,
+    Severity,
+    SignalType,
+)
+from drift_engine.ingestion.git_history import build_co_change_pairs
+from drift_engine.ingestion.test_detection import is_generated_file
+from drift_engine.signals._utils import is_test_file
+from drift_engine.signals.base import BaseSignal, SignalCacheDependencySpec, register_signal
+
+if TYPE_CHECKING:
+    from drift_engine.signals.base import EmbeddingServiceProtocol
+
+logger = logging.getLogger("drift.avs")
+
+_SOURCE_ROOT_PREFIXES: frozenset[str] = frozenset({"src", "lib", "python"})
+_GENERATED_HEADER_MAX_LINES = 6
+
+
+def _module_for_path(path: Path) -> str:
+    """Convert file path to a dotted module path."""
+    parts = list(path.with_suffix("").parts)
+    return ".".join(parts)
+
+
+def _module_aliases_for_path(path: Path) -> list[str]:
+    """Return dotted module aliases for a file path.
+
+    Repositories often keep importable packages under source roots like
+    ``src/``. This helper maps both forms so imports such as
+    ``transformers.utils`` can resolve to ``src/transformers/utils.py``.
+    """
+    module = _module_for_path(path)
+    aliases = [module]
+
+    parts = path.with_suffix("").parts
+    if len(parts) >= 2 and parts[0].lower() in _SOURCE_ROOT_PREFIXES:
+        aliases.append(".".join(parts[1:]))
+
+    return aliases
+
+
+def _matches_pattern(path_str: str, pattern: str) -> bool:
+    return fnmatch.fnmatch(path_str, pattern)
+
+
+def _matches_module_pattern(module: str, pattern: str) -> bool:
+    """Match module names against exact/prefix or glob-style patterns."""
+    if _matches_pattern(module, pattern):
+        return True
+    if any(ch in pattern for ch in "*?[]"):
+        return False
+    return module == pattern or module.startswith(f"{pattern}.")
+
+
+def _relative_import_candidates(source_file: Path, imp: ImportInfo) -> list[str]:
+    """Build candidate module paths for unresolved relative imports.
+
+    The Python parser currently records ``is_relative`` but stores
+    ``imported_module`` without leading dots. For large codebases that use
+    package-relative imports heavily, this can collapse internal edges into
+    unresolved externals. This helper reconstructs best-effort candidates from
+    the source file package path.
+    """
+    if not imp.is_relative:
+        return []
+
+    source_parts = list(source_file.with_suffix("").parts)
+    if len(source_parts) < 2:
+        return []
+
+    base_parts = source_parts[:-1]
+    module = (imp.imported_module or "").strip(".").strip()
+
+    candidates: list[str] = []
+    if module:
+        candidates.append(".".join(base_parts + module.split(".")))
+    else:
+        for name in imp.imported_names:
+            token = (name or "").strip()
+            if token and token != "*":
+                candidates.append(".".join(base_parts + [token]))
+
+    if module:
+        module_parts = module.split(".")
+        for name in imp.imported_names:
+            token = (name or "").strip()
+            if token and token != "*":
+                candidates.append(".".join(base_parts + module_parts + [token]))
+
+    unique: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate and candidate not in seen:
+            seen.add(candidate)
+            unique.append(candidate)
+    return unique
+
+
+def _relative_path_candidates(source_file: Path, module_spec: str) -> list[str]:
+    """Build path-like candidates for relative import specifiers.
+
+    Handles TS/JS ESM conventions such as ``./foo.js`` pointing at
+    ``./foo.ts`` as well as extension-less relative specifiers.
+    """
+    spec = (module_spec or "").strip()
+    if not spec.startswith("."):
+        return []
+
+    source_dir = PurePosixPath(source_file.as_posix()).parent
+    joined = source_dir.as_posix() + "/" + spec
+    base = posixpath.normpath(joined)
+
+    ext_aliases: dict[str, tuple[str, ...]] = {
+        ".js": (".js", ".ts", ".tsx"),
+        ".jsx": (".jsx", ".tsx"),
+        ".mjs": (".mjs", ".mts"),
+        ".cjs": (".cjs", ".cts"),
+    }
+
+    p = PurePosixPath(base)
+    candidates: list[str] = [p.as_posix()]
+    suffix = p.suffix.lower()
+    if suffix in ext_aliases:
+        stem = p.with_suffix("").as_posix()
+        candidates.extend(stem + ext for ext in ext_aliases[suffix])
+    elif suffix == "":
+        stem = p.as_posix()
+        candidates.extend(
+            stem + ext
+            for ext in (
+                ".py",
+                ".ts",
+                ".tsx",
+                ".js",
+                ".jsx",
+                ".mts",
+                ".cts",
+                ".mjs",
+                ".cjs",
+            )
+        )
+
+    unique: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate and candidate not in seen:
+            seen.add(candidate)
+            unique.append(candidate)
+    return unique
+
+
+def _extension_workspace_root(path_str: str) -> str | None:
+    """Return extensions/<name> workspace root for a repo path, if present."""
+    parts = PurePosixPath(path_str).parts
+    if len(parts) >= 2 and parts[0] == "extensions":
+        return f"extensions/{parts[1]}"
+    return None
+
+
+def _has_generated_header(path: Path) -> bool:
+    """Return True when the first lines contain explicit auto-generated markers."""
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            header = "".join(
+                next(handle, "") for _ in range(_GENERATED_HEADER_MAX_LINES)
+            ).lower()
+    except OSError:
+        return False
+
+    return (
+        "auto-generated" in header
+        or "autogenerated" in header
+        or ("generated by" in header and "do not edit" in header)
+    )
+
+
+def _is_passive_definition_module(parse_result: ParseResult | None) -> bool:
+    """Return True for files that only carry passive definitions.
+
+    These modules often contain constants/type shapes and intentionally
+    no executable logic. They should not be treated as "Zone of Pain"
+    architecture hotspots.
+    """
+    if parse_result is None:
+        return False
+    if parse_result.parse_errors:
+        return False
+
+    return (
+        not parse_result.imports
+        and not parse_result.functions
+        and not parse_result.classes
+        and not parse_result.patterns
+        and parse_result.line_count > 0
+    )
+
+
+def _build_graph_lookups(
+    parse_results: list[ParseResult],
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Build module-to-file and path-to-file lookup dicts from parse results."""
+    module_to_file: dict[str, str] = {}
+    path_to_file: dict[str, str] = {}
+    for pr in parse_results:
+        file_posix = pr.file_path.as_posix()
+        path_to_file.setdefault(file_posix, file_posix)
+        path_to_file.setdefault(pr.file_path.with_suffix("").as_posix(), file_posix)
+        parts = pr.file_path.parts
+        if len(parts) >= 2 and parts[0].lower() in _SOURCE_ROOT_PREFIXES:
+            trimmed = Path(*parts[1:])
+            path_to_file.setdefault(trimmed.as_posix(), file_posix)
+            path_to_file.setdefault(trimmed.with_suffix("").as_posix(), file_posix)
+        for module_alias in _module_aliases_for_path(pr.file_path):
+            module_to_file.setdefault(module_alias, file_posix)
+    return module_to_file, path_to_file
+
+
+def _resolve_import_target(
+    imp: ImportInfo,
+    file_path: Path,
+    module_to_file: dict[str, str],
+    path_to_file: dict[str, str],
+) -> tuple[str | None, str]:
+    """Resolve an import to a known file path, returning (target_file, target_module)."""
+    target_module = imp.imported_module
+    target_file: str | None = module_to_file.get(target_module)
+    if target_file is None:
+        target_file = path_to_file.get(target_module)
+    if target_file is None and imp.is_relative:
+        for candidate in _relative_import_candidates(file_path, imp):
+            resolved = module_to_file.get(candidate)
+            if resolved is not None:
+                return resolved, candidate
+    if target_file is None and imp.is_relative:
+        for candidate in _relative_path_candidates(file_path, target_module):
+            resolved = path_to_file.get(candidate)
+            if resolved is not None:
+                return resolved, candidate
+    return target_file, target_module
+
+
+def _add_graph_edge(
+    graph: nx.DiGraph,
+    src: str,
+    target_file: str | None,
+    target_module: str,
+    imp: ImportInfo,
+) -> None:
+    """Add an import edge to the graph, handling unresolved/external imports."""
+    if target_file is not None:
+        graph.add_edge(src, target_file, import_info=imp)
+    else:
+        unresolved_target = target_module.strip()
+        if not unresolved_target:
+            unresolved_target = ".".join(
+                n for n in imp.imported_names if n and n != "*"
+            ) or "<relative>"
+        graph.add_node(unresolved_target, external=True)
+        graph.add_edge(src, unresolved_target, import_info=imp)
+
+
+def build_import_graph(
+    parse_results: list[ParseResult],
+) -> tuple[nx.DiGraph, list[ImportInfo]]:
+    """Build a directed dependency graph from import statements.
+
+    Complexity: O(n + m) where n = files, m = total imports.
+    Nodes are files (or unresolved external modules). Edges are import
+    relationships. Downstream analysis uses in-degree centrality for hub
+    detection and Tarjan's SCC algorithm for circular dependency detection.
+    """
+    module_to_file, path_to_file = _build_graph_lookups(parse_results)
+    graph = nx.DiGraph()
+    all_imports: list[ImportInfo] = []
+
+    for pr in parse_results:
+        src = pr.file_path.as_posix()
+        graph.add_node(src)
+        for imp in pr.imports:
+            all_imports.append(imp)
+            target_file, target_module = _resolve_import_target(
+                imp, pr.file_path, module_to_file, path_to_file
+            )
+            _add_graph_edge(graph, src, target_file, target_module, imp)
+
+    return graph, all_imports
+
+
+# ---------------------------------------------------------------------------
+# Layer inference
+# ---------------------------------------------------------------------------
+
+# Sentinel for cross-cutting modules that may be imported from any layer.
+_OMNILAYER = -1
+
+_DEFAULT_LAYERS: dict[str, int] = {
+    "api": 0,
+    "routes": 0,
+    "views": 0,
+    "handlers": 0,
+    "controllers": 0,
+    "scripts": 0,
+    "commands": 0,
+    "cli": 0,
+    "services": 1,
+    "core": 1,
+    "domain": 1,
+    "use_cases": 1,
+    "db": 2,
+    "repositories": 2,
+    "storage": 2,
+    "infrastructure": 2,
+}
+
+_OMNILAYER_DIRS: set[str] = {
+    "config",
+    "settings",
+    "constants",
+    "types",
+    "utils",
+    "helpers",
+    "common",
+    "shared",
+    "base",
+    "exceptions",
+    "errors",
+    "enums",
+    "schemas",
+    "models",
+}
+
+# Layer-prototype descriptions for embedding-based inference.
+_LAYER_PROTOTYPES: dict[int, str] = {
+    0: "HTTP request handling, route, endpoint, REST API, web handler, response",
+    1: "business logic, service, domain, use case, orchestration, workflow",
+    2: "database, query, model, repository, ORM, storage, persistence, SQL",
+    _OMNILAYER: "configuration, settings, constants, utilities, helpers, types, enums",
+}
+
+
+def _infer_layer(path: Path, extra_omnilayer: set[str] | None = None) -> int | None:
+    """Infer the architectural layer from directory name.
+
+    Returns ``_OMNILAYER`` for cross-cutting modules, a layer int for
+    recognised layer directories, or ``None`` when no layer can be
+    inferred.
+    """
+    effective_omnilayer = _OMNILAYER_DIRS | extra_omnilayer if extra_omnilayer else _OMNILAYER_DIRS
+    for part in path.parts:
+        low = part.lower()
+        if low in effective_omnilayer:
+            return _OMNILAYER
+        if low in _DEFAULT_LAYERS:
+            return _DEFAULT_LAYERS[low]
+    return None
+
+
+def _infer_layer_with_embeddings(
+    path: Path,
+    parse_result: ParseResult | None,
+    emb: EmbeddingServiceProtocol,
+    proto_embeddings: dict[int, Any],
+    extra_omnilayer: set[str] | None = None,
+) -> int | None:
+    """Embedding-enhanced layer inference.
+
+    Falls back to directory-name inference when no strong semantic match
+    is found.
+    """
+    # Try directory-name first
+    layer = _infer_layer(path, extra_omnilayer=extra_omnilayer)
+    if layer is not None:
+        return layer
+
+    # Build a text representation from the file's docstrings/imports
+    if parse_result is None:
+        return None
+
+    parts: list[str] = []
+    for fn in parse_result.functions[:5]:
+        parts.append(fn.name)
+    for imp in parse_result.imports[:10]:
+        parts.append(imp.imported_module)
+
+    if not parts:
+        return None
+
+    text = " ".join(parts)
+    vec = emb.embed_text(text)
+    if vec is None:
+        return None
+
+    best_layer = None
+    best_sim = 0.0
+    for layer_id, proto_vec in proto_embeddings.items():
+        sim = emb.cosine_similarity(vec, proto_vec)
+        if sim > best_sim:
+            best_sim = sim
+            best_layer = layer_id
+
+    if best_sim >= 0.5 and best_layer is not None:
+        return best_layer
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Hub-module detection via centrality
+# ---------------------------------------------------------------------------
+
+
+def _compute_hub_nodes(graph: nx.DiGraph, percentile: float = 0.90) -> set[str]:
+    """Find hub nodes with in-degree centrality above *percentile*."""
+    if graph.number_of_nodes() < 3:
+        return set()
+    centrality = nx.in_degree_centrality(graph)
+    if not centrality:
+        return set()
+    values = sorted(centrality.values())
+    cutoff_idx = int(len(values) * percentile)
+    cutoff_val = values[min(cutoff_idx, len(values) - 1)]
+    return {node for node, c in centrality.items() if c >= cutoff_val and c > 0}
+
+
+# ---------------------------------------------------------------------------
+# Signal
+# ---------------------------------------------------------------------------
+
+
+@register_signal
+class ArchitectureViolationSignal(BaseSignal):  # drift:ignore[DCA]
+    """Detect imports that violate architectural layer boundaries."""
+
+    uses_embeddings = True
+    cache_dependency_spec: ClassVar[SignalCacheDependencySpec] = SignalCacheDependencySpec(
+        scope="repo_wide",
+        include_languages=("python", "typescript", "tsx", "javascript", "jsx"),
+    )
+
+    @property
+    def signal_type(self) -> SignalType:
+        return SignalType.ARCHITECTURE_VIOLATION
+
+    @property
+    def name(self) -> str:
+        return "Architecture Violations"
+
+    def analyze(
+        self,
+        parse_results: list[ParseResult],
+        file_histories: dict[str, FileHistory],
+        config: DriftConfig,
+    ) -> list[Finding]:
+        """Detect architecture-layer violations across *parse_results*."""
+        filtered_prs = [
+            pr
+            for pr in parse_results
+            if not is_test_file(pr.file_path)
+            and not is_generated_file(pr.file_path)
+            and not _has_generated_header(pr.file_path)
+        ]
+        graph, all_imports = build_import_graph(filtered_prs)
+        findings: list[Finding] = []
+
+        # Pre-compute per-file lookup for embedding inference
+        pr_by_path: dict[str, ParseResult] = {pr.file_path.as_posix(): pr for pr in filtered_prs}
+
+        # Pre-compute embedding prototypes once
+        proto_embeddings: dict[int, Any] = {}
+        emb = self.embedding_service
+        if emb is not None:
+            for layer_id, text in _LAYER_PROTOTYPES.items():
+                vec = emb.embed_text(text)
+                if vec is not None:
+                    proto_embeddings[layer_id] = vec
+
+        # Compute hub nodes for score dampening
+        hub_nodes = _compute_hub_nodes(graph)
+
+        # Pre-compute transitive blast radius for internal nodes.
+        # In the import graph edges go from importer → imported, so
+        # *ancestors* of a node are all modules that transitively depend
+        # on it — i.e. the set of modules affected by a change.
+        blast_radius: dict[str, int] = {}
+        internal_nodes = [n for n in graph.nodes if not graph.nodes.get(n, {}).get("external")]
+        internal_set = set(internal_nodes)
+        for node in internal_nodes:
+            blast_radius[node] = len(nx.ancestors(graph, node) & internal_set)
+
+        # Collect allowed_cross_layer patterns
+        policies = getattr(config, "policies", None) if config else None
+        allowed_patterns: list[str] = getattr(policies, "allowed_cross_layer", []) or []
+        lazy_import_rules = getattr(policies, "lazy_import_rules", []) or []
+
+        # --- Check configured layer boundaries ---
+        if policies and hasattr(policies, "layer_boundaries"):
+            for boundary in policies.layer_boundaries:
+                findings.extend(self._check_boundary(boundary, all_imports, parse_results))
+
+        # --- Check configured lazy-import policy rules ---
+        if lazy_import_rules:
+            findings.extend(self._check_lazy_import_rules(lazy_import_rules, all_imports))
+
+        # --- Check inferred layer violations (upward imports) ---
+        extra_omnilayer: set[str] | None = None
+        if policies and policies.omnilayer_dirs:
+            extra_omnilayer = set(policies.omnilayer_dirs)
+        findings.extend(
+            self._check_inferred_layers(
+                graph,
+                parse_results,
+                pr_by_path,
+                emb,
+                proto_embeddings,
+                hub_nodes,
+                allowed_patterns,
+                blast_radius,
+                extra_omnilayer=extra_omnilayer,
+            )
+        )
+
+        # --- Check for circular dependencies ---
+        findings.extend(self._check_circular_deps(graph))
+
+        # --- Check for high transitive blast radius ---
+        findings.extend(self._check_blast_radius(blast_radius, internal_nodes, file_histories))
+
+        # --- Check instability / distance from main sequence ---
+        findings.extend(
+            self._check_instability(graph, parse_results, pr_by_path, internal_nodes)
+        )
+
+        # --- Check for over-centralized modules (god modules) ---
+        findings.extend(self._check_god_modules(graph, internal_nodes, blast_radius))
+
+        # --- Check for unstable dependency smell ---
+        findings.extend(
+            self._check_unstable_dependencies(
+                graph,
+                internal_nodes,
+                file_histories,
+            )
+        )
+
+        # --- Check co-change coupling (hidden logical dependencies) ---
+        commits = self.commits
+        if commits:
+            known = {pr.file_path.as_posix() for pr in filtered_prs}
+            findings.extend(self._check_co_change(graph, commits, known))
+
+        # --- Deduplicate findings by canonical semantic key ---
+        seen: set[tuple[str, ...]] = set()
+        deduped: list[Finding] = []
+        for f in findings:
+            key = self._finding_dedupe_key(f)
+            if key not in seen:
+                seen.add(key)
+                deduped.append(f)
+
+        return deduped
+
+    def _finding_dedupe_key(self, finding: Finding) -> tuple[str, ...]:
+        """Build a stable dedup key that collapses same-edge cross-pass AVS findings."""
+        file_path = finding.file_path.as_posix() if finding.file_path else ""
+        start_line = str(int(finding.start_line or 0))
+        end_line = str(int(finding.end_line or 0))
+        rule_id = finding.rule_id or str(self.signal_type)
+        title = (finding.title or "").strip()
+
+        # Policy-boundary and inferred-upward checks can report the same
+        # source-line -> target edge with different titles. Collapse by edge.
+        import_target = finding.metadata.get("import_target") if finding.metadata else None
+        if isinstance(import_target, str) and import_target and int(start_line) > 0:
+            return ("import-edge", file_path, start_line, import_target)
+
+        if int(start_line) > 0 and finding.related_files:
+            related = ",".join(sorted(p.as_posix() for p in finding.related_files))
+            return ("line-related", rule_id, file_path, start_line, related)
+
+        return ("generic", rule_id, file_path, start_line, end_line, title)
+
+    def _check_boundary(
+        self,
+        boundary: Any,
+        all_imports: list[ImportInfo],
+        parse_results: list[ParseResult],
+    ) -> list[Finding]:
+        findings: list[Finding] = []
+        from_pattern = boundary.from_pattern
+        deny_patterns = boundary.deny_import
+
+        module_to_file: dict[str, Path] = {}
+        for pr in parse_results:
+            module_to_file.setdefault(_module_for_path(pr.file_path), pr.file_path)
+
+        for imp in all_imports:
+            src = imp.source_file.as_posix()
+            if not _matches_pattern(src, from_pattern):
+                continue
+
+            for deny in deny_patterns:
+                target = imp.imported_module.replace(".", "/")
+                if _matches_pattern(target, deny) or _matches_pattern(imp.imported_module, deny):
+                    resolved_target = module_to_file.get(imp.imported_module)
+                    findings.append(
+                        Finding(
+                            signal_type=self.signal_type,
+                            severity=Severity.HIGH,
+                            score=0.8,
+                            title=f"Policy violation: {boundary.name}",
+                            description=(
+                                f"{imp.source_file}:{imp.line_number} imports "
+                                f"'{imp.imported_module}' which violates boundary "
+                                f"rule '{boundary.name}' (deny: {deny})"
+                            ),
+                            file_path=imp.source_file,
+                            start_line=imp.line_number,
+                            related_files=[resolved_target] if resolved_target is not None else [],
+                            fix=(
+                                f"Remove import '{imp.imported_module}' in "
+                                f"{imp.source_file.name}:{imp.line_number}. "
+                                f"Route access through a service layer or interface."
+                            ),
+                            rule_id="avs_policy_boundary",
+                            metadata={
+                                "rule": boundary.name,
+                                "import": imp.imported_module,
+                                "import_target": (
+                                    resolved_target.as_posix()
+                                    if resolved_target is not None
+                                    else imp.imported_module
+                                ),
+                            },
+                        )
+                    )
+
+        return findings
+
+    def _check_inferred_layers(
+        self,
+        graph: nx.DiGraph,
+        parse_results: list[ParseResult],
+        pr_by_path: dict[str, ParseResult],
+        emb: EmbeddingServiceProtocol | None,
+        proto_embeddings: dict[int, Any],
+        hub_nodes: set[str],
+        allowed_patterns: list[str],
+        blast_radius: dict[str, int] | None = None,
+        extra_omnilayer: set[str] | None = None,
+    ) -> list[Finding]:
+        """Flag cross-layer imports when no explicit policy boundaries exist.
+
+        Infers architectural layers from directory structure and optional
+        embedding-based prototype matching, then checks whether edges cross
+        layer boundaries.  Hub modules (high in-degree) are dampened to
+        reduce false positives from legitimate shared infrastructure.
+        """
+        findings: list[Finding] = []
+
+        for src, dst, data in graph.edges(data=True):
+            if graph.nodes.get(dst, {}).get("external"):
+                continue
+
+            # Infer layers (with optional embedding enhancement)
+            if emb is not None and proto_embeddings:
+                src_layer = _infer_layer_with_embeddings(
+                    Path(src), pr_by_path.get(src), emb, proto_embeddings,
+                    extra_omnilayer=extra_omnilayer,
+                )
+                dst_layer = _infer_layer_with_embeddings(
+                    Path(dst), pr_by_path.get(dst), emb, proto_embeddings,
+                    extra_omnilayer=extra_omnilayer,
+                )
+            else:
+                src_layer = _infer_layer(Path(src), extra_omnilayer=extra_omnilayer)
+                dst_layer = _infer_layer(Path(dst), extra_omnilayer=extra_omnilayer)
+
+            if src_layer is None or dst_layer is None:
+                continue
+
+            # Omnilayer modules never cause violations
+            if src_layer == _OMNILAYER or dst_layer == _OMNILAYER:
+                continue
+
+            # Check allowed_cross_layer patterns
+            if any(
+                _matches_pattern(src, pat) or _matches_pattern(dst, pat) for pat in allowed_patterns
+            ):
+                continue
+
+            # Upward import: higher-numbered layer (infra) importing lower (API)
+            if src_layer > dst_layer:
+                imp_info = data.get("import_info")
+                line = imp_info.line_number if imp_info else 0
+
+                score = 0.5
+                # Dampen score for hub-module targets (0.5× instead
+                # of 0.3× — less aggressive to reduce false negatives
+                # on legitimate architectural violations via hubs).
+                if dst in hub_nodes:
+                    score *= 0.5
+
+                # Filter out very low-confidence findings
+                if score < 0.15:
+                    continue
+
+                findings.append(
+                    Finding(
+                        signal_type=self.signal_type,
+                        severity=Severity.MEDIUM,
+                        score=score,
+                        title=f"Upward layer import: {Path(src).name} → {Path(dst).name}",
+                        description=(
+                            f"{src}:{line} — data/infrastructure layer imports from "
+                            f"presentation/API layer. Expected direction: "
+                            f"presentation → service → data."
+                        ),
+                        file_path=Path(src),
+                        start_line=line,
+                        related_files=[Path(dst)],
+                        rule_id="avs_upward_import",
+                        fix=(
+                            f"Move {Path(dst).name} logic behind a service layer "
+                            f"or abstraction interface that {Path(src).name} "
+                            f"is allowed to import."
+                        ),
+                        metadata={
+                            "src_layer": src_layer,
+                            "dst_layer": dst_layer,
+                            "hub_dampened": dst in hub_nodes,
+                            "blast_radius": blast_radius.get(src, 0) if blast_radius else 0,
+                            "import_target": dst,
+                        },
+                    )
+                )
+
+        return findings
+
+    def _check_lazy_import_rules(
+        self,
+        rules: list[Any],
+        all_imports: list[ImportInfo],
+    ) -> list[Finding]:
+        """Detect policy violations for heavy modules imported at module level."""
+        findings: list[Finding] = []
+
+        for rule in rules:
+            from_pattern = getattr(rule, "from_pattern", "**/*.py")
+            modules = getattr(rule, "modules", []) or []
+            module_level_only = bool(getattr(rule, "module_level_only", True))
+            if not modules:
+                continue
+
+            for imp in all_imports:
+                src = imp.source_file.as_posix()
+                if not _matches_pattern(src, from_pattern):
+                    continue
+                if module_level_only and not imp.is_module_level:
+                    continue
+                if not any(_matches_module_pattern(imp.imported_module, m) for m in modules):
+                    continue
+
+                findings.append(
+                    Finding(
+                        signal_type=self.signal_type,
+                        severity=Severity.HIGH,
+                        score=0.75,
+                        title=f"Lazy-import policy violation: {rule.name}",
+                        description=(
+                            f"{imp.source_file}:{imp.line_number} imports "
+                            f"'{imp.imported_module}' at module level, violating "
+                            f"lazy-import policy rule '{rule.name}'."
+                        ),
+                        file_path=imp.source_file,
+                        start_line=imp.line_number,
+                        fix=(
+                            f"Move import '{imp.imported_module}' in "
+                            f"{imp.source_file.name}:{imp.line_number} into a local "
+                            "function/class scope and initialize lazily at runtime."
+                        ),
+                        rule_id="avs_lazy_import_policy",
+                        metadata={
+                            "rule": rule.name,
+                            "import": imp.imported_module,
+                            "module_level_only": module_level_only,
+                            "is_module_level": imp.is_module_level,
+                            "lazy_import_target": imp.imported_module,
+                        },
+                    )
+                )
+
+        return findings
+
+    def _check_circular_deps(self, graph: nx.DiGraph) -> list[Finding]:
+        findings: list[Finding] = []
+
+        # simple_cycles is exponential on dense graphs. Use a bounded approach:
+        # find strongly connected components first (linear), then only enumerate
+        # cycles within small SCCs.
+        sccs = [s for s in nx.strongly_connected_components(graph) if len(s) > 1]
+        if not sccs:
+            return findings
+
+        for reported, scc in enumerate(sorted(sccs, key=len, reverse=True)):
+            if reported >= 5:
+                break
+            cycle = sorted(scc)  # deterministic ordering
+            cycle_str = " → ".join(Path(p).name for p in cycle)
+            findings.append(
+                Finding(
+                    signal_type=self.signal_type,
+                    severity=Severity.MEDIUM,
+                    score=0.6,
+                    title=f"Circular dependency ({len(cycle)} modules)",
+                    rule_id="avs_circular_dep",
+                    description=f"Cycle: {cycle_str}",
+                    file_path=Path(cycle[0]),
+                    related_files=[Path(p) for p in cycle[1:]],
+                    fix=(
+                        f"Circular dependency ({len(cycle)} modules): {cycle_str}. "
+                        f"Break the cycle via interface extraction or dependency inversion."
+                    ),
+                    metadata={"cycle": cycle},
+                )
+            )
+
+        return findings
+
+    def _check_blast_radius(
+        self,
+        blast_radius: dict[str, int],
+        internal_nodes: list[str],
+        file_histories: dict[str, FileHistory],
+    ) -> list[Finding]:
+        """Flag modules whose transitive blast radius is unusually high.
+
+        A high blast radius means a change in that module transitively
+        affects many downstream dependents, indicating poor encapsulation.
+        """
+        if not internal_nodes or not blast_radius:
+            return []
+
+        values = [blast_radius.get(n, 0) for n in internal_nodes]
+        if not values:
+            return []
+
+        mean_br = sum(values) / len(values)
+        # Only flag when there are enough modules to make the stat meaningful
+        # and threshold is at least 5 transitive dependents.
+        threshold = max(5, mean_br * 2)
+
+        findings: list[Finding] = []
+        for node in sorted(internal_nodes):
+            br = blast_radius.get(node, 0)
+            if br < threshold:
+                continue
+            # Churn guard: stable modules (change_frequency_30d <= 1.0) with
+            # modest blast radius are not urgent — skip to avoid noise (ADR-050).
+            fh = file_histories.get(node)
+            churn = float(fh.change_frequency_30d) if fh is not None else 0.0
+            if churn <= 1.0 and br <= 50:
+                continue
+            total = len(internal_nodes)
+            pct = round(br / max(1, total - 1) * 100)
+            score = min(1.0, round(br / max(1, total) * 0.8, 2))
+            churn_note = f" Churn: {churn:.1f} changes/week." if churn > 0 else ""
+            findings.append(
+                Finding(
+                    signal_type=self.signal_type,
+                    severity=Severity.MEDIUM if score < 0.6 else Severity.HIGH,
+                    score=score,
+                    title=(
+                        f"High blast radius: {Path(node).name} "
+                        f"({br} transitive dependents)"
+                    ),
+                    rule_id="avs_blast_radius",
+                    description=(
+                        f"A change in {node} transitively affects {br} of "
+                        f"{total} modules ({pct}%). This indicates tight "
+                        f"coupling and poor encapsulation.{churn_note}"
+                    ),
+                    file_path=Path(node),
+                    fix=(
+                        f"Refactor {Path(node).name} to reduce transitive coupling "
+                        f"via interface extraction or by splitting into "
+                        f"smaller, better-encapsulated modules."
+                    ),
+                    metadata={
+                        "blast_radius": br,
+                        "total_modules": total,
+                        "blast_pct": pct,
+                        "churn_per_week": round(churn, 2),
+                    },
+                )
+            )
+        return findings
+
+    def _check_instability(
+        self,
+        graph: nx.DiGraph,
+        parse_results: list[ParseResult],
+        pr_by_path: dict[str, ParseResult],
+        internal_nodes: list[str],
+    ) -> list[Finding]:
+        """Flag modules in the Zone of Pain (Robert C. Martin).
+
+        Instability  I = Ce / (Ca + Ce)
+        Abstraction  A = abstract_classes / total_classes  (0 if no classes)
+        Distance     D = |A + I - 1|
+
+        Modules with low abstraction AND low instability (D close to 1)
+        are concrete and hard to change yet heavily depended upon —
+        the "Zone of Pain".
+        """
+        if len(internal_nodes) < 4:
+            return []
+
+        findings: list[Finding] = []
+
+        for node in internal_nodes:
+            ca = graph.in_degree(node)   # afferent coupling
+            ce = graph.out_degree(node)  # efferent coupling
+            total_coupling = ca + ce
+            if total_coupling == 0:
+                continue
+
+            instability = ce / total_coupling
+
+            # Compute abstraction ratio from class info
+            pr = pr_by_path.get(node)
+            line_count = pr.line_count if pr is not None else 0
+            total_classes = len(pr.classes) if pr is not None else 0
+            function_count = len(pr.functions) if pr is not None else 0
+            entity_count = total_classes + function_count
+
+            # Passive constants/type-definition modules are expected to be
+            # concrete and stable; Zone-of-Pain escalation is not useful there.
+            if _is_passive_definition_module(pr):
+                continue
+
+            if pr is not None and total_classes > 0:
+                abstract_count = 0
+                for c in pr.classes:
+                    if any(
+                        b in ("ABC", "ABCMeta", "Protocol", "Interface")
+                        for b in c.bases
+                    ):
+                        abstract_count += 1
+                abstraction = abstract_count / total_classes
+            else:
+                abstraction = 0.0
+
+            distance = abs(abstraction + instability - 1)
+
+            # Zone of Pain: low instability (stable) + low abstraction
+            # (concrete) → D ≈ 1.0 and I < 0.3
+            if distance < 0.7 or instability > 0.5:
+                continue
+            # Only flag if enough dependents to matter
+            if ca < 3:
+                continue
+
+            score = min(1.0, round(distance * 0.7, 2))
+            # Tiny stable adapter/base modules can be legitimate foundations.
+            # Keep the finding but require stronger coupling evidence for HIGH.
+            tiny_foundational = (
+                line_count > 0
+                and line_count <= 20
+                and entity_count <= 2
+                and ce <= 1
+            )
+            has_high_risk_evidence = ca >= 6 or (ca >= 4 and ce >= 2)
+            dampened_for_tiny_foundation = tiny_foundational and not has_high_risk_evidence
+            if dampened_for_tiny_foundation:
+                score = min(score, 0.49)
+
+            severity = Severity.MEDIUM if score < 0.5 else Severity.HIGH
+            evidence_note = (
+                " Severity dampened for tiny foundational module; "
+                "require stronger coupling evidence for HIGH."
+                if dampened_for_tiny_foundation
+                else ""
+            )
+            findings.append(
+                Finding(
+                    signal_type=self.signal_type,
+                    severity=severity,
+                    score=score,
+                    title=(
+                        f"Zone of Pain: {Path(node).name} "
+                        f"(I={instability:.2f}, D={distance:.2f})"
+                    ),
+                    rule_id="avs_zone_of_pain",
+                    description=(
+                        f"{node} is concrete (A={abstraction:.2f}) and stable "
+                        f"(I={instability:.2f}) with {ca} dependents. "
+                        f"Distance from main sequence D={distance:.2f}. "
+                        f"Changes here are costly and propagate widely."
+                        f"{evidence_note}"
+                    ),
+                    file_path=Path(node),
+                    fix=(
+                        f"Extract abstractions (interfaces/protocols) from "
+                        f"{Path(node).name} to invert dependencies, or reduce coupling."
+                    ),
+                    metadata={
+                        "instability": round(instability, 3),
+                        "abstraction": round(abstraction, 3),
+                        "distance_main_seq": round(distance, 3),
+                        "afferent_coupling": ca,
+                        "efferent_coupling": ce,
+                        "line_count": line_count,
+                        "entity_count": entity_count,
+                        "has_high_risk_evidence": has_high_risk_evidence,
+                        "tiny_foundational_dampened": dampened_for_tiny_foundation,
+                    },
+                )
+            )
+        return findings
+
+    def _check_god_modules(
+        self,
+        graph: nx.DiGraph,
+        internal_nodes: list[str],
+        blast_radius: dict[str, int],
+    ) -> list[Finding]:
+        """Detect modules with excessive centrality and dependency load.
+
+        Heuristic:
+        - unusually high total coupling (in + out)
+        - non-trivial fan-in and fan-out
+        - meaningful transitive blast radius
+        """
+        if len(internal_nodes) < 6:
+            return []
+
+        total_degrees: list[int] = [
+            graph.in_degree(n) + graph.out_degree(n) for n in internal_nodes
+        ]
+        if not total_degrees:
+            return []
+
+        mean_degree = sum(total_degrees) / len(total_degrees)
+        threshold = max(6, int(mean_degree * 2))
+
+        findings: list[Finding] = []
+        for node in sorted(internal_nodes):
+            ca = graph.in_degree(node)
+            ce = graph.out_degree(node)
+            total = ca + ce
+            br = blast_radius.get(node, 0)
+
+            if total < threshold:
+                continue
+            if ca < 2 or ce < 2:
+                continue
+            if br < 3:
+                continue
+
+            score = min(1.0, round((total / max(1, len(internal_nodes))) * 1.5, 2))
+            findings.append(
+                Finding(
+                    signal_type=self.signal_type,
+                    severity=Severity.MEDIUM if score < 0.6 else Severity.HIGH,
+                    score=score,
+                    title=f"God module candidate: {Path(node).name}",
+                    rule_id="avs_god_module",
+                    description=(
+                        f"{node} has high coupling (Ca={ca}, Ce={ce}, total={total}) "
+                        f"and blast radius {br}. This concentration of responsibilities "
+                        f"increases change impact and architectural fragility."
+                    ),
+                    file_path=Path(node),
+                    fix=(
+                        f"Split {Path(node).name} by responsibility and extract stable "
+                        f"interfaces to reduce fan-in and fan-out."
+                    ),
+                    metadata={
+                        "afferent_coupling": ca,
+                        "efferent_coupling": ce,
+                        "total_coupling": total,
+                        "blast_radius": br,
+                        "god_module_threshold": threshold,
+                    },
+                )
+            )
+        return findings
+
+    def _check_unstable_dependencies(
+        self,
+        graph: nx.DiGraph,
+        internal_nodes: list[str],
+        file_histories: dict[str, FileHistory],
+    ) -> list[Finding]:
+        """Detect stable modules depending on unstable/volatile modules.
+
+        Approximates the Unstable Dependency smell by combining
+        graph instability with observed recent change frequency.
+        """
+        if len(internal_nodes) < 4:
+            return []
+
+        instability: dict[str, float] = {}
+        for node in internal_nodes:
+            ca = graph.in_degree(node)
+            ce = graph.out_degree(node)
+            total = ca + ce
+            instability[node] = ce / total if total > 0 else 0.0
+
+        findings: list[Finding] = []
+        for src, dst in graph.edges():
+            if src not in instability or dst not in instability:
+                continue
+            if graph.nodes.get(dst, {}).get("external"):
+                continue
+
+            src_extension = _extension_workspace_root(src)
+            dst_extension = _extension_workspace_root(dst)
+            # In extension-based monorepos, intra-extension imports are expected
+            # implementation detail wiring and should not be treated as AVS smell.
+            if src_extension is not None and src_extension == dst_extension:
+                continue
+
+            src_ca = graph.in_degree(src)
+            src_i = instability[src]
+            dst_i = instability[dst]
+            dst_hist = file_histories.get(dst)
+            dst_churn = (
+                float(dst_hist.change_frequency_30d)
+                if dst_hist is not None
+                else 0.0
+            )
+
+            # Stable source (widely depended upon + low instability)
+            is_stable_src = src_ca >= 2 and src_i <= 0.40
+            # Unstable dependency target (topology unstable and/or high churn)
+            is_unstable_dst = dst_i >= 0.70 or dst_churn >= 1.0
+
+            if not (is_stable_src and is_unstable_dst):
+                continue
+
+            score = min(1.0, round((dst_i * 0.6) + (min(dst_churn, 2.0) * 0.2), 2))
+            findings.append(
+                Finding(
+                    signal_type=self.signal_type,
+                    severity=Severity.MEDIUM if score < 0.6 else Severity.HIGH,
+                    score=score,
+                    title=(
+                        f"Unstable dependency: {Path(src).name} -> {Path(dst).name}"
+                    ),
+                    rule_id="avs_unstable_dep",
+                    description=(
+                        f"Stable module {src} (I={src_i:.2f}, Ca={src_ca}) depends on "
+                        f"unstable/volatile module {dst} (I={dst_i:.2f}, "
+                        f"churn/week={dst_churn:.2f})."
+                    ),
+                    file_path=Path(src),
+                    related_files=[Path(dst)],
+                    fix=(
+                        f"Decouple {Path(src).name} from unstable module "
+                        f"{Path(dst).name} using interface inversion or adapters "
+                        f"so changes in {Path(dst).name} do not propagate upward."
+                    ),
+                    metadata={
+                        "src_instability": round(src_i, 3),
+                        "src_afferent": src_ca,
+                        "dst_instability": round(dst_i, 3),
+                        "dst_churn_week": round(dst_churn, 3),
+                    },
+                )
+            )
+        return findings
+
+    def _check_co_change(
+        self,
+        graph: nx.DiGraph,
+        commits: list,
+        known_files: set[str],
+    ) -> list[Finding]:
+        """Flag file pairs with high co-change coupling but no import edge.
+
+        These indicate hidden logical dependencies that the import graph
+        does not capture — a strong signal for architectural drift.
+        """
+        pairs = build_co_change_pairs(commits, known_files)
+        if not pairs:
+            return []
+
+        findings: list[Finding] = []
+        for pair in pairs[:10]:  # cap to avoid noise
+            # Only flag if there is NO static import relationship
+            has_edge = (
+                graph.has_edge(pair.file_a, pair.file_b)
+                or graph.has_edge(pair.file_b, pair.file_a)
+            )
+            if has_edge:
+                continue
+
+            # Suppress same-directory co-evolution (sisters in a package).
+            # Root-level files (parent == ".") are NOT suppressed to
+            # preserve detection for flat-root repos.
+            dir_a = str(PurePosixPath(pair.file_a).parent)
+            dir_b = str(PurePosixPath(pair.file_b).parent)
+            if dir_a == dir_b and dir_a != ".":
+                continue
+
+            score = min(1.0, round(pair.confidence * 0.7, 2))
+            if score < 0.2:
+                continue
+
+            findings.append(
+                Finding(
+                    signal_type=self.signal_type,
+                    severity=Severity.LOW if score < 0.4 else Severity.MEDIUM,
+                    score=score,
+                    title=(
+                        f"Hidden coupling: {Path(pair.file_a).name} ↔ "
+                        f"{Path(pair.file_b).name} "
+                        f"({pair.co_change_count} co-changes)"
+                    ),
+                    rule_id="avs_co_change",
+                    description=(
+                        f"{pair.file_a} and {pair.file_b} changed together in "
+                        f"{pair.co_change_count} commits "
+                        f"(confidence {pair.confidence:.0%}) but share no "
+                        f"import relationship. This suggests a hidden logical "
+                        f"dependency not visible in the import graph."
+                    ),
+                    file_path=Path(pair.file_a),
+                    related_files=[Path(pair.file_b)],
+                    fix=(
+                        f"Investigate hidden coupling between "
+                        f"{Path(pair.file_a).name} and {Path(pair.file_b).name}. "
+                        f"Extract shared logic or make the dependency explicit."
+                    ),
+                    metadata={
+                        "co_change_count": pair.co_change_count,
+                        "confidence": pair.confidence,
+                        "total_commits_a": pair.total_commits_a,
+                        "total_commits_b": pair.total_commits_b,
+                    },
+                )
+            )
+        return findings

--- a/packages/drift-engine/src/drift_engine/signals/base.py
+++ b/packages/drift-engine/src/drift_engine/signals/base.py
@@ -1,0 +1,305 @@
+"""Base interface for detection signals."""
+
+from __future__ import annotations
+
+import fnmatch
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar, Literal, Protocol, cast, runtime_checkable
+
+from drift.config import DriftConfig
+from drift.models import AnalyzerWarning, CommitInfo, FileHistory, Finding, ParseResult, SignalType
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+@runtime_checkable
+class EmbeddingServiceProtocol(Protocol):
+    """Minimal interface expected by signal infrastructure for embeddings."""
+
+    def embed_text(self, text: str) -> np.ndarray | None: ...
+
+    def embed_texts(self, texts: list[str]) -> list[np.ndarray | None]: ...
+
+    @staticmethod
+    def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float: ...
+
+    @staticmethod
+    def build_index(vectors: list[np.ndarray] | np.ndarray) -> object | None: ...
+
+    @staticmethod
+    def search_index(
+        index: object,
+        query: np.ndarray,
+        top_k: int = 10,
+    ) -> list[tuple[int, float]]: ...
+
+
+@dataclass
+class AnalysisContext:
+    """Shared context passed to all signals during analysis.
+
+    Provides standardised access to repo-level data so that signals
+    don't need heterogeneous constructor arguments.
+    """
+
+    repo_path: Path
+    config: DriftConfig
+    parse_results: list[ParseResult] = field(default_factory=list)
+    file_histories: dict[str, FileHistory] = field(default_factory=dict)
+    embedding_service: EmbeddingServiceProtocol | None = None
+    commits: list[CommitInfo] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class SignalCapabilities:
+    """Explicit runtime capabilities provided by the analyzer to each signal."""
+
+    repo_path: Path
+    embedding_service: EmbeddingServiceProtocol | None
+    commits: list[CommitInfo]
+
+    @classmethod
+    def from_analysis_context(cls, ctx: AnalysisContext) -> SignalCapabilities:
+        """Build a capabilities payload from the full analysis context."""
+        return cls(
+            repo_path=ctx.repo_path,
+            embedding_service=ctx.embedding_service,
+            commits=ctx.commits,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SignalCacheDependencySpec:
+    """Declarative cache-dependency contract for signal result invalidation."""
+
+    scope: Literal["file_local", "module_wide", "repo_wide", "git_dependent"]
+    include_languages: tuple[str, ...] = ()
+    include_path_globs: tuple[str, ...] = ()
+    exclude_path_globs: tuple[str, ...] = ()
+
+
+class BaseSignal(ABC):
+    """Abstract base class for all detection signals.
+
+    Each signal analyzes a specific dimension of architectural drift
+    and produces findings with scores between 0.0 (no drift) and
+    1.0 (severe drift).
+    """
+
+    incremental_scope: ClassVar[
+        Literal["file_local", "cross_file", "git_dependent"]
+    ] = "cross_file"
+    cache_dependency_scope: ClassVar[
+        Literal["file_local", "module_wide", "repo_wide", "git_dependent"]
+    ] = "repo_wide"
+    cache_dependency_spec: ClassVar[SignalCacheDependencySpec | None] = None
+    uses_embeddings: ClassVar[bool] = False
+    depends_on_signals: ClassVar[tuple[str, ...]] = ()
+
+    _repo_path: Path | None
+    _embedding_service: EmbeddingServiceProtocol | None
+    _commits: list[CommitInfo]
+
+    def __init__(
+        self,
+        *,
+        repo_path: Path | None = None,
+        embedding_service: EmbeddingServiceProtocol | None = None,
+        commits: list[CommitInfo] | None = None,
+    ) -> None:
+        self._repo_path = repo_path
+        self._embedding_service = embedding_service
+        self._commits = commits if commits is not None else []
+        self._warnings: list[AnalyzerWarning] = []
+
+    def emit_warning(self, message: str, *, skipped: bool = True) -> None:
+        """Record a non-finding diagnostic for this signal."""
+        self._warnings.append(
+            AnalyzerWarning(
+                signal_type=str(self.signal_type),
+                message=message,
+                skipped=skipped,
+            )
+        )
+
+    def bind_context(self, capabilities: SignalCapabilities) -> None:
+        """Bind analyzer-provided runtime capabilities to this signal instance."""
+        self._repo_path = capabilities.repo_path
+        self._embedding_service = capabilities.embedding_service
+        self._commits = capabilities.commits
+
+    @property
+    def repo_path(self) -> Path | None:
+        """Repository root path if provided by the analyzer."""
+        return self._repo_path
+
+    @property
+    def embedding_service(self) -> EmbeddingServiceProtocol | None:
+        """Embedding service if enabled for the current analysis run."""
+        return self._embedding_service
+
+    @property
+    def commits(self) -> list[CommitInfo]:
+        """Commit history available for co-change style analysis."""
+        return self._commits
+
+    @property
+    @abstractmethod
+    def signal_type(self) -> SignalType: ...
+
+    @property
+    @abstractmethod
+    def name(self) -> str: ...
+
+    @abstractmethod
+    def analyze(
+        self,
+        parse_results: list[ParseResult],
+        file_histories: dict[str, FileHistory],
+        config: DriftConfig,
+    ) -> list[Finding]:
+        """Run this signal's detection logic and return findings."""
+        ...
+
+    def should_process_file(self, parse_result: ParseResult) -> bool:
+        """Return whether a file-local run should include this parse result.
+
+        Signals can override this to cheaply pre-filter irrelevant files in
+        file-local cache mode.
+        """
+        return True
+
+    def resolve_cache_dependency_spec(self) -> SignalCacheDependencySpec:
+        """Return dependency spec with legacy fallback from existing scope fields."""
+        explicit_spec = getattr(self, "cache_dependency_spec", None)
+        if isinstance(explicit_spec, SignalCacheDependencySpec):
+            return explicit_spec
+
+        explicit_scope = getattr(self, "cache_dependency_scope", None)
+        if isinstance(explicit_scope, str) and explicit_scope in {
+            "file_local",
+            "module_wide",
+            "repo_wide",
+            "git_dependent",
+        }:
+            scope_type = cast(
+                Literal["file_local", "module_wide", "repo_wide", "git_dependent"],
+                explicit_scope,
+            )
+            return SignalCacheDependencySpec(scope=scope_type)
+
+        incremental_scope = getattr(self, "incremental_scope", "cross_file")
+        if incremental_scope == "file_local":
+            return SignalCacheDependencySpec(scope="file_local")
+        if incremental_scope == "git_dependent":
+            return SignalCacheDependencySpec(scope="git_dependent")
+        return SignalCacheDependencySpec(scope="repo_wide")
+
+    def cache_dependency_paths(self, parse_results: list[ParseResult]) -> set[str] | None:
+        """Return selected repo paths for cache invalidation, or ``None`` for all files."""
+        spec = self.resolve_cache_dependency_spec()
+        if (
+            not spec.include_languages
+            and not spec.include_path_globs
+            and not spec.exclude_path_globs
+        ):
+            return None
+
+        allowed_languages = {lang.lower() for lang in spec.include_languages}
+        selected: set[str] = set()
+        for pr in parse_results:
+            path_str = pr.file_path.as_posix()
+            if allowed_languages and pr.language.lower() not in allowed_languages:
+                continue
+            if spec.include_path_globs and not any(
+                fnmatch.fnmatch(path_str, pattern) for pattern in spec.include_path_globs
+            ):
+                continue
+            if any(fnmatch.fnmatch(path_str, pattern) for pattern in spec.exclude_path_globs):
+                continue
+            selected.add(path_str)
+
+        return selected
+
+
+# ---------------------------------------------------------------------------
+# Signal registry
+# ---------------------------------------------------------------------------
+
+_SIGNAL_REGISTRY: list[type[BaseSignal]] = []
+_SIGNAL_TYPE_VALUE_CACHE: dict[type[BaseSignal], str] = {}
+
+
+def register_signal(cls: type[BaseSignal]) -> type[BaseSignal]:
+    """Class decorator that registers a signal for automatic discovery."""
+    _SIGNAL_REGISTRY.append(cls)
+    return cls
+
+
+def _instantiate_signal(
+    cls: type[BaseSignal],
+    capabilities: SignalCapabilities,
+) -> BaseSignal:
+    """Instantiate a signal class with explicit contract and legacy fallback."""
+    try:
+        return cls()
+    except TypeError:
+        legacy_ctor = cast(Callable[..., BaseSignal], cls)
+        try:
+            return legacy_ctor(
+                repo_path=capabilities.repo_path,
+                embedding_service=capabilities.embedding_service,
+            )
+        except TypeError as legacy_error:
+            raise TypeError(
+                f"Signal '{cls.__name__}' could not be instantiated. "
+                "Expected either a parameterless constructor or the legacy "
+                "constructor signature (__init__(repo_path=..., embedding_service=...))."
+            ) from legacy_error
+
+
+def create_signals(
+    ctx: AnalysisContext,
+    *,
+    active_signals: set[str] | None = None,
+) -> list[BaseSignal]:
+    """Instantiate registered signals with optional pre-filtering.
+
+    Preferred contract:
+    1. Parameterless constructor on the signal class
+    2. Analyzer calls ``bind_context`` with explicit runtime capabilities
+
+    Backward compatibility:
+    Legacy signal constructors accepting ``repo_path`` and
+    ``embedding_service`` keywords are still supported.
+    """
+    capabilities = SignalCapabilities.from_analysis_context(ctx)
+
+    signals: list[BaseSignal] = []
+    for cls in _SIGNAL_REGISTRY:
+        if active_signals is not None:
+            cached_type = _SIGNAL_TYPE_VALUE_CACHE.get(cls)
+            if cached_type is None:
+                probe = _instantiate_signal(cls, capabilities)
+                cached_type = str(probe.signal_type)
+                _SIGNAL_TYPE_VALUE_CACHE[cls] = cached_type
+                if cached_type not in active_signals:
+                    continue
+                probe.bind_context(capabilities)
+                signals.append(probe)
+                continue
+            if cached_type not in active_signals:
+                continue
+        inst = _instantiate_signal(cls, capabilities)
+        inst.bind_context(capabilities)
+        signals.append(inst)
+    return signals
+
+
+def registered_signals() -> list[type[BaseSignal]]:
+    """Return a copy of the current signal registry (for testing)."""
+    return list(_SIGNAL_REGISTRY)

--- a/packages/drift-engine/src/drift_engine/signals/broad_exception_monoculture.py
+++ b/packages/drift-engine/src/drift_engine/signals/broad_exception_monoculture.py
@@ -1,0 +1,199 @@
+"""Signal 8: Broad Exception Monoculture (BEM).
+
+Detects modules where exception handling is uniformly broad —
+catching ``Exception``, ``BaseException`` or bare ``except`` — and
+uniformly swallowing (pass / log / print without re-raise).
+
+This is a proxy for *consistent wrongness* (EPISTEMICS §2): when every
+handler looks the same and catches everything, real error classes are
+silently discarded.  The signal does NOT judge *what* is caught, only
+that the handling is uniform-broad across an entire module.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path, PurePosixPath
+
+from drift.config import DriftConfig
+from drift.models import (
+    FileHistory,
+    Finding,
+    ParseResult,
+    PatternCategory,
+    Severity,
+    SignalType,
+)
+from drift_engine.signals.base import BaseSignal, register_signal
+
+_BROAD_TYPES: frozenset[str] = frozenset({
+    "bare", "Exception", "BaseException",
+    "any", "unknown", "Error",
+})
+
+_SWALLOWING_ACTIONS: frozenset[str] = frozenset({
+    "pass", "log", "print", "fallback_assign",
+})
+
+# Module-name stems that legitimately use broad exception handling
+# (error boundaries, middleware).  Findings here are excluded.
+_BOUNDARY_STEMS: frozenset[str] = frozenset({
+    "middleware",
+    "error_handler",
+    "exception_handler",
+    "error_boundary",
+    "error_middleware",
+    "celery_error",
+    "task_error",
+    "signal_handler",
+    "fallback",
+    "recovery",
+})
+
+# Decorators that indicate intentional error-boundary design.
+_BOUNDARY_DECORATORS: frozenset[str] = frozenset({
+    "app.exception_handler",
+    "app.errorhandler",
+    "app_errorhandler",
+    "errorhandler",
+    "exception_handler",
+    "error_handler",
+    "receiver",
+    "task",
+    "shared_task",
+})
+
+
+def _is_error_boundary(file_path: Path) -> bool:
+    """Return True if a file is an intentional error-boundary module."""
+    stem = file_path.stem.lower()
+    return any(b in stem for b in _BOUNDARY_STEMS)
+
+
+def _has_boundary_decorator(parse_result: ParseResult) -> bool:
+    """Return True if any function in the file uses a boundary decorator."""
+    for fn in parse_result.functions:
+        for dec in fn.decorators:
+            dec_lower = dec.lower()
+            if any(bd in dec_lower for bd in _BOUNDARY_DECORATORS):
+                return True
+    return False
+
+
+@register_signal
+class BroadExceptionMonocultureSignal(BaseSignal):
+    """Detect modules with uniformly broad exception handling."""
+
+    incremental_scope = "file_local"
+
+    @property
+    def signal_type(self) -> SignalType:
+        return SignalType.BROAD_EXCEPTION_MONOCULTURE
+
+    @property
+    def name(self) -> str:
+        return "Broad Exception Monoculture"
+
+    def analyze(
+        self,
+        parse_results: list[ParseResult],
+        file_histories: dict[str, FileHistory],
+        config: DriftConfig,
+    ) -> list[Finding]:
+        """Flag modules where most exception handlers catch only broad types.
+
+        A module is flagged when >=bem_min_handlers handlers exist and
+        the broad-handler ratio exceeds 0.7.  Error-boundary modules
+        (e.g. middleware, error_handler) are excluded.
+        """
+        min_handlers = config.thresholds.bem_min_handlers
+
+        # Group error-handling patterns by module directory
+        module_handlers: dict[str, list[tuple[Path, dict]]] = defaultdict(list)
+        # Track parse results per module for decorator analysis
+        module_parse_results: dict[str, list[ParseResult]] = defaultdict(list)
+
+        for pr in parse_results:
+            module_key = PurePosixPath(pr.file_path.parent).as_posix()
+            module_parse_results[module_key].append(pr)
+            for pat in pr.patterns:
+                if pat.category != PatternCategory.ERROR_HANDLING:
+                    continue
+                handlers = pat.fingerprint.get("handlers", [])
+                if not handlers:
+                    continue
+                for h in handlers:
+                    module_handlers[module_key].append((pr.file_path, h))
+
+        findings: list[Finding] = []
+
+        for module_key, handler_list in module_handlers.items():
+            if len(handler_list) < min_handlers:
+                continue
+
+            # Skip error-boundary modules (by filename or decorator)
+            files_in_module = {fp for fp, _ in handler_list}
+            if all(_is_error_boundary(fp) for fp in files_in_module):
+                continue
+            prs_in_module = [
+                pr
+                for pr in module_parse_results.get(module_key, [])
+                if pr.file_path in files_in_module
+            ]
+            if prs_in_module and all(_has_boundary_decorator(pr) for pr in prs_in_module):
+                continue
+
+            broad_count = 0
+            swallowing_count = 0
+            total = len(handler_list)
+
+            for _, h in handler_list:
+                exc_type = h.get("exception_type", "")
+                actions = set(h.get("actions", []))
+
+                if exc_type in _BROAD_TYPES:
+                    broad_count += 1
+
+                if actions and actions <= _SWALLOWING_ACTIONS:
+                    swallowing_count += 1
+
+            broadness = broad_count / total
+            swallowing = swallowing_count / total
+
+            if broadness < 0.80 or swallowing < 0.60:
+                continue
+
+            score = round(min(1.0, broadness * swallowing), 3)
+
+            severity = Severity.HIGH if score >= 0.7 else Severity.MEDIUM
+
+            related = sorted(files_in_module, key=lambda fp: fp.as_posix())
+
+            findings.append(
+                Finding(
+                    signal_type=self.signal_type,
+                    severity=severity,
+                    score=score,
+                    title=f"Broad exception monoculture in {module_key}/",
+                    description=(
+                        f"{broad_count}/{total} handlers catch broad exceptions "
+                        f"({broadness:.0%}), {swallowing_count}/{total} swallow "
+                        f"errors ({swallowing:.0%})."
+                    ),
+                    file_path=Path(module_key),
+                    related_files=related,
+                    fix=(
+                        "Differentiate exception handlers: catch specific "
+                        "exception types and re-raise or convert unknown errors."
+                    ),
+                    metadata={
+                        "total_handlers": total,
+                        "broad_count": broad_count,
+                        "swallowing_count": swallowing_count,
+                        "broadness_ratio": broadness,
+                        "swallowing_ratio": swallowing,
+                    },
+                )
+            )
+
+        return findings

--- a/packages/drift-engine/src/drift_engine/signals/bypass_accumulation.py
+++ b/packages/drift-engine/src/drift_engine/signals/bypass_accumulation.py
@@ -1,0 +1,203 @@
+"""Signal 12: Bypass Accumulation Tracker (BAT).
+
+Detects files or modules where quality-bypass markers (``# type: ignore``,
+``# noqa``, ``# pragma: no cover``, ``typing.Any`` annotations, ``cast()``,
+``@pytest.mark.skip``, ``TODO``/``FIXME``/``HACK``/``XXX``) accumulate
+beyond a density threshold.
+
+High bypass density is a proxy for *process drift*: the gap between the
+quality process a team intends and the shortcuts actually taken.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from statistics import median
+
+from drift.config import DriftConfig
+from drift.models import (
+    FileHistory,
+    Finding,
+    ParseResult,
+    Severity,
+    SignalType,
+)
+from drift_engine.signals._utils import _SUPPORTED_LANGUAGES, is_test_file
+from drift_engine.signals.base import BaseSignal, register_signal
+
+# ── Bypass marker patterns ────────────────────────────────────────
+
+_MARKER_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("type_safety", re.compile(r"#\s*type:\s*ignore")),
+    ("lint", re.compile(r"#\s*noqa\b")),
+    ("coverage", re.compile(r"#\s*pragma:\s*no\s*cover")),
+    ("type_safety", re.compile(r"\bcast\s*\(")),
+    ("test", re.compile(r"pytest\.mark\.skip")),
+    ("deferred", re.compile(r"#\s*(?:TODO|FIXME|HACK|XXX)\b")),
+    # TypeScript / JavaScript bypass markers
+    ("type_safety", re.compile(r"//\s*@ts-ignore\b")),
+    ("type_safety", re.compile(r"//\s*@ts-expect-error\b")),
+    ("type_safety", re.compile(r"//\s*@ts-nocheck\b")),
+    ("type_safety", re.compile(r"\bas\s+any\b")),
+    ("lint", re.compile(r"//\s*eslint-disable")),
+]
+
+# typing.Any in function annotations — checked structurally
+_ANY_ANNOTATION = re.compile(r"\bAny\b|\bany\b")
+
+
+def _count_markers(source: str) -> dict[str, int]:
+    """Count bypass markers in source text, grouped by category."""
+    counts: dict[str, int] = {
+        "type_safety": 0,
+        "lint": 0,
+        "coverage": 0,
+        "test": 0,
+        "deferred": 0,
+    }
+    for line in source.splitlines():
+        for category, pattern in _MARKER_PATTERNS:
+            if pattern.search(line):
+                counts[category] += 1
+    return counts
+
+
+def _count_any_annotations(pr: ParseResult) -> int:
+    """Count typing.Any usage in function parameter/return annotations."""
+    count = 0
+    for fn in pr.functions:
+        if fn.return_type and _ANY_ANNOTATION.search(fn.return_type):
+            count += 1
+        for param in fn.parameters:
+            ptype = param.get("type", "") if isinstance(param, dict) else ""
+            if ptype and _ANY_ANNOTATION.search(ptype):
+                count += 1
+    return count
+
+
+def _read_file_source(
+    file_path: Path, repo_path: Path | None = None,
+) -> str | None:
+    """Read full file source."""
+    try:
+        target = file_path
+        if repo_path and not file_path.is_absolute():
+            target = repo_path / file_path
+        return target.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _total_loc(pr: ParseResult) -> int:
+    """Estimate total LOC from function LOCs or file read."""
+    return sum(fn.loc for fn in pr.functions) if pr.functions else 0
+
+
+@register_signal
+class BypassAccumulationSignal(BaseSignal):
+    """Detect files with abnormally high density of quality-bypass markers."""
+
+    incremental_scope = "file_local"
+
+    @property
+    def signal_type(self) -> SignalType:
+        return SignalType.BYPASS_ACCUMULATION
+
+    @property
+    def name(self) -> str:
+        return "Bypass Accumulation"
+
+    def analyze(
+        self,
+        parse_results: list[ParseResult],
+        file_histories: dict[str, FileHistory],
+        config: DriftConfig,
+    ) -> list[Finding]:
+        density_threshold = config.thresholds.bat_density_threshold
+        min_loc = config.thresholds.bat_min_loc
+        findings: list[Finding] = []
+
+        # Phase 1: collect per-file bypass densities
+        file_data: list[tuple[ParseResult, dict[str, int], int, float, int]] = []
+
+        for pr in parse_results:
+            if pr.language not in _SUPPORTED_LANGUAGES:
+                continue
+            if is_test_file(pr.file_path):
+                continue
+
+            source = _read_file_source(pr.file_path, self._repo_path)
+            if source is None:
+                continue
+
+            loc = source.count("\n") + 1
+            if loc < min_loc:
+                continue
+
+            markers = _count_markers(source)
+            markers["type_safety"] += _count_any_annotations(pr)
+
+            total = sum(markers.values())
+            if total == 0:
+                continue
+
+            density = total / loc
+            file_data.append((pr, markers, total, density, loc))
+
+        if not file_data:
+            return findings
+
+        # Phase 2: compute median density for anomaly context
+        densities = [d for _, _, _, d, _ in file_data]
+        median_density = median(densities) if densities else 0.0
+
+        # Phase 3: emit findings for files above threshold
+        for pr, markers, total, density, file_loc in file_data:
+            if density < density_threshold:
+                continue
+
+            score = min(1.0, density / density_threshold)
+            severity = (
+                Severity.HIGH if density >= density_threshold * 2
+                else Severity.MEDIUM
+            )
+
+            # Build category breakdown for description
+            categories = {k: v for k, v in markers.items() if v > 0}
+            cat_desc = ", ".join(
+                f"{k}: {v}" for k, v in sorted(
+                    categories.items(), key=lambda x: -x[1],
+                )
+            )
+
+            findings.append(
+                Finding(
+                    signal_type=self.signal_type,
+                    severity=severity,
+                    score=score,
+                    title=f"High bypass marker density in {pr.file_path.name}",
+                    description=(
+                        f"{pr.file_path.as_posix()} has {total} bypass markers "
+                        f"across ~{file_loc} LOC "
+                        f"(density {density:.3f}, threshold {density_threshold:.3f}). "
+                        f"Breakdown: {cat_desc}."
+                    ),
+                    file_path=pr.file_path,
+                    start_line=1,
+                    end_line=None,
+                    fix=(
+                        f"Remove or document each bypass marker in '{pr.file_path.name}': "
+                        f"replace Any with concrete types and add explicit "
+                        f"ignores only where the root cause is resolved."
+                    ),
+                    metadata={
+                        "total_markers": total,
+                        "markers_by_category": markers,
+                        "bypass_density": round(density, 4),
+                        "module_median_density": round(median_density, 4),
+                    },
+                )
+            )
+
+        return findings

--- a/packages/drift-engine/src/drift_engine/signals/circular_import.py
+++ b/packages/drift-engine/src/drift_engine/signals/circular_import.py
@@ -1,0 +1,202 @@
+"""Signal: Circular Import Detection (CID).
+
+Detects circular import chains within Python packages by building a
+directed import graph from ParseResult data and running cycle detection.
+
+Circular imports cause runtime ImportErrors, fragile import ordering,
+and indicate tangled module responsibilities.
+
+TypeScript/JS circular imports are already covered by ts_architecture.py.
+This signal handles Python-only codebases.
+
+Deterministic, AST-only, LLM-free.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path, PurePosixPath
+from typing import ClassVar
+
+from drift.config import DriftConfig
+from drift.models import (
+    FileHistory,
+    Finding,
+    ParseResult,
+    Severity,
+    SignalType,
+)
+from drift_engine.signals._utils import is_test_file
+from drift_engine.signals.base import BaseSignal, SignalCacheDependencySpec, register_signal
+
+
+def _build_import_graph(
+    parse_results: list[ParseResult],
+) -> tuple[dict[str, set[str]], dict[str, Path]]:
+    """Build a directed graph of module → imported-modules from parse results.
+
+    Returns ``(graph, module_to_path)`` where graph maps normalised
+    module names to sets of imported module names, and module_to_path
+    maps module names back to their file paths.
+    """
+    graph: dict[str, set[str]] = defaultdict(set)
+    module_to_path: dict[str, Path] = {}
+
+    for pr in parse_results:
+        if pr.language != "python":
+            continue
+        if is_test_file(pr.file_path):
+            continue
+
+        module_name = _path_to_module(pr.file_path)
+        if not module_name:
+            continue
+
+        module_to_path[module_name] = pr.file_path
+        # Ensure every module appears in graph even without imports
+        graph.setdefault(module_name, set())
+
+        for imp in pr.imports:
+            target = imp.imported_module
+            if not target:
+                continue
+            graph[module_name].add(target)
+
+    return dict(graph), module_to_path
+
+
+def _path_to_module(file_path: Path) -> str:
+    """Convert a file path to a dotted module name.
+
+    ``src/drift/signals/base.py`` → ``src.drift.signals.base``
+    ``drift/config.py`` → ``drift.config``
+    ``__init__.py`` files → package name (e.g. ``drift.signals``)
+    """
+    posix = PurePosixPath(file_path)
+    parts = list(posix.parts)
+    if not parts:
+        return ""
+    # Remove .py extension
+    if parts[-1].endswith(".py"):
+        parts[-1] = parts[-1][:-3]
+    # __init__ → use parent package
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _find_cycles(graph: dict[str, set[str]]) -> list[list[str]]:
+    """Find all elementary cycles via DFS.
+
+    Returns a list of cycles, each cycle being a list of module names.
+    Only returns cycles where *all* participants exist as keys in the
+    graph (i.e. are local modules, not external dependencies).
+    """
+    visited: set[str] = set()
+    on_stack: set[str] = set()
+    stack: list[str] = []
+    cycles: list[list[str]] = []
+    seen_cycles: set[frozenset[str]] = set()
+
+    def _dfs(node: str) -> None:
+        visited.add(node)
+        on_stack.add(node)
+        stack.append(node)
+
+        for neighbour in graph.get(node, ()):
+            # Only follow edges to local modules (present in graph)
+            if neighbour not in graph:
+                continue
+            if neighbour not in visited:
+                _dfs(neighbour)
+            elif neighbour in on_stack:
+                # Found a cycle
+                idx = stack.index(neighbour)
+                cycle = stack[idx:]
+                cycle_key = frozenset(cycle)
+                if cycle_key not in seen_cycles:
+                    seen_cycles.add(cycle_key)
+                    cycles.append(list(cycle))
+
+        stack.pop()
+        on_stack.discard(node)
+
+    for node in graph:
+        if node not in visited:
+            _dfs(node)
+
+    return cycles
+
+
+@register_signal
+class CircularImportSignal(BaseSignal):
+    """Detect circular import chains in Python packages."""
+
+    cache_dependency_spec: ClassVar[SignalCacheDependencySpec] = SignalCacheDependencySpec(
+        scope="repo_wide",
+        include_languages=("python",),
+    )
+
+    @property
+    def signal_type(self) -> SignalType:
+        return SignalType.CIRCULAR_IMPORT
+
+    @property
+    def name(self) -> str:
+        return "Circular Import"
+
+    def analyze(
+        self,
+        parse_results: list[ParseResult],
+        file_histories: dict[str, FileHistory],
+        config: DriftConfig,
+    ) -> list[Finding]:
+        graph, module_to_path = _build_import_graph(parse_results)
+        cycles = _find_cycles(graph)
+        findings: list[Finding] = []
+
+        for cycle in cycles:
+            cycle_len = len(cycle)
+            score = round(min(1.0, 0.3 + 0.1 * cycle_len), 3)
+            severity = Severity.HIGH if score >= 0.7 else Severity.MEDIUM
+
+            # Use the first module's path as the finding location
+            first_module = cycle[0]
+            file_path = module_to_path.get(first_module)
+
+            related = [
+                module_to_path[m]
+                for m in cycle[1:]
+                if m in module_to_path
+            ]
+
+            cycle_display = " → ".join(cycle) + " → " + cycle[0]
+
+            findings.append(
+                Finding(
+                    signal_type=self.signal_type,
+                    severity=severity,
+                    score=score,
+                    title=f"Circular import ({cycle_len} modules)",
+                    description=(
+                        f"Circular import chain detected: {cycle_display}. "
+                        f"This can cause runtime ImportErrors and indicates "
+                        f"tangled module responsibilities."
+                    ),
+                    file_path=file_path,
+                    related_files=related,
+                    fix=(
+                        f"Break the import cycle ({cycle_display}) by: "
+                        f"extracting shared types into a separate module, "
+                        f"using TYPE_CHECKING-guarded imports, or "
+                        f"restructuring module boundaries."
+                    ),
+                    metadata={
+                        "cycle_modules": cycle,
+                        "cycle_length": cycle_len,
+                    },
+                    rule_id="circular_import",
+                )
+            )
+
+        return findings

--- a/packages/drift-engine/src/drift_engine/signals/co_change_coupling.py
+++ b/packages/drift-engine/src/drift_engine/signals/co_change_coupling.py
@@ -1,0 +1,502 @@
+"""Signal: Co-Change Coupling (CCC).
+
+Detects hidden coupling between files that repeatedly change together
+without an explicit import relationship.
+"""
+
+from __future__ import annotations
+
+import posixpath
+import re
+from collections import defaultdict
+from itertools import combinations
+from pathlib import Path
+
+from drift.config import DriftConfig
+from drift.models import (
+    CommitInfo,
+    FileHistory,
+    Finding,
+    ImportInfo,
+    ParseResult,
+    SignalType,
+    severity_for_score,
+)
+from drift_engine.ingestion.test_detection import is_test_file
+from drift_engine.signals.base import BaseSignal, register_signal
+
+_MIN_HISTORY_COMMITS = 8
+_MIN_EFFECTIVE_COMMITS = 4.0
+_MIN_CO_CHANGE_WEIGHT = 2.5
+_MIN_CONFIDENCE = 0.45
+_MAX_FILES_PER_COMMIT = 20
+_MAX_FINDINGS = 10
+
+_MERGE_WEIGHT = 0.35
+_AUTOMATED_WEIGHT = 0.50
+
+_AUTOMATION_MARKERS = (
+    "bot",
+    "github-actions",
+    "dependabot",
+    "renovate",
+    "release-please",
+    "automation",
+)
+
+_JS_TS_EXTENSIONS = (".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs")
+_RUNTIME_VARIANT_TOKENS = {
+    "gateway",
+    "node",
+    "browser",
+    "server",
+    "client",
+    "edge",
+    "native",
+    "worker",
+}
+
+
+def _find_nearest_subpackage_root(file_path: str, repo_root: Path | None) -> str | None:
+    """Return a subpackage scope key for monorepo-aware coupling suppression.
+
+    Scope detection prefers the nearest ``package.json`` below repository root.
+    A root-level ``package.json`` is intentionally ignored to avoid suppressing
+    valid findings for single-package repositories. For repos where package
+    manifests are not present in the analysis workspace, use a conservative
+    path heuristic for ``extensions/<name>/...``.
+    """
+    rel_path = Path(file_path)
+    posix = rel_path.as_posix().lstrip("./")
+
+    if repo_root is not None:
+        candidate = repo_root / rel_path
+        for parent in [candidate.parent, *candidate.parents]:
+            if parent == repo_root or not str(parent).startswith(str(repo_root)):
+                break
+            if (parent / "package.json").is_file():
+                return parent.relative_to(repo_root).as_posix()
+
+    parts = [p for p in posix.split("/") if p]
+    if len(parts) >= 2 and parts[0] == "extensions":
+        return f"extensions/{parts[1]}"
+
+    return None
+
+
+def _shares_monorepo_subpackage(file_a: str, file_b: str, repo_root: Path | None) -> bool:
+    """Return True when both files belong to the same monorepo subpackage."""
+    scope_a = _find_nearest_subpackage_root(file_a, repo_root)
+    if scope_a is None:
+        return False
+    scope_b = _find_nearest_subpackage_root(file_b, repo_root)
+    return scope_a == scope_b
+
+
+def _module_candidates(file_path: Path) -> set[str]:
+    """Return plausible python module names for a file path."""
+    normalized = file_path.as_posix().lstrip("./")
+    if not normalized.endswith(".py"):
+        return set()
+
+    stem = normalized[:-3]
+    candidates = {stem.replace("/", ".")}
+    if stem.endswith("/__init__"):
+        candidates.add(stem[: -len("/__init__")].replace("/", "."))
+    return {c for c in candidates if c}
+
+
+def _build_module_index(parse_results: list[ParseResult]) -> dict[str, set[str]]:
+    """Map module names to candidate file paths in parse results."""
+    index: dict[str, set[str]] = defaultdict(set)
+    for pr in parse_results:
+        for module in _module_candidates(pr.file_path):
+            index[module].add(pr.file_path.as_posix())
+    return index
+
+
+def _resolve_non_relative_targets(imp: ImportInfo, module_index: dict[str, set[str]]) -> set[str]:
+    """Resolve non-relative imports to known in-repo file paths."""
+    targets: set[str] = set()
+    module = imp.imported_module.lstrip(".")
+    if not module:
+        return targets
+
+    if module in module_index:
+        targets.update(module_index[module])
+
+    for imported_name in imp.imported_names:
+        nested = f"{module}.{imported_name}"
+        if nested in module_index:
+            targets.update(module_index[nested])
+
+    return targets
+
+
+def _expand_relative_module_path(source_file: Path, raw_module: str) -> Path | None:
+    """Resolve a relative module string to a normalized candidate path."""
+    raw = raw_module.strip()
+    if not raw:
+        return None
+
+    if raw.startswith("./") or raw.startswith("../"):
+        merged = posixpath.join(source_file.parent.as_posix(), raw)
+        return Path(posixpath.normpath(merged))
+
+    leading_dots = len(raw) - len(raw.lstrip("."))
+    if leading_dots == 0:
+        return None
+
+    anchor = source_file.parent
+    for _ in range(max(leading_dots - 1, 0)):
+        anchor = anchor.parent
+
+    module_part = raw.lstrip(".")
+    if not module_part:
+        return anchor
+
+    return anchor / Path(module_part.replace(".", "/"))
+
+
+def _candidate_targets_from_relative_module(module_path: Path, source_ext: str) -> set[str]:
+    """Build conservative candidate file paths for relative imports."""
+    targets: set[str] = set()
+    posix = module_path.as_posix()
+    suffix = module_path.suffix.lower()
+
+    if suffix:
+        targets.add(posix)
+        if suffix in {".js", ".jsx", ".mjs", ".cjs"}:
+            targets.update(
+                {
+                    f"{module_path.with_suffix('.ts').as_posix()}",
+                    f"{module_path.with_suffix('.tsx').as_posix()}",
+                }
+            )
+        return targets
+
+    candidates = {".py"}
+    if source_ext in _JS_TS_EXTENSIONS:
+        candidates.update(_JS_TS_EXTENSIONS)
+
+    for ext in candidates:
+        targets.add(f"{posix}{ext}")
+
+    targets.add((module_path / "__init__.py").as_posix())
+    targets.add((module_path / "index.ts").as_posix())
+    targets.add((module_path / "index.js").as_posix())
+    return targets
+
+
+def _candidate_targets_from_stem_shadow_dir(
+    source_file: Path,
+    module_path: Path,
+    source_ext: str,
+) -> set[str]:
+    """Add candidates for stem-shadowed TS layouts (``run.ts`` + ``run/types.ts``).
+
+    Some repositories colocate helper modules under a folder named like the
+    importing file stem. For ``run.ts`` importing ``./types.js``, include
+    ``run/types.ts`` as an explicit-dependency candidate in addition to the
+    sibling ``types.ts`` path.
+    """
+    if module_path.parent != source_file.parent:
+        return set()
+
+    stem_dir = source_file.with_suffix("")
+    if not stem_dir.name:
+        return set()
+
+    shadowed_module = stem_dir / module_path.name
+    return _candidate_targets_from_relative_module(shadowed_module, source_ext)
+
+
+def _resolve_relative_targets(
+    source_file: Path,
+    imp: ImportInfo,
+    known_files: set[str] | None = None,
+) -> set[str]:
+    """Resolve relative imports with conservative local path heuristics."""
+    targets: set[str] = set()
+    source = Path(source_file.as_posix())
+    source_ext = source.suffix.lower()
+
+    resolved_module = _expand_relative_module_path(source, imp.imported_module)
+    if resolved_module is not None:
+        targets.update(_candidate_targets_from_relative_module(resolved_module, source_ext))
+        if source_ext in _JS_TS_EXTENSIONS:
+            targets.update(
+                _candidate_targets_from_stem_shadow_dir(source, resolved_module, source_ext)
+            )
+
+    imported_name_base = resolved_module if resolved_module is not None else source.parent
+    for imported_name in imp.imported_names:
+        imported_path = imported_name.replace(".", "/")
+        named_base = imported_name_base / imported_path
+        targets.update(_candidate_targets_from_relative_module(named_base, source_ext))
+
+    if known_files is None:
+        return targets
+
+    return {t for t in targets if t in known_files}
+
+
+def _is_parallel_runtime_variant_pair(file_a: str, file_b: str) -> bool:
+    """Suppress sibling runtime variants (e.g. *-gateway.ts vs *-node.ts)."""
+    path_a = Path(file_a)
+    path_b = Path(file_b)
+    if path_a.parent != path_b.parent or path_a.suffix != path_b.suffix:
+        return False
+
+    tokens_a = [t for t in re.split(r"[-_.]", path_a.stem) if t]
+    tokens_b = [t for t in re.split(r"[-_.]", path_b.stem) if t]
+    if not tokens_a or not tokens_b:
+        return False
+
+    filtered_a = [t for t in tokens_a if t not in _RUNTIME_VARIANT_TOKENS]
+    filtered_b = [t for t in tokens_b if t not in _RUNTIME_VARIANT_TOKENS]
+    removed_a = len(filtered_a) != len(tokens_a)
+    removed_b = len(filtered_b) != len(tokens_b)
+    return removed_a and removed_b and filtered_a == filtered_b
+
+
+def _is_cross_extension_parallel_template_pair(file_a: str, file_b: str) -> bool:
+    """Suppress cross-extension template entrypoint coupling in plugin repos."""
+    parts_a = [p for p in Path(file_a).as_posix().split("/") if p]
+    parts_b = [p for p in Path(file_b).as_posix().split("/") if p]
+    if len(parts_a) < 4 or len(parts_b) < 4:
+        return False
+    if parts_a[0] != "extensions" or parts_b[0] != "extensions":
+        return False
+    if parts_a[1] == parts_b[1]:
+        return False
+
+    suffix_a = "/".join(parts_a[2:])
+    suffix_b = "/".join(parts_b[2:])
+    if suffix_a != suffix_b:
+        return False
+
+    return suffix_a in {"src/index.ts", "src/index.js", "src/index.tsx", "src/index.jsx"}
+
+
+def _is_parallel_implementation_pair(file_a: str, file_b: str) -> bool:
+    """Return True for known intentional parallel-implementation patterns."""
+    return _is_parallel_runtime_variant_pair(
+        file_a, file_b
+    ) or _is_cross_extension_parallel_template_pair(file_a, file_b)
+
+def _explicit_dependency_pairs(parse_results: list[ParseResult]) -> set[tuple[str, str]]:
+    """Build undirected explicit dependency pairs from import metadata."""
+    module_index = _build_module_index(parse_results)
+    known_files = {pr.file_path.as_posix() for pr in parse_results}
+    explicit: set[tuple[str, str]] = set()
+
+    for pr in parse_results:
+        source = pr.file_path.as_posix()
+        for imp in pr.imports:
+            if imp.is_relative:
+                resolved = _resolve_relative_targets(pr.file_path, imp, known_files)
+            else:
+                resolved = _resolve_non_relative_targets(imp, module_index)
+
+            for target in resolved:
+                if target not in known_files or target == source:
+                    continue
+                pair = tuple(sorted((source, target)))
+                explicit.add(pair)  # type: ignore[arg-type]
+
+    return explicit
+
+
+def _is_merge_commit(message: str) -> bool:
+    """Heuristic merge commit detection from message text."""
+    lower = message.lower().strip()
+    return lower.startswith("merge ") or "merge pull request" in lower
+
+
+def _is_automated_commit(commit: CommitInfo) -> bool:
+    """Heuristic detection for bot/automated commits."""
+    if commit.is_ai_attributed:
+        return True
+
+    haystack = " ".join(
+        [
+            commit.author.lower(),
+            commit.email.lower(),
+            commit.message.lower(),
+        ]
+    )
+    return any(marker in haystack for marker in _AUTOMATION_MARKERS)
+
+
+@register_signal
+class CoChangeCouplingSignal(BaseSignal):
+    """Detect hidden file coupling from recurring co-change patterns."""
+
+    incremental_scope = "git_dependent"
+
+    @property
+    def signal_type(self) -> SignalType:
+        return SignalType.CO_CHANGE_COUPLING
+
+    @property
+    def name(self) -> str:
+        return "Co-Change Coupling"
+
+    def analyze(
+        self,
+        parse_results: list[ParseResult],
+        file_histories: dict[str, FileHistory],
+        config: DriftConfig,
+    ) -> list[Finding]:
+        """Find repeated co-change pairs without explicit import edges.
+
+        Uses only commit metadata from AnalysisContext, with deterministic
+        weighting to avoid over-emphasizing merge and automated commits.
+        """
+        del file_histories
+        handling = config.test_file_handling or "reduce_severity"
+
+        if len(self.commits) < _MIN_HISTORY_COMMITS:
+            return []
+
+        known_files = {pr.file_path.as_posix() for pr in parse_results}
+        if len(known_files) < 2:
+            return []
+
+        explicit_pairs = _explicit_dependency_pairs(parse_results)
+        repo_root = self.repo_path.resolve() if self.repo_path is not None else None
+
+        file_weights: dict[str, float] = defaultdict(float)
+        pair_weights: dict[tuple[str, str], float] = defaultdict(float)
+        pair_raw_counts: dict[tuple[str, str], int] = defaultdict(int)
+        pair_commit_hashes: dict[tuple[str, str], list[str]] = defaultdict(list)
+        pair_commit_messages: dict[tuple[str, str], list[str]] = defaultdict(list)
+
+        effective_commits = 0.0
+
+        for commit in self.commits:
+            files = sorted({f for f in commit.files_changed if f in known_files})
+            if len(files) < 2 or len(files) > _MAX_FILES_PER_COMMIT:
+                continue
+
+            weight = 1.0
+            if _is_merge_commit(commit.message):
+                weight *= _MERGE_WEIGHT
+            if _is_automated_commit(commit):
+                weight *= _AUTOMATED_WEIGHT
+
+            if weight <= 0.0:
+                continue
+
+            effective_commits += weight
+            for file_path in files:
+                file_weights[file_path] += weight
+
+            for file_a, file_b in combinations(files, 2):
+                pair = (file_a, file_b)
+                pair_weights[pair] += weight
+                pair_raw_counts[pair] += 1
+                pair_commit_hashes[pair].append(commit.hash)
+                pair_commit_messages[pair].append(commit.message[:60])
+
+        if effective_commits < _MIN_EFFECTIVE_COMMITS:
+            return []
+
+        findings: list[Finding] = []
+        for pair, weighted_count in pair_weights.items():
+            if weighted_count < _MIN_CO_CHANGE_WEIGHT:
+                continue
+            if pair in explicit_pairs:
+                continue
+            if _shares_monorepo_subpackage(pair[0], pair[1], repo_root):
+                continue
+            if _is_parallel_implementation_pair(pair[0], pair[1]):
+                continue
+
+            total_a = file_weights[pair[0]]
+            total_b = file_weights[pair[1]]
+            denom = min(total_a, total_b)
+            if denom <= 0.0:
+                continue
+
+            confidence = weighted_count / denom
+            if confidence < _MIN_CONFIDENCE:
+                continue
+
+            support = min(1.0, weighted_count / 8.0)
+            raw_score = max(0.0, (0.55 * confidence) + (0.45 * support))
+            # Keep initial rollout conservative: hidden co-change findings
+            # should not auto-escalate to CRITICAL without explicit validation.
+            score = min(0.79, raw_score)
+            if score < 0.2:
+                continue
+
+            path_a = Path(str(pair[0]))
+            path_b = Path(str(pair[1]))
+            pair_has_test = is_test_file(path_a) or is_test_file(path_b)
+            if pair_has_test and handling == "exclude":
+                continue
+
+            if pair_has_test and handling == "reduce_severity":
+                score = round(score * 0.5, 3)
+                if score < 0.2:
+                    continue
+
+            sample_hashes = sorted(set(pair_commit_hashes[pair]))[:5]
+            raw_count = pair_raw_counts[pair]
+            sample_messages = pair_commit_messages[pair][:3]
+            msg_context = (
+                "\n".join(f'  - "{m}"' for m in sample_messages)
+                if sample_messages
+                else ""
+            )
+
+            findings.append(
+                Finding(
+                    signal_type=self.signal_type,
+                    severity=severity_for_score(score),
+                    score=round(score, 3),
+                    title=(
+                        f"Hidden co-change coupling: {path_a.name} <-> {path_b.name} "
+                        f"({raw_count} commits)"
+                    ),
+                    description=(
+                        f"{pair[0]} and {pair[1]} changed together repeatedly "  # type: ignore[index]
+                        f"(weighted={weighted_count:.2f}, confidence={confidence:.0%}) "
+                        f"without an explicit import relationship. "
+                        "This indicates hidden coupling and implicit change propagation risk."
+                    ),
+                    file_path=path_a,
+                    related_files=[path_b],
+                    fix=(
+                        f"Co-change coupling: {path_a.name} \u2194 {path_b.name}."
+                        + (f"\nRecent context:\n{msg_context}" if msg_context else "")
+                        + "\n\nIf intentional (shared boundary):\n"
+                        + "  \u2192 Add integration test: "
+                        + f"def test_{path_a.stem}_{path_b.stem}_sync():\n"
+                        + "        # Verify consistent contracts between both modules\n"
+                        + "\nIf accidental (layering issue):\n"
+                        + "  \u2192 Extract shared logic into src/<domain>/shared.py"
+                    ),
+                    metadata={
+                        "file_a": pair[0],
+                        "file_b": pair[1],
+                        "co_change_commits": raw_count,
+                        "co_change_weight": round(weighted_count, 3),
+                        "confidence": round(confidence, 3),
+                        "total_weight_file_a": round(total_a, 3),
+                        "total_weight_file_b": round(total_b, 3),
+                        "explicit_dependency": False,
+                        "commit_samples": sample_hashes,
+                        "commit_messages": sample_messages,
+                        "finding_context": "test" if pair_has_test else "production",
+                    },
+                    finding_context="test" if pair_has_test else "production",
+                )
+            )
+
+        findings.sort(  # type: ignore[union-attr]
+            key=lambda f: (-f.score, f.file_path.as_posix() if f.file_path else "", f.title)
+        )
+        return findings[:_MAX_FINDINGS]

--- a/packages/drift-engine/src/drift_engine/signals/cognitive_complexity.py
+++ b/packages/drift-engine/src/drift_engine/signals/cognitive_complexity.py
@@ -1,0 +1,462 @@
+"""Signal: Cognitive Complexity (CXS).
+
+Detects functions whose cognitive complexity exceeds a configurable
+threshold, indicating hard-to-understand control flow.
+
+The metric follows the SonarSource cognitive-complexity model:
+increments for each break in linear flow (if, for, while, except, …)
+with a nesting bonus that penalises deeply nested structures more
+heavily than equivalent flat code.
+
+Supports Python (via ``ast``) and TypeScript/JavaScript (via
+``tree-sitter``).
+
+Deterministic, AST-only, LLM-free.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+from drift.config import DriftConfig
+from drift.models import (
+    FileHistory,
+    Finding,
+    FunctionInfo,
+    ParseResult,
+    Severity,
+    SignalType,
+)
+from drift_engine.signals._utils import _SUPPORTED_LANGUAGES, is_test_file
+from drift_engine.signals.base import BaseSignal, register_signal
+
+# ---------------------------------------------------------------------------
+# Cognitive-complexity calculation (SonarSource-style)
+# ---------------------------------------------------------------------------
+
+# Statements that increment complexity and increase nesting.
+_NESTING_INCREMENTS: frozenset[type] = frozenset({
+    ast.If,
+    ast.For,
+    ast.While,
+    ast.AsyncFor,
+    ast.AsyncWith,
+    ast.With,
+    ast.ExceptHandler,
+})
+
+# Statements that increment complexity but do NOT increase nesting.
+_FLAT_INCREMENTS: frozenset[type] = frozenset({
+    ast.BoolOp,
+})
+
+
+def _cognitive_complexity_of_body(
+    stmts: list[ast.stmt],
+    nesting: int = 0,
+) -> int:
+    """Recursively compute cognitive complexity for a list of statements."""
+    total = 0
+    for stmt in stmts:
+        if isinstance(stmt, tuple(_NESTING_INCREMENTS)):
+            # +1 inherent increment + nesting bonus
+            total += 1 + nesting
+            # recurse into children with increased nesting
+            total += _complexity_children(stmt, nesting + 1)
+        elif isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            # nested function — increase nesting but no inherent increment
+            total += _cognitive_complexity_of_body(stmt.body, nesting + 1)
+        else:
+            total += _complexity_children(stmt, nesting)
+
+        # boolean operators within expressions
+        total += _count_bool_ops(stmt)
+
+    return total
+
+
+def _complexity_children(node: ast.stmt, nesting: int) -> int:
+    """Sum cognitive complexity of all child statement blocks."""
+    total = 0
+    for attr in ("body", "orelse", "finalbody", "handlers"):
+        children = getattr(node, attr, None)
+        if children is None:
+            continue
+        if isinstance(children, list):
+            # `handlers` contains ExceptHandler nodes
+            total += _cognitive_complexity_of_body(children, nesting)
+    return total
+
+
+def _count_bool_ops(node: ast.AST) -> int:
+    """Count boolean-operator sequences (&&/||) as +1 each."""
+    count = 0
+    for child in ast.walk(node):
+        if isinstance(child, ast.BoolOp):
+            # Each BoolOp chain of same type = +1 (not per operand)
+            count += 1
+    # Subtract 1 if the node itself is a BoolOp (already counted by walk)
+    if isinstance(node, ast.BoolOp):
+        count -= 1
+    return count
+
+
+def _function_cognitive_complexity(source: str, func: FunctionInfo) -> int | None:
+    """Extract cognitive complexity for a single function from source."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return _cognitive_complexity_of_body(node.body)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# TypeScript / JavaScript cognitive complexity (tree-sitter)
+# ---------------------------------------------------------------------------
+
+# Node types that increment complexity AND increase nesting.
+_TS_NESTING_TYPES: frozenset[str] = frozenset({
+    "if_statement",
+    "for_statement",
+    "for_in_statement",
+    "while_statement",
+    "do_statement",
+    "switch_case",      # each case label = +1 nesting
+    "catch_clause",
+    "ternary_expression",
+})
+
+# Node types that increment complexity but do NOT increase nesting.
+_TS_FLAT_TYPES: frozenset[str] = frozenset({
+    "break_statement",
+    "continue_statement",
+})
+
+_TS_JS_EXTENSIONS: frozenset[str] = frozenset({".ts", ".tsx", ".js", ".jsx"})
+_SCHEMA_FILE_SUFFIXES: tuple[str, ...] = (
+    ".schema.ts",
+    ".schema.tsx",
+    ".schema.js",
+    ".schema.jsx",
+)
+_CONFIG_DEFAULT_FILENAME_MARKERS: tuple[str, ...] = (
+    "config-defaults",
+    "config.defaults",
+    "default-config",
+)
+_SCHEMA_FILENAME_MARKERS: tuple[str, ...] = (
+    "config-schema",
+)
+
+
+def _is_inherent_ts_complexity_context(path: Path | str) -> bool:
+    """Return True for TS/JS files where high branching is often structural."""
+    value = path.as_posix() if isinstance(path, Path) else path.replace("\\", "/")
+    value = value.lower()
+
+    if not any(value.endswith(ext) for ext in _TS_JS_EXTENSIONS):
+        return False
+
+    filename = value.rsplit("/", 1)[-1]
+    if filename.endswith(_SCHEMA_FILE_SUFFIXES):
+        return True
+    if any(marker in filename for marker in _SCHEMA_FILENAME_MARKERS):
+        return True
+    if "migration" in filename:
+        return True
+    if any(marker in filename for marker in _CONFIG_DEFAULT_FILENAME_MARKERS):
+        return True
+
+    return "/migrations/" in value or "/migration/" in value
+
+
+def _ts_walk(node: Any) -> list[Any]:
+    """Return all descendants of a tree-sitter node."""
+    stack = list(node.children)
+    result: list[Any] = []
+    while stack:
+        child = stack.pop()
+        result.append(child)
+        stack.extend(child.children)
+    return result
+
+
+def _ts_cognitive_complexity(node: Any) -> int:
+    """Compute cognitive complexity for a tree-sitter function body node."""
+    return _ts_cc_recurse(node, 0)
+
+
+def _ts_cc_recurse(node: Any, nesting: int) -> int:
+    total = 0
+    for child in node.children:
+        if child.type in _TS_NESTING_TYPES:
+            total += 1 + nesting
+            total += _ts_cc_recurse(child, nesting + 1)
+        elif child.type in (
+            "function_declaration", "arrow_function",
+            "method_definition", "generator_function_declaration",
+        ):
+            # Nested function — increase nesting without inherent increment.
+            total += _ts_cc_recurse(child, nesting + 1)
+        elif child.type == "binary_expression":
+            # Logical operators (&&, ||, ??) contribute +1 per chain.
+            op = None
+            for c in child.children:
+                if c.type in ("&&", "||", "??"):
+                    op = c.type
+            if op:
+                total += 1
+            total += _ts_cc_recurse(child, nesting)
+        else:
+            total += _ts_cc_recurse(child, nesting)
+    return total
+
+
+def _ts_find_functions(root: Any) -> list[Any]:
+    """Find all top-level and class-level function nodes in tree-sitter AST."""
+    fn_types = {
+        "function_declaration",
+        "method_definition",
+        "arrow_function",
+        "generator_function_declaration",
+    }
+    result: list[Any] = []
+    for node in _ts_walk(root):
+        if node.type in fn_types:
+            result.append(node)
+    return result
+
+
+def _ts_function_name(node: Any) -> str:
+    """Extract function name from a tree-sitter node."""
+    # function_declaration, generator_function_declaration → name field
+    for child in node.children:
+        if child.type == "identifier":
+            return str(child.text.decode("utf-8", errors="replace"))
+        if child.type == "property_identifier":
+            return str(child.text.decode("utf-8", errors="replace"))
+    # method_definition → first property_identifier child
+    # arrow_function — check parent for variable_declarator
+    parent = node.parent
+    if parent and parent.type == "variable_declarator":
+        for child in parent.children:
+            if child.type == "identifier":
+                return str(child.text.decode("utf-8", errors="replace"))
+    return "<anonymous>"
+
+
+# ---------------------------------------------------------------------------
+# Signal
+# ---------------------------------------------------------------------------
+
+
+@register_signal
+class CognitiveComplexitySignal(BaseSignal):
+    """Detect functions with excessive cognitive complexity."""
+
+    incremental_scope = "file_local"
+
+    @property
+    def signal_type(self) -> SignalType:
+        return SignalType.COGNITIVE_COMPLEXITY
+
+    @property
+    def name(self) -> str:
+        return "Cognitive Complexity"
+
+    _TS_LANGS = frozenset({"typescript", "tsx", "javascript", "jsx"})
+
+    def analyze(
+        self,
+        parse_results: list[ParseResult],
+        file_histories: dict[str, FileHistory],
+        config: DriftConfig,
+    ) -> list[Finding]:
+        threshold = config.thresholds.cxs_max_complexity
+        findings: list[Finding] = []
+
+        for pr in parse_results:
+            if pr.language not in _SUPPORTED_LANGUAGES:
+                continue
+            if is_test_file(pr.file_path):
+                continue
+
+            if pr.language == "python":
+                findings.extend(
+                    self._analyze_python(pr, threshold)
+                )
+            elif pr.language in self._TS_LANGS:
+                findings.extend(
+                    self._analyze_typescript(pr, threshold)
+                )
+
+        return findings
+
+    # ------------------------------------------------------------------
+    # Python path (ast-based)
+    # ------------------------------------------------------------------
+
+    def _analyze_python(
+        self,
+        pr: ParseResult,
+        threshold: int,
+    ) -> list[Finding]:
+        findings: list[Finding] = []
+        source = self._read_source(pr.file_path)
+        if source is None:
+            return findings
+
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            return findings
+
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if node.name.startswith("_"):
+                continue
+            body_lines = (node.end_lineno or node.lineno) - node.lineno + 1
+            if body_lines < 5:
+                continue
+
+            cc = _cognitive_complexity_of_body(node.body)
+            if cc <= threshold:
+                continue
+
+            findings.append(self._make_finding(
+                pr, node.name, cc, threshold,
+                node.lineno, node.end_lineno, body_lines,
+            ))
+
+        return findings
+
+    # ------------------------------------------------------------------
+    # TypeScript / JavaScript path (tree-sitter)
+    # ------------------------------------------------------------------
+
+    def _analyze_typescript(
+        self,
+        pr: ParseResult,
+        threshold: int,
+    ) -> list[Finding]:
+        findings: list[Finding] = []
+        source = self._read_source(pr.file_path)
+        if source is None:
+            return findings
+
+        try:
+            from drift_engine.ingestion.ts_parser import _get_parser  # type: ignore[attr-defined]
+            ts_lang = "tsx" if pr.language == "tsx" else "typescript"
+            parser = _get_parser(ts_lang)
+            tree = parser.parse(source.encode("utf-8"))
+        except Exception:
+            return findings
+
+        dampen_for_file = _is_inherent_ts_complexity_context(pr.file_path)
+
+        for fn_node in _ts_find_functions(tree.root_node):
+            name = _ts_function_name(fn_node)
+            if name.startswith("_"):
+                continue
+            start_line = fn_node.start_point[0] + 1
+            end_line = fn_node.end_point[0] + 1
+            body_lines = end_line - start_line + 1
+            if body_lines < 5:
+                continue
+
+            # Find the body node (statement_block)
+            body_node = None
+            for child in fn_node.children:
+                if child.type == "statement_block":
+                    body_node = child
+                    break
+            if body_node is None:
+                continue
+
+            cc = _ts_cognitive_complexity(body_node)
+            if cc <= threshold:
+                continue
+
+            findings.append(self._make_finding(
+                pr, name, cc, threshold,
+                start_line, end_line, body_lines,
+                context_dampened=dampen_for_file,
+            ))
+
+        return findings
+
+    # ------------------------------------------------------------------
+    # Shared helpers
+    # ------------------------------------------------------------------
+
+    def _make_finding(
+        self,
+        pr: ParseResult,
+        func_name: str,
+        cc: int,
+        threshold: int,
+        start_line: int,
+        end_line: int | None,
+        body_lines: int,
+        *,
+        context_dampened: bool = False,
+    ) -> Finding:
+        overshoot = cc - threshold
+        score = round(min(1.0, 0.3 + overshoot * 0.04), 3)
+        severity = Severity.HIGH if score >= 0.7 else Severity.MEDIUM
+        if context_dampened:
+            score = min(score, 0.19)
+            severity = Severity.INFO
+
+        description_suffix = ""
+        if context_dampened:
+            description_suffix = (
+                " Detected in schema/migration code where higher branching is often "
+                "structural and expected; severity was capped."
+            )
+        return Finding(
+            signal_type=self.signal_type,
+            severity=severity,
+            score=score,
+            title=f"High cognitive complexity in {func_name}()",
+            description=(
+                f"Function '{func_name}' in {pr.file_path.as_posix()} has "
+                f"cognitive complexity {cc} (threshold: {threshold}). "
+                f"Complex control flow makes this function hard to "
+                f"understand and maintain.{description_suffix}"
+            ),
+            file_path=pr.file_path,
+            start_line=start_line,
+            end_line=end_line,
+            fix=(
+                f"Reduce cognitive complexity of '{func_name}' "
+                f"(currently {cc}, threshold {threshold}): "
+                f"extract nested logic into helper functions, "
+                f"replace nested conditionals with guard clauses, "
+                f"simplify boolean expressions."
+            ),
+            metadata={
+                "cognitive_complexity": cc,
+                "threshold": threshold,
+                "function_name": func_name,
+                "body_lines": body_lines,
+                "context_dampened": context_dampened,
+            },
+            rule_id="cognitive_complexity",
+        )
+
+    def _read_source(self, file_path: Path) -> str | None:
+        try:
+            target = file_path
+            if self._repo_path and not file_path.is_absolute():
+                target = self._repo_path / file_path
+            return target.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None

--- a/packages/drift-engine/src/drift_engine/signals/cohesion_deficit.py
+++ b/packages/drift-engine/src/drift_engine/signals/cohesion_deficit.py
@@ -1,0 +1,449 @@
+"""Signal: Cohesion Deficit (COD).
+
+Detects files that contain many semantically unrelated responsibilities,
+for example "god modules" or dump-like utility files.
+
+The detector is deterministic and LLM-free:
+- build semantic token sets from function/class names
+- measure pairwise name-overlap (Jaccard similarity)
+- flag files where most units do not cohere with each other
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from drift.config import DriftConfig
+from drift.models import (
+    ClassInfo,
+    FileHistory,
+    Finding,
+    FunctionInfo,
+    ParseResult,
+    SignalType,
+    severity_for_score,
+)
+from drift_engine.signals._utils import _SUPPORTED_LANGUAGES
+from drift_engine.signals.base import BaseSignal, register_signal
+
+_CAMEL_PART_RE = re.compile(r"[A-Z]?[a-z]+|[A-Z]+(?=[A-Z]|$)|\d+")
+_TOKEN_SPLIT_RE = re.compile(r"[^A-Za-z0-9]+")
+
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "get",
+        "set",
+        "run",
+        "make",
+        "create",
+        "build",
+        "helper",
+        "utils",
+        "util",
+        "common",
+        "module",
+        "data",
+        "item",
+        "value",
+        "manager",
+        "service",
+        "handler",
+        "process",
+        "core",
+        "base",
+        "main",
+        "file",
+        "object",
+    }
+)
+
+
+@dataclass(frozen=True)
+class _SemanticUnit:
+    name: str
+    start_line: int
+    end_line: int
+    tokens: frozenset[str]
+
+
+_INDEX_NAMES: frozenset[str] = frozenset(
+    {"__init__.py", "index.ts", "index.tsx", "index.js", "index.jsx"},
+)
+
+_LOGGER_LEVEL_NAMES: frozenset[str] = frozenset(
+    {"trace", "debug", "info", "warn", "warning", "error", "fatal", "log"}
+)
+
+_UTILITY_FILENAME_HINTS: frozenset[str] = frozenset(
+    {"util", "utils", "helper", "helpers", "constant", "constants"}
+)
+
+_COHESIVE_ACTION_PREFIXES: frozenset[str] = frozenset(
+    {"register", "format", "create"}
+)
+
+_TEST_HARNESS_SUFFIXES: tuple[str, ...] = (
+    ".test-harness.ts",
+    ".test-harness.tsx",
+    ".test-harness.js",
+    ".test-harness.jsx",
+    ".test-helpers.ts",
+    ".test-helpers.tsx",
+    ".test-helpers.js",
+    ".test-helpers.jsx",
+    ".test-support.ts",
+    ".test-support.tsx",
+    ".test-support.js",
+    ".test-support.jsx",
+)
+
+_TEST_HARNESS_BASENAMES: frozenset[str] = frozenset(
+    {
+        "test-harness.ts",
+        "test-harness.tsx",
+        "test-harness.js",
+        "test-harness.jsx",
+        "test-helpers.ts",
+        "test-helpers.tsx",
+        "test-helpers.js",
+        "test-helpers.jsx",
+        "test-support.ts",
+        "test-support.tsx",
+        "test-support.js",
+        "test-support.jsx",
+    }
+)
+
+
+def _is_test_like(path: Path) -> bool:
+    """Return *True* if *path* is likely a test or test-support file."""
+    p = path.as_posix().lower()
+    name = path.name.lower()
+    if name in _TEST_HARNESS_BASENAMES or any(
+        name.endswith(suffix) for suffix in _TEST_HARNESS_SUFFIXES
+    ):
+        return True
+    return (
+        "/tests/" in p
+        or p.startswith("tests/")
+        or "/__tests__/" in p
+        or name.startswith("test_")
+        or name.endswith("_test.py")
+        or name.endswith(".test.ts")
+        or name.endswith(".test.tsx")
+        or name.endswith(".test.js")
+        or name.endswith(".test.jsx")
+        or name.endswith(".spec.ts")
+        or name.endswith(".spec.tsx")
+        or name.endswith(".spec.js")
+        or name.endswith(".spec.jsx")
+    )
+
+
+def _tokenize_name(name: str) -> set[str]:
+    base = name.split(".")[-1]
+    chunks = _TOKEN_SPLIT_RE.split(base)
+    tokens: set[str] = set()
+    for chunk in chunks:
+        if not chunk:
+            continue
+        parts = _CAMEL_PART_RE.findall(chunk) or [chunk]
+        for part in parts:
+            token = part.lower()
+            if len(token) < 3:
+                continue
+            if token in _STOPWORDS:
+                continue
+            tokens.add(token)
+    return tokens
+
+
+def _jaccard(left: frozenset[str], right: frozenset[str]) -> float:
+    if not left or not right:
+        return 0.0
+    inter = len(left & right)
+    union = len(left | right)
+    if union == 0:
+        return 0.0
+    return inter / union
+
+
+def _function_unit(fn: FunctionInfo) -> _SemanticUnit | None:
+    if "." in fn.name:
+        return None
+    if fn.name.startswith("_"):
+        # Private helpers are implementation details, not independent semantic units.
+        # Counting them inflates isolation_ratio and causes FPs after helper extraction.
+        return None
+    tokens = _tokenize_name(fn.name)
+    if len(tokens) < 1:
+        return None
+    return _SemanticUnit(
+        name=fn.name,
+        start_line=fn.start_line,
+        end_line=fn.end_line,
+        tokens=frozenset(tokens),
+    )
+
+
+def _class_unit(cls: ClassInfo) -> _SemanticUnit | None:
+    tokens = _tokenize_name(cls.name)
+    for method in cls.methods:
+        tokens.update(_tokenize_name(method.name))
+    if len(tokens) < 1:
+        return None
+    return _SemanticUnit(
+        name=cls.name,
+        start_line=cls.start_line,
+        end_line=cls.end_line,
+        tokens=frozenset(tokens),
+    )
+
+
+def _collect_units(parse_result: ParseResult) -> list[_SemanticUnit]:
+    units: list[_SemanticUnit] = []
+    for fn in parse_result.functions:
+        unit = _function_unit(fn)
+        if unit:
+            units.append(unit)
+    for cls in parse_result.classes:
+        unit = _class_unit(cls)
+        if unit:
+            units.append(unit)
+    return units
+
+
+def _name_tokens(name: str) -> set[str]:
+    return _tokenize_name(name)
+
+
+def _is_logger_like_module(parse_result: ParseResult, units: list[_SemanticUnit]) -> bool:
+    stem_tokens = _name_tokens(parse_result.file_path.stem)
+    if "logger" in stem_tokens:
+        return True
+
+    scored_names = [u.name.split(".")[-1].lower() for u in units]
+    if not scored_names:
+        return False
+
+    logger_like_count = 0
+    for name in scored_names:
+        tokens = _name_tokens(name)
+        if tokens & _LOGGER_LEVEL_NAMES:
+            logger_like_count += 1
+            continue
+        if "logger" in tokens or name.startswith("log"):
+            logger_like_count += 1
+
+    return (logger_like_count / len(scored_names)) >= 0.5
+
+
+def _has_utility_filename_hint(path: Path) -> bool:
+    stem = path.stem.lower()
+    split_tokens = [part for part in _TOKEN_SPLIT_RE.split(stem) if part]
+    for token in split_tokens:
+        if token in _UTILITY_FILENAME_HINTS:
+            return True
+    return any(hint in stem for hint in _UTILITY_FILENAME_HINTS)
+
+
+def _leading_token(name: str) -> str:
+    tokens = _CAMEL_PART_RE.findall(name.split(".")[-1])
+    if not tokens:
+        return ""
+    return str(tokens[0]).lower()
+
+
+def _shared_action_prefix_ratio(units: list[_SemanticUnit]) -> float:
+    if not units:
+        return 0.0
+
+    prefix_count: dict[str, int] = {}
+    for unit in units:
+        prefix = _leading_token(unit.name)
+        if prefix not in _COHESIVE_ACTION_PREFIXES:
+            continue
+        prefix_count[prefix] = prefix_count.get(prefix, 0) + 1
+
+    if not prefix_count:
+        return 0.0
+    return max(prefix_count.values()) / len(units)
+
+
+def _filename_token_cohesion_ratio(path: Path, units: list[_SemanticUnit]) -> float:
+    stem_tokens = _name_tokens(path.stem)
+    if not stem_tokens or not units:
+        return 0.0
+
+    covered = sum(1 for unit in units if unit.tokens & stem_tokens)
+    return covered / len(units)
+
+
+def _is_plugin_workspace_source(path: Path) -> bool:
+    parts = [part.lower() for part in path.parts]
+    if len(parts) < 3:
+        return False
+    return parts[0] == "extensions" and "src" in parts[2:]
+
+
+@register_signal
+class CohesionDeficitSignal(BaseSignal):
+    """Detect semantically incoherent modules/files."""
+
+    incremental_scope = "file_local"
+
+    @property
+    def signal_type(self) -> SignalType:
+        return SignalType.COHESION_DEFICIT
+
+    @property
+    def name(self) -> str:
+        return "Cohesion Deficit"
+
+    def analyze(
+        self,
+        parse_results: list[ParseResult],
+        file_histories: dict[str, FileHistory],
+        config: DriftConfig,
+    ) -> list[Finding]:
+        """Detect cohesion deficits across all supported *parse_results*."""
+        del file_histories  # Not required for this structural signal.
+
+        repo_files = [
+            pr
+            for pr in parse_results
+            if pr.language in _SUPPORTED_LANGUAGES
+            and pr.file_path.name not in _INDEX_NAMES
+            and not _is_test_like(pr.file_path)
+        ]
+
+        small_repo_threshold = config.thresholds.small_repo_module_threshold
+        repo_ratio = min(1.0, len(repo_files) / max(1, small_repo_threshold))
+        repo_dampening = 0.7 + (0.3 * repo_ratio)
+
+        min_units = 4
+        isolated_similarity_threshold = 0.15
+        detection_threshold = 0.35
+
+        findings: list[Finding] = []
+
+        for pr in repo_files:
+            units = _collect_units(pr)
+            if len(units) < min_units:
+                continue
+
+            is_logger_like = _is_logger_like_module(pr, units)
+            has_utility_filename_hint = _has_utility_filename_hint(pr.file_path)
+            shared_action_prefix_ratio = _shared_action_prefix_ratio(units)
+            filename_token_cohesion_ratio = _filename_token_cohesion_ratio(
+                pr.file_path, units
+            )
+            is_plugin_workspace_source = _is_plugin_workspace_source(pr.file_path)
+
+            best_similarities: list[float] = []
+            isolated_names: list[str] = []
+
+            for idx, unit in enumerate(units):
+                best = 0.0
+                for jdx, other in enumerate(units):
+                    if idx == jdx:
+                        continue
+                    best = max(best, _jaccard(unit.tokens, other.tokens))
+                best_similarities.append(best)
+                if best < isolated_similarity_threshold:
+                    isolated_names.append(unit.name)
+
+            mean_best_similarity = sum(best_similarities) / len(best_similarities)
+            isolation_ratio = len(isolated_names) / len(units)
+            diversity = 1.0 - mean_best_similarity
+
+            # 65% isolation, 35% global incoherence.
+            raw_score = (0.65 * isolation_ratio) + (0.35 * diversity)
+
+            module_pattern_dampening = 1.0
+            if is_logger_like:
+                # Logger facades intentionally expose independent severity entrypoints.
+                module_pattern_dampening *= 0.35
+            if has_utility_filename_hint and not is_logger_like:
+                # Utility modules can contain loosely related helpers by convention.
+                module_pattern_dampening *= 0.8
+            if shared_action_prefix_ratio >= 0.6:
+                # Action families like register*/format*/create* can still be cohesive.
+                module_pattern_dampening *= 0.55
+            if filename_token_cohesion_ratio >= 0.5:
+                # format.ts/serializer.ts-like modules often reflect a single domain concern.
+                module_pattern_dampening *= 0.7
+            if (
+                is_plugin_workspace_source
+                and (shared_action_prefix_ratio >= 0.6 or filename_token_cohesion_ratio >= 0.5)
+                and not is_logger_like
+            ):
+                # Extension workspaces frequently group one plugin concern per module.
+                module_pattern_dampening *= 0.8
+
+            # Small member sets are noisier: ramp up confidence with module size.
+            member_scale = min(1.0, (len(units) - 2) / 4)
+            # Keep COD conservative for CI gating: severe but non-critical by default.
+            score = round(
+                min(
+                    0.79,
+                    raw_score
+                    * member_scale
+                    * repo_dampening
+                    * module_pattern_dampening,
+                ),
+                3,
+            )
+
+            if score < detection_threshold:
+                continue
+
+            severity = severity_for_score(score)
+            file_path = pr.file_path
+            isolated_preview = ", ".join(isolated_names[:5])
+            if len(isolated_names) > 5:
+                isolated_preview += f" (+{len(isolated_names) - 5} more)"
+
+            findings.append(
+                Finding(
+                    signal_type=self.signal_type,
+                    severity=severity,
+                    score=score,
+                    title=f"Cohesion deficit in {file_path.as_posix()}",
+                    description=(
+                        f"{len(isolated_names)}/{len(units)} semantic units are isolated "
+                        f"(mean best similarity={mean_best_similarity:.2f}, "
+                        f"isolation ratio={isolation_ratio:.2f})."
+                    ),
+                    file_path=file_path,
+                    related_files=[file_path],
+                    fix=(
+                        f"Split {len(isolated_names)} isolated units into focused modules. "
+                        f"Start with: {isolated_preview}. "
+                        f"Move each cohesive group into its own module."
+                    ),
+                    metadata={
+                        "unit_count": len(units),
+                        "isolated_count": len(isolated_names),
+                        "isolated_units": isolated_names,
+                        "mean_best_similarity": round(mean_best_similarity, 3),
+                        "isolation_ratio": round(isolation_ratio, 3),
+                        "repo_dampening": round(repo_dampening, 3),
+                        "module_pattern_dampening": round(module_pattern_dampening, 3),
+                        "logger_like_module": is_logger_like,
+                        "utility_filename_hint": has_utility_filename_hint,
+                        "shared_action_prefix_ratio": round(
+                            shared_action_prefix_ratio, 3
+                        ),
+                        "filename_token_cohesion_ratio": round(
+                            filename_token_cohesion_ratio, 3
+                        ),
+                        "plugin_workspace_source": is_plugin_workspace_source,
+                        "member_scale": round(member_scale, 3),
+                    },
+                )
+            )
+
+        return findings

--- a/packages/drift-engine/src/drift_engine/signals/dead_code_accumulation.py
+++ b/packages/drift-engine/src/drift_engine/signals/dead_code_accumulation.py
@@ -1,0 +1,675 @@
+"""Signal: Dead Code Accumulation (DCA).
+
+Detects exported functions and classes that are never imported anywhere
+else in the codebase, indicating potentially dead code.
+
+Dead code increases maintenance cost, confuses contributors, and can
+mask real issues by inflating code metrics.
+
+Known limitations (documented, not suppressed):
+- Dynamic imports (importlib, __import__) may cause false positives.
+- Framework entry-points (CLI commands, signal handlers, etc.) may be
+  flagged if they are only referenced in configuration files.
+
+Deterministic, AST-only, LLM-free.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import ClassVar
+
+from drift.config import DriftConfig
+from drift.models import (
+    FileHistory,
+    Finding,
+    ParseResult,
+    Severity,
+    SignalType,
+)
+from drift_engine.ingestion.test_detection import classify_file_context
+from drift_engine.signals._utils import (
+    _SUPPORTED_LANGUAGES,
+    is_library_finding_path,
+    is_likely_library_repo,
+    is_test_file,
+)
+from drift_engine.signals.base import BaseSignal, SignalCacheDependencySpec, register_signal
+
+# Files that typically re-export or serve as entry points.
+_SKIP_FILES: frozenset[str] = frozenset({
+    "__init__.py",
+    "__main__.py",
+    "conftest.py",
+    "setup.py",
+    "manage.py",
+    "wsgi.py",
+    "asgi.py",
+    "index.ts",
+    "index.tsx",
+    "index.js",
+    "index.jsx",
+})
+
+# Common names that are framework-invoked rather than explicitly imported.
+_FRAMEWORK_NAMES: frozenset[str] = frozenset({
+    "main",
+    "cli",
+    "app",
+    "create_app",
+    "setup",
+    "teardown",
+    "configure",
+    "register",
+    "migrate",
+    "upgrade",
+    "downgrade",
+})
+
+_ROUTE_DECORATOR_TOKENS: frozenset[str] = frozenset({
+    "get",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "options",
+    "head",
+    "route",
+    "websocket",
+    "api_view",
+})
+
+_SCHEMA_CLASS_SUFFIXES: tuple[str, ...] = (
+    "Schema",
+    "Model",
+    "DTO",
+    "Request",
+    "Response",
+)
+
+_APPLICATION_LAYOUT_TOKENS: frozenset[str] = frozenset({
+    "app",
+    "apps",
+    "backend",
+    "frontend",
+    "service",
+    "services",
+    "server",
+    "web",
+})
+
+_INTERNAL_LIBRARY_PATH_TOKENS: frozenset[str] = frozenset({
+    "internal",
+    "_internal",
+    "private",
+    "_private",
+    "impl",
+    "generated",
+})
+
+_SCRIPT_PATH_TOKENS: frozenset[str] = frozenset({
+    "scripts",
+    "tools",
+    "bin",
+    "workflows",
+})
+
+_RUNTIME_PLUGIN_CONFIG_ROOT_TOKENS: frozenset[str] = frozenset({
+    "extensions",
+    "plugins",
+})
+
+_RUNTIME_PLUGIN_CONFIG_BASENAMES: frozenset[str] = frozenset({
+    "config.ts",
+    "config.tsx",
+    "config.js",
+    "config.jsx",
+    "config.mjs",
+    "config.cjs",
+})
+
+_RUNTIME_PLUGIN_ENTRYPOINT_PATH_TOKENS: frozenset[str] = frozenset({
+    "components",
+    "component",
+    "plugin-sdk",
+    "plugin_sdk",
+    "sdk",
+})
+
+_RUNTIME_PLUGIN_ENTRYPOINT_BASENAMES: frozenset[str] = frozenset({
+    "components.ts",
+    "components.tsx",
+    "components.js",
+    "components.jsx",
+})
+
+_RUNTIME_PLUGIN_WORKSPACE_SOURCE_SUFFIXES: frozenset[str] = frozenset({
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".mts",
+    ".cts",
+    ".mjs",
+    ".cjs",
+})
+
+_PUBLISHED_PACKAGE_SOURCE_ROOTS: frozenset[str] = frozenset({"src", "lib"})
+
+
+def _relative_to_or_none(path: Path, base: Path) -> Path | None:
+    """Return *path* relative to *base* or None when not contained."""
+    try:
+        return path.relative_to(base)
+    except ValueError:
+        return None
+
+
+def _extract_package_root_candidates(file_path: Path) -> list[Path]:
+    """Extract packages/<name> root candidates from a file path."""
+    parts = file_path.parts
+    if len(parts) < 3:
+        return []
+
+    candidates: list[Path] = []
+    lowered_parts = [part.lower() for part in parts]
+    for idx, token in enumerate(lowered_parts[:-1]):
+        if token != "packages" or idx + 1 >= len(parts):
+            continue
+        candidates.append(Path(*parts[: idx + 2]))
+
+    return candidates
+
+
+def _discover_published_package_roots(parse_results: list[ParseResult]) -> dict[Path, str]:
+    """Return package roots with non-private npm package.json name metadata."""
+    package_roots: dict[Path, str] = {}
+    inspected_roots: set[Path] = set()
+
+    for pr in parse_results:
+        if pr.language not in _SUPPORTED_LANGUAGES:
+            continue
+
+        for package_root in _extract_package_root_candidates(pr.file_path):
+            if package_root in inspected_roots:
+                continue
+            inspected_roots.add(package_root)
+
+            package_json = package_root / "package.json"
+            if not package_json.is_file():
+                continue
+
+            try:
+                package_data = json.loads(package_json.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+
+            package_name = package_data.get("name")
+            is_private = package_data.get("private") is True
+            if not isinstance(package_name, str) or not package_name.strip() or is_private:
+                continue
+
+            package_roots[package_root] = package_name
+
+    return package_roots
+
+
+def _published_package_name_for_source(
+    file_path: Path,
+    published_package_roots: dict[Path, str],
+) -> str | None:
+    """Return npm package name when *file_path* belongs to a published package."""
+    suffix = file_path.suffix.lower()
+    if suffix not in _RUNTIME_PLUGIN_WORKSPACE_SOURCE_SUFFIXES:
+        return None
+
+    for package_root, package_name in published_package_roots.items():
+        rel_path = _relative_to_or_none(file_path, package_root)
+        if rel_path is None or not rel_path.parts:
+            continue
+        if rel_path.parts[0].lower() in _PUBLISHED_PACKAGE_SOURCE_ROOTS:
+            return package_name
+
+    return None
+
+
+def _is_testkit_contract_path(file_path: Path) -> bool:
+    """Return True for testkit contract modules consumed by downstream tests.
+
+    Files like `*.testkit.ts` or `*.testkit.js` commonly expose reusable
+    test contracts/harness APIs that are intentionally consumed outside the
+    local static import graph.
+    """
+    suffix = file_path.suffix.lower()
+    if suffix not in _RUNTIME_PLUGIN_WORKSPACE_SOURCE_SUFFIXES:
+        return False
+
+    file_name = file_path.name.lower()
+    return ".testkit." in file_name
+
+
+def _is_runtime_plugin_workspace_path(file_path: Path) -> bool:
+    """Return True for files inside extension/plugin workspaces.
+
+    In monorepos, these exports are often consumed by host runtime loaders
+    across package boundaries and can appear dead in static import-only views.
+    """
+    tokens = _path_tokens(file_path)
+    if len(tokens) < 3:
+        return False
+
+    for idx, token in enumerate(tokens[:-1]):
+        if token not in _RUNTIME_PLUGIN_CONFIG_ROOT_TOKENS:
+            continue
+        # Require at least one path segment after extensions/plugins.
+        if idx + 1 < len(tokens):
+            return True
+    return False
+
+
+def _is_runtime_plugin_workspace_source_file(file_path: Path) -> bool:
+    """Return True for JS/TS source files inside runtime plugin workspaces."""
+    if file_path.suffix.lower() not in _RUNTIME_PLUGIN_WORKSPACE_SOURCE_SUFFIXES:
+        return False
+    return _is_runtime_plugin_workspace_path(file_path)
+
+
+def _is_script_context_path(file_path: Path) -> bool:
+    """Return True for path contexts that are likely executable scripts."""
+    tokens = _path_tokens(file_path)
+    if not tokens:
+        return False
+
+    if len(tokens) >= 2 and tokens[0] == ".github" and tokens[1] == "workflows":
+        return True
+
+    return any(token in _SCRIPT_PATH_TOKENS for token in tokens)
+
+
+def _is_runtime_plugin_config_path(file_path: Path) -> bool:
+    """Return True for plugin/extension config modules often loaded dynamically."""
+    tokens = _path_tokens(file_path)
+    if len(tokens) < 3:
+        return False
+
+    if tokens[0] not in _RUNTIME_PLUGIN_CONFIG_ROOT_TOKENS:
+        return False
+
+    file_name = file_path.name.lower()
+    if file_name in _RUNTIME_PLUGIN_CONFIG_BASENAMES:
+        return True
+
+    return file_name.startswith("config-")
+
+
+def _is_runtime_plugin_entrypoint_path(file_path: Path) -> bool:
+    """Return True for plugin/extension entrypoint modules loaded indirectly."""
+    tokens = _path_tokens(file_path)
+    if len(tokens) < 3:
+        return False
+
+    if tokens[0] not in _RUNTIME_PLUGIN_CONFIG_ROOT_TOKENS:
+        return False
+
+    file_name = file_path.name.lower()
+    if file_name in _RUNTIME_PLUGIN_ENTRYPOINT_BASENAMES:
+        return True
+
+    return any(
+        token in _RUNTIME_PLUGIN_ENTRYPOINT_PATH_TOKENS for token in tokens
+    )
+
+
+def _path_tokens(file_path: Path) -> list[str]:
+    """Return lowercase path tokens for deterministic path heuristics."""
+    return [token for token in file_path.as_posix().lower().split("/") if token]
+
+
+def _has_application_layout(parse_results: list[ParseResult]) -> bool:
+    """Return True when parse results indicate a classic application layout."""
+    tokens: set[str] = set()
+    for pr in parse_results:
+        if pr.language not in _SUPPORTED_LANGUAGES:
+            continue
+        if is_test_file(pr.file_path):
+            continue
+        tokens.update(_path_tokens(pr.file_path))
+    return any(token in _APPLICATION_LAYOUT_TOKENS for token in tokens)
+
+
+def _discover_package_roots(parse_results: list[ParseResult]) -> set[str]:
+    """Discover top-level package roots from __init__.py files.
+
+    This targets library/framework repositories that expose symbols via
+    package modules (e.g. fastapi/applications.py) without requiring
+    internal imports for external API usage.
+    """
+    package_roots: set[str] = set()
+    for pr in parse_results:
+        if pr.language not in _SUPPORTED_LANGUAGES:
+            continue
+        if is_test_file(pr.file_path):
+            continue
+        if pr.file_path.name != "__init__.py":
+            continue
+
+        tokens = _path_tokens(pr.file_path)
+        if len(tokens) < 2:
+            continue
+
+        root = tokens[0]
+        if root in {"src", "lib", "packages", "tests", "test", "docs"}:
+            continue
+        package_roots.add(root)
+
+    return package_roots
+
+
+def _is_public_api_package_path(file_path: Path, package_roots: set[str]) -> bool:
+    """Return True for package-layout modules that likely expose public API."""
+    if not package_roots:
+        return False
+
+    tokens = _path_tokens(file_path)
+    if not tokens:
+        return False
+    if tokens[0] not in package_roots:
+        return False
+    return not any(token in _INTERNAL_LIBRARY_PATH_TOKENS for token in tokens)
+
+
+def _is_route_entrypoint_function(decorators: list[str]) -> bool:
+    """Return True when decorators indicate a framework route entry-point."""
+    for dec in decorators:
+        token = dec.split(".")[-1].lower()
+        if token in _ROUTE_DECORATOR_TOKENS:
+            return True
+    return False
+
+
+def _is_schema_like_class(name: str, bases: list[str]) -> bool:
+    """Return True for classes that likely represent API/Pydantic schemas."""
+    if name.endswith(_SCHEMA_CLASS_SUFFIXES):
+        return True
+
+    for base in bases:
+        base_token = base.split(".")[-1]
+        if base_token in {"BaseModel", "SQLModel", "Schema"}:
+            return True
+    return False
+
+
+def _is_public(name: str) -> bool:
+    """Return True if *name* is a public symbol (no leading underscore)."""
+    return not name.startswith("_")
+
+
+@register_signal
+class DeadCodeAccumulationSignal(BaseSignal):
+    """Detect exported symbols that are never imported elsewhere."""
+
+    cache_dependency_spec: ClassVar[SignalCacheDependencySpec] = SignalCacheDependencySpec(
+        scope="repo_wide",
+        include_languages=("python", "typescript", "javascript"),
+    )
+
+    @property
+    def signal_type(self) -> SignalType:
+        return SignalType.DEAD_CODE_ACCUMULATION
+
+    @property
+    def name(self) -> str:
+        return "Dead Code Accumulation"
+
+    def analyze(
+        self,
+        parse_results: list[ParseResult],
+        file_histories: dict[str, FileHistory],
+        config: DriftConfig,
+    ) -> list[Finding]:
+        ignore_re_exports = config.thresholds.dca_ignore_re_exports
+        handling = config.test_file_handling or "reduce_severity"
+        has_application_layout = _has_application_layout(parse_results)
+        package_roots = (
+            set() if has_application_layout else _discover_package_roots(parse_results)
+        )
+        library_repo = is_likely_library_repo(parse_results) or bool(package_roots)
+        published_package_roots = _discover_published_package_roots(parse_results)
+
+        # Phase 1: collect all exported (public) symbols per file
+        # symbol_name → list of (file_path, kind, start_line)
+        exported: dict[str, list[tuple[Path, str, int]]] = defaultdict(list)
+        route_entrypoint_files: set[Path] = set()
+
+        for pr in parse_results:
+            if pr.language not in _SUPPORTED_LANGUAGES:
+                continue
+            for fn in pr.functions:
+                if _is_route_entrypoint_function(fn.decorators):
+                    route_entrypoint_files.add(pr.file_path)
+                    break
+
+        for pr in parse_results:
+            if pr.language not in _SUPPORTED_LANGUAGES:
+                continue
+            if is_test_file(pr.file_path) and handling == "exclude":
+                continue
+            if pr.language == "python" and _is_script_context_path(pr.file_path):
+                # Script-like modules are typically executed, not imported.
+                continue
+
+            file_name = pr.file_path.name
+            if file_name in _SKIP_FILES and ignore_re_exports:
+                    continue
+
+            for fn in pr.functions:
+                if _is_route_entrypoint_function(fn.decorators):
+                    continue
+                if (
+                    pr.language in {"typescript", "javascript"}
+                    and not fn.is_exported
+                ):
+                    continue
+                if _is_public(fn.name) and fn.name not in _FRAMEWORK_NAMES:
+                    exported[fn.name].append(
+                        (pr.file_path, "function", fn.start_line)
+                    )
+
+            for cls in pr.classes:
+                if (
+                    pr.file_path in route_entrypoint_files
+                    and _is_schema_like_class(cls.name, cls.bases)
+                ):
+                    continue
+                if (
+                    pr.language in {"typescript", "javascript"}
+                    and not cls.is_exported
+                ):
+                    continue
+                if _is_public(cls.name) and cls.name not in _FRAMEWORK_NAMES:
+                    exported[cls.name].append(
+                        (pr.file_path, "class", cls.start_line)
+                    )
+
+        # Phase 2: collect all imported names across the entire codebase
+        imported_names: set[str] = set()
+        for pr in parse_results:
+            for imp in pr.imports:
+                for name in imp.imported_names:
+                    imported_names.add(name)
+                # Also count the module itself (from X import Y → Y is used)
+                # and dotted access patterns
+                parts = imp.imported_module.split(".")
+                for part in parts:
+                    imported_names.add(part)
+
+        # Phase 3: find symbols that are exported but never imported
+        findings: list[Finding] = []
+        # Group dead symbols by file for aggregate findings
+        dead_by_file: dict[Path, list[tuple[str, str, int]]] = defaultdict(list)
+        suppressed_public_api_by_file: dict[Path, list[tuple[str, str, int]]] = (
+            defaultdict(list)
+        )
+
+        for symbol_name, locations in exported.items():
+            if symbol_name in imported_names:
+                continue
+            for file_path, kind, start_line in locations:
+                if library_repo and _is_public_api_package_path(file_path, package_roots):
+                    suppressed_public_api_by_file[file_path].append(
+                        (symbol_name, kind, start_line)
+                    )
+                    continue
+                dead_by_file[file_path].append((symbol_name, kind, start_line))
+
+        for file_path, dead_symbols in dead_by_file.items():
+            if not dead_symbols:
+                continue
+
+            # Count total exports for this file
+            total_exports = sum(
+                1
+                for sym, locs in exported.items()
+                for fp, _, _ in locs
+                if fp == file_path
+            )
+
+            dead_count = len(dead_symbols)
+            dead_ratio = dead_count / max(1, total_exports)
+
+            # Only flag files with meaningful dead code accumulation
+            if dead_count < 2:
+                continue
+
+            score = round(min(1.0, dead_ratio * 0.8 + dead_count * 0.02), 3)
+            severity = Severity.HIGH if score >= 0.7 else Severity.MEDIUM
+            path_context = classify_file_context(file_path)
+            testkit_contract_heuristic_applied = False
+            if _is_testkit_contract_path(file_path):
+                score = round(score * 0.45, 3)
+                severity = Severity.LOW
+                testkit_contract_heuristic_applied = True
+            elif path_context == "test" and handling == "reduce_severity":
+                score = round(score * 0.45, 3)
+                severity = Severity.LOW
+
+            runtime_plugin_config_heuristic_applied = False
+            runtime_plugin_entrypoint_heuristic_applied = False
+            runtime_plugin_workspace_heuristic_applied = False
+            published_package_heuristic_applied = False
+            published_package_name: str | None = None
+            if (
+                path_context != "test"
+                and _is_runtime_plugin_config_path(file_path)
+            ):
+                # Plugin config modules are frequently loaded via runtime import()
+                # patterns and cannot be resolved reliably with static imports only.
+                score = round(min(0.69, score * 0.6), 3)
+                severity = Severity.MEDIUM
+                runtime_plugin_config_heuristic_applied = True
+            elif (
+                path_context != "test"
+                and _is_runtime_plugin_entrypoint_path(file_path)
+            ):
+                # Plugin entrypoint modules (components/plugin-sdk) are often
+                # consumed via host registries and dynamic framework wiring.
+                score = round(min(0.69, score * 0.6), 3)
+                severity = Severity.MEDIUM
+                runtime_plugin_entrypoint_heuristic_applied = True
+            elif (
+                path_context != "test"
+                and _is_runtime_plugin_workspace_source_file(file_path)
+            ):
+                # Workspace exports are commonly consumed via host runtime/plugin
+                # loader boundaries that static import graphs do not resolve.
+                score = round(min(0.39, score * 0.45), 3)
+                severity = Severity.LOW
+                runtime_plugin_workspace_heuristic_applied = True
+            elif path_context != "test":
+                published_package_name = _published_package_name_for_source(
+                    file_path,
+                    published_package_roots,
+                )
+                if published_package_name:
+                    # Published npm package exports are often consumed by
+                    # downstream users and can appear dead in monorepo-only
+                    # static import graphs.
+                    score = round(min(0.39, score * 0.45), 3)
+                    severity = Severity.LOW
+                    published_package_heuristic_applied = True
+
+            dead_names = [s[0] for s in dead_symbols[:10]]
+
+            # Use line of first dead symbol for SARIF region support (#88)
+            first_dead_line = dead_symbols[0][2] if dead_symbols[0][2] else None
+
+            findings.append(
+                Finding(
+                    signal_type=self.signal_type,
+                    severity=severity,
+                    score=score,
+                    title=(
+                        f"{dead_count} potentially unused exports "
+                        f"in {file_path.name}"
+                    ),
+                    description=(
+                        f"{file_path.as_posix()} exports {dead_count}/{total_exports} "
+                        f"public symbols that are never imported elsewhere: "
+                        f"{', '.join(dead_names)}"
+                        f"{'…' if dead_count > 10 else ''}. "
+                        f"Dead code increases maintenance cost and confuses "
+                        f"contributors."
+                    ),
+                    file_path=file_path,
+                    start_line=first_dead_line,
+                    fix=(
+                        f"Review and remove {dead_count} unused exports in "
+                        f"{file_path.name}: {', '.join(dead_names)}. "
+                        f"If they are framework entry-points or dynamically "
+                        f"loaded, mark with # drift:ignore or add to "
+                        f"exclude patterns."
+                    ),
+                    metadata={
+                        "dead_symbols": [
+                            {"name": s[0], "kind": s[1], "line": s[2]}
+                            for s in dead_symbols
+                        ],
+                        "dead_count": dead_count,
+                        "total_exports": total_exports,
+                        "dead_ratio": round(dead_ratio, 3),
+                        "library_context_candidate": (
+                            library_repo
+                            and (
+                                is_library_finding_path(file_path)
+                                or _is_public_api_package_path(
+                                    file_path, package_roots
+                                )
+                            )
+                        )
+                        or runtime_plugin_workspace_heuristic_applied,
+                        "runtime_plugin_config_heuristic_applied": (
+                            runtime_plugin_config_heuristic_applied
+                        ),
+                        "runtime_plugin_entrypoint_heuristic_applied": (
+                            runtime_plugin_entrypoint_heuristic_applied
+                        ),
+                        "runtime_plugin_workspace_heuristic_applied": (
+                            runtime_plugin_workspace_heuristic_applied
+                        ),
+                        "published_package_heuristic_applied": (
+                            published_package_heuristic_applied
+                        ),
+                        "published_package_name": published_package_name,
+                        "testkit_contract_heuristic_applied": (
+                            testkit_contract_heuristic_applied
+                        ),
+                        "finding_context": path_context,
+                    },
+                    finding_context=path_context,
+                    rule_id="dead_code_accumulation",
+                )
+            )
+
+        return findings

--- a/packages/drift-engine/src/drift_engine/signals/dependency_dag.py
+++ b/packages/drift-engine/src/drift_engine/signals/dependency_dag.py
@@ -1,0 +1,81 @@
+"""Signal dependency DAG utilities for deterministic scheduling."""
+
+from __future__ import annotations
+
+import threading
+from collections import defaultdict, deque
+
+from drift_engine.signals.base import BaseSignal
+
+_topo_cache: dict[frozenset[type[BaseSignal]], list[type[BaseSignal]]] = {}
+_topo_cache_lock = threading.Lock()
+
+
+def order_signal_classes_topologically(
+    classes: list[type[BaseSignal]],
+) -> list[type[BaseSignal]]:
+    """Return classes in dependency order while preserving stable fallback order.
+
+    Signals may declare dependencies via ``depends_on_signals`` containing
+    signal-type values. Unknown dependencies are ignored to keep legacy
+    behavior unchanged.
+    """
+    if len(classes) <= 1:
+        return classes
+
+    cache_key = frozenset(classes)
+    cached = _topo_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    by_signal_name: dict[str, type[BaseSignal]] = {}
+    index_by_class: dict[type[BaseSignal], int] = {}
+    for idx, cls in enumerate(classes):
+        index_by_class[cls] = idx
+        try:
+            instance = cls()
+            signal_name = str(instance.signal_type)
+            by_signal_name[signal_name] = cls
+        except Exception:
+            continue
+
+    adjacency: dict[type[BaseSignal], set[type[BaseSignal]]] = defaultdict(set)
+    indegree: dict[type[BaseSignal], int] = {cls: 0 for cls in classes}
+
+    for cls in classes:
+        deps = getattr(cls, "depends_on_signals", ()) or ()
+        for dep_name in deps:
+            dep_cls = by_signal_name.get(str(dep_name))
+            if dep_cls is None or dep_cls is cls:
+                continue
+            if cls in adjacency[dep_cls]:
+                continue
+            adjacency[dep_cls].add(cls)
+            indegree[cls] += 1
+
+    n = len(classes)
+    queue = deque(
+        sorted(
+            [c for c, d in indegree.items() if d == 0],
+            key=lambda c: index_by_class.get(c, n),
+        )
+    )
+    ordered: list[type[BaseSignal]] = []
+
+    while queue:
+        cls = queue.popleft()
+        ordered.append(cls)
+        for nxt in sorted(
+            adjacency.get(cls, ()),
+            key=lambda c: index_by_class.get(c, n),
+        ):
+            indegree[nxt] -= 1
+            if indegree[nxt] == 0:
+                queue.append(nxt)
+
+    if len(ordered) != len(classes):
+        # Cycle or unknown edge case: preserve previous deterministic order.
+        return classes
+    with _topo_cache_lock:
+        _topo_cache[cache_key] = ordered
+    return ordered

--- a/packages/drift-engine/src/drift_engine/signals/doc_impl_drift.py
+++ b/packages/drift-engine/src/drift_engine/signals/doc_impl_drift.py
@@ -1,0 +1,742 @@
+"""Signal 5: Doc-Implementation Drift (DIA).
+
+Detects divergence between architectural documentation (ADRs, README)
+and actual code implementation.
+
+v0.2 enhancements:
+- Markdown AST parsing via mistune instead of raw-text regex.
+- URL-segment blacklist eliminates false positives from badge/CI links.
+- Separate extraction per node type (links, code-blocks, prose).
+- Optional embedding-based claim validation.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+from drift.config import DriftConfig
+from drift.models import FileHistory, Finding, ParseResult, Severity, SignalType
+from drift_engine.signals._utils import is_library_finding_path, is_likely_library_repo
+from drift_engine.signals.base import BaseSignal, register_signal
+
+logger = logging.getLogger("drift.dia")
+
+
+# ---------------------------------------------------------------------------
+# URL / path segment blacklist – segments that look like directories but
+# belong to URLs (GitHub, CI badges, package registries, etc.)
+# ---------------------------------------------------------------------------
+
+_URL_PATH_SEGMENTS: set[str] = {
+    # GitHub / GitLab UI paths
+    "actions",
+    "badge",
+    "blob",
+    "tree",
+    "commit",
+    "commits",
+    "compare",
+    "pull",
+    "pulls",
+    "issues",
+    "releases",
+    "tags",
+    "raw",
+    "archive",
+    "wiki",
+    "settings",
+    "security",
+    "discussions",
+    "packages",
+    "milestones",
+    "labels",
+    "projects",
+    "graphs",
+    "network",
+    # CI/CD
+    "workflows",
+    "runs",
+    "jobs",
+    "steps",
+    "artifacts",
+    "pipelines",
+    # Package registries
+    "pypi",
+    "npmjs",
+    "registry",
+    "npm",
+    "dist",
+    "download",
+    # Web / URL generic
+    "http",
+    "https",
+    "www",
+    "com",
+    "org",
+    "io",
+    "dev",
+    "net",
+    "api",
+    "v1",
+    "v2",
+    "v3",
+    # Common markdown / text fragments
+    "e",
+    "g",
+    "i",
+    "eg",
+    "etc",
+    "img",
+    "svg",
+    "png",
+    "jpg",
+    "gif",
+    "ico",
+    "shields",
+    "codecov",
+    "coveralls",
+    "readthedocs",
+    # Common short REST/API path segments and prose words that appear
+    # in README examples but are not real directories
+    "auth",
+    "db",
+    "en",
+    "de",
+    "fr",
+    "es",
+    "ja",
+    "zh",
+    "pt",
+    "login",
+    "logout",
+    "signup",
+    "token",
+    "oauth",
+    "callback",
+    "webhook",
+    "graphql",
+    "json",
+    "xml",
+    "csv",
+    "html",
+    "css",
+    "js",
+    "ts",
+    "py",
+}
+
+
+# ---------------------------------------------------------------------------
+# Markdown AST helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_mistune():
+    """Lazy-import mistune; returns the module or None if unavailable."""
+    try:
+        import mistune  # noqa: PLC0415
+
+        return mistune
+    except ImportError:
+        return None
+
+
+_VERSION_SEGMENT_RE = re.compile(r"^(?:v\d+(?:[._-]\d+)*)$")
+
+# ---------------------------------------------------------------------------
+# URL stripping (P3: remove URLs before dir-ref extraction to avoid
+# extracting path segments from GitHub/registry links in plain text)
+# ---------------------------------------------------------------------------
+
+_URL_RE = re.compile(r"https?://\S+")
+
+
+def _strip_urls(text: str) -> str:
+    """Remove URLs from text to prevent extracting URL path segments."""
+    return _URL_RE.sub("", text)
+_DIRECTORY_CONTEXT_KEYWORDS: tuple[str, ...] = (
+    "directory",
+    "directories",
+    "folder",
+    "folders",
+    "path",
+    "paths",
+    "tree",
+    "layout",
+    "structure",
+    "module",
+    "modules",
+    "package",
+    "packages",
+    "architecture",
+    "component",
+    "components",
+)
+
+
+def _is_likely_proper_noun(name: str) -> bool:
+    """Heuristic for prose nouns that are unlikely to be repo directories."""
+    if not name:
+        return False
+    if not name[0].isupper():
+        return False
+    if name.isupper():
+        return False
+    if "_" in name:
+        return False
+    return not any(ch.isdigit() for ch in name)
+
+
+def _is_version_or_numeric_segment(name: str) -> bool:
+    """Return True for numeric/version-like fragments (v1/, 2024/, 20240315/)."""
+    if not name:
+        return False
+    if name.isdigit():
+        # years, dates, generic numeric URL/path segments
+        return len(name) >= 4
+    return _VERSION_SEGMENT_RE.match(name.lower()) is not None
+
+
+def _is_noise_dir_reference(name: str) -> bool:
+    """Return True if *name* is likely noise and should be ignored."""
+    if len(name) <= 2:
+        return True
+    if _is_url_segment(name):
+        return True
+    if _is_version_or_numeric_segment(name):
+        return True
+    return bool(_is_likely_proper_noun(name))
+
+
+def _has_directory_context(raw_text: str, match_start: int, match_end: int) -> bool:
+    """Return True when nearby prose indicates a structural directory claim."""
+    text = raw_text.lower()
+    window_start = max(0, match_start - 48)
+    window_end = min(len(text), match_end + 48)
+    window = text[window_start:window_end]
+    return any(keyword in window for keyword in _DIRECTORY_CONTEXT_KEYWORDS)
+
+
+def _extract_contextual_dir_refs(
+    raw_text: str,
+    *,
+    allow_without_context: bool = False,
+) -> set[str]:
+    """Extract directory refs while filtering prose slash-tokens without context."""
+    refs: set[str] = set()
+    # P3: strip URLs first so GitHub/registry path segments aren't extracted
+    cleaned_text = _strip_urls(raw_text)
+    for match in _PROSE_DIR_RE.finditer(cleaned_text):
+        ref = match.group("ref")
+        wrapped = bool(match.group("tick"))
+        if _is_noise_dir_reference(ref):
+            continue
+        if (
+            allow_without_context
+            or wrapped
+            or _has_directory_context(cleaned_text, match.start(), match.end())
+        ):
+            refs.add(ref)
+    return refs
+
+
+def _extract_dir_refs_from_ast(
+    markdown_text: str,
+    *,
+    trust_codespans: bool = False,
+) -> set[str]:
+    """Parse Markdown via mistune AST and extract directory-like references.
+
+    Only prose nodes are inspected; link URLs, code spans, and fenced
+    code blocks are skipped entirely (they are the main sources of false
+    positives from badge/CI links and code examples).
+
+    When *trust_codespans* is True, inline code spans are always extracted
+    regardless of surrounding keyword context (useful for ADR files where
+    codespans are architectural references by definition).
+
+    Falls back to a simple regex when mistune is not installed.
+    """
+    mistune = _get_mistune()
+    if mistune is None:
+        # Regex fallback — less precise, but functional without mistune
+        # Strip fenced code blocks (example code, not structure claims)
+        cleaned = re.sub(r"```[^`]*```", "", markdown_text, flags=re.DOTALL)
+        # Strip inline links [text](url) to avoid extracting URL segments
+        cleaned = re.sub(r"\[([^\]]*)\]\([^)]+\)", r"\1", cleaned)
+        return _extract_contextual_dir_refs(cleaned)
+
+    md = mistune.create_markdown(renderer="ast")
+    try:
+        tokens: list[dict[str, Any]] = md(markdown_text)  # type: ignore[assignment]
+    except Exception:
+        logger.debug("Failed to parse Markdown AST, falling back to empty refs")
+        return set()
+
+    refs: set[str] = set()
+    _walk_tokens(tokens, refs, trust_codespans=trust_codespans)
+    return refs
+
+
+_PROSE_DIR_RE = re.compile(r"(?P<tick>`)?(?P<ref>\w[\w\-]*)/(?!\w)(?P=tick)?")
+
+
+def _collect_sibling_text(children: list[dict[str, Any]]) -> str:
+    """Concatenate raw text from text-type children for context checks."""
+    parts: list[str] = []
+    for child in children:
+        if child.get("type") in ("text", "softbreak"):
+            raw = child.get("raw", child.get("text", ""))
+            if raw:
+                parts.append(raw)
+    return " ".join(parts)
+
+
+def _walk_tokens(
+    tokens: list[dict[str, Any]],
+    refs: set[str],
+    *,
+    sibling_context: str = "",
+    trust_codespans: bool = False,
+) -> None:
+    """Recursively walk mistune AST tokens collecting directory references."""
+    # Track context across sequential sibling tokens so that e.g.
+    # a paragraph "Project structure:" propagates to its following list.
+    running_ctx = sibling_context
+    for tok in tokens:
+        tok_type = tok.get("type", "")
+
+        # Skip link URLs entirely — they are the #1 source of FPs
+        if tok_type == "link":
+            # Still walk the link *text children* (they may mention real dirs)
+            children = tok.get("children")
+            if children:
+                _walk_tokens(
+                    children, refs, sibling_context=running_ctx, trust_codespans=trust_codespans
+                )
+            continue
+
+        # Skip images
+        if tok_type == "image":
+            continue
+
+        # Skip fenced code blocks — code examples are not structure claims.
+        if tok_type == "block_code":
+            continue
+
+        # For inline code spans — extract directory-like patterns only when
+        # the surrounding paragraph/heading text contains a directory keyword.
+        if tok_type == "codespan":
+            raw = tok.get("raw", tok.get("text", ""))
+            if raw:
+                if trust_codespans:
+                    has_ctx = True
+                else:
+                    ctx_lower = running_ctx.lower()
+                    has_ctx = any(
+                        kw in ctx_lower for kw in _DIRECTORY_CONTEXT_KEYWORDS
+                    )
+                refs.update(
+                    _extract_contextual_dir_refs(
+                        raw,
+                        allow_without_context=has_ctx,
+                    )
+                )
+            continue
+
+        # For paragraphs, headings, list items — check raw text of
+        # leaf children (text, softbreak, etc.)
+        raw = tok.get("raw", tok.get("text", ""))
+        if raw and tok_type in ("text", "paragraph", "heading"):
+            refs.update(_extract_contextual_dir_refs(raw))
+
+        # Recurse into children — for paragraphs/headings, build sibling
+        # context from text children so codespans can use it.
+        # Context is accumulated across siblings: a paragraph "Project
+        # structure:" propagates through a subsequent list to its items.
+        children = tok.get("children")
+        if children and isinstance(children, list):
+            if tok_type in ("paragraph", "heading"):
+                local = _collect_sibling_text(children)
+                ctx = (running_ctx + " " + local).strip() if local else running_ctx
+                running_ctx = ctx  # Propagate to following siblings
+            elif tok_type == "list_item":
+                # list_item children are paragraphs (not text nodes),
+                # pass through inherited context without overwriting.
+                ctx = running_ctx
+            else:
+                ctx = running_ctx
+            _walk_tokens(children, refs, sibling_context=ctx, trust_codespans=trust_codespans)
+
+
+def _is_url_segment(name: str) -> bool:
+    """Return True if *name* looks like a URL path component, not a directory."""
+    return name.lower() in _URL_PATH_SEGMENTS
+
+
+# ---------------------------------------------------------------------------
+# Container-prefix existence check (Phase B: CS-2 fix)
+# ---------------------------------------------------------------------------
+
+_CONTAINER_PREFIXES: frozenset[str] = frozenset(
+    {"src", "lib", "app", "pkg", "packages", "libs", "internal"}
+)
+
+
+def _ref_exists_in_repo(
+    repo_path: Path, ref: str, source_dirs: set[str]
+) -> bool:
+    """Check whether *ref* exists as a directory anywhere plausible in the repo."""
+    if (repo_path / ref).exists():
+        return True
+    if ref.lower() in {d.lower() for d in source_dirs}:
+        return True
+    # Check under known container prefixes (e.g. src/services/ for ref=services)
+    for prefix in _CONTAINER_PREFIXES:
+        container = repo_path / prefix
+        if container.is_dir() and (container / ref).is_dir():
+            return True
+    # P6: check with dotfile prefix (e.g. drift-cache → .drift-cache)
+    return (repo_path / f".{ref}").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# ADR status parsing (Phase C: CS-3 fix)
+# ---------------------------------------------------------------------------
+
+_SKIP_ADR_STATUSES: frozenset[str] = frozenset(
+    {"superseded", "deprecated", "rejected"}
+)
+
+_ADR_FRONTMATTER_STATUS_RE = re.compile(
+    r"^---\s*\n.*?^status:\s*(\S+)", re.MULTILINE | re.DOTALL
+)
+_ADR_MADR_STATUS_RE = re.compile(
+    r"^##\s+Status\s*\n+\s*(\w+)", re.MULTILINE
+)
+
+
+def _extract_adr_status(text: str) -> str | None:
+    """Extract ADR status from YAML frontmatter or MADR heading format."""
+    m = _ADR_FRONTMATTER_STATUS_RE.search(text)
+    if m:
+        return m.group(1).lower().strip()
+    m = _ADR_MADR_STATUS_RE.search(text)
+    if m:
+        return m.group(1).lower().strip()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Signal
+# ---------------------------------------------------------------------------
+
+
+@register_signal
+class DocImplDriftSignal(BaseSignal):
+    """Detect drift between documentation claims and code reality.
+
+    Checks:
+    1. README or docs/ presence.
+    2. Modules referenced in README that don't exist in the codebase.
+    3. Top-level source directories with no README mention.
+    4. (Optional, with embeddings) Semantic claim validation.
+    """
+
+    # -----------------------------------------------------------------------
+    # P1: Auxiliary directories — conventional project dirs that don't need
+    # explicit README documentation (tests, scripts, benchmarks, etc.)
+    # -----------------------------------------------------------------------
+    _AUXILIARY_DIRS: frozenset[str] = frozenset({
+        "tests", "test",
+        "scripts", "script",
+        "benchmarks", "benchmark",
+        "tools", "tool",
+        "examples", "example",
+        "samples", "sample",
+        "demos", "demo",
+        "fixtures",
+        "docs", "doc",
+        # Build / CI artifacts and working directories
+        "artifacts", "work_artifacts",
+    })
+
+    incremental_scope = "file_local"
+
+    @property
+    def signal_type(self) -> SignalType:
+        return SignalType.DOC_IMPL_DRIFT
+
+    @property
+    def name(self) -> str:
+        return "Doc-Implementation Drift"
+
+    def analyze(
+        self,
+        parse_results: list[ParseResult],
+        file_histories: dict[str, FileHistory],
+        config: DriftConfig,
+    ) -> list[Finding]:
+        findings: list[Finding] = []
+        library_repo = is_likely_library_repo(parse_results)
+        repo_path = self.repo_path
+        if repo_path is None:
+            return findings
+
+        # Locate README
+        readme_path = self._find_readme()
+        is_bootstrap_repo = len(parse_results) <= 1 or (
+            bool(parse_results)
+            and all(result.file_path.name == "__init__.py" for result in parse_results)
+        )
+        if readme_path is None:
+            if is_bootstrap_repo:
+                return findings
+            findings.append(
+                Finding(
+                    signal_type=self.signal_type,
+                    severity=Severity.MEDIUM,
+                    score=0.4,
+                    title="No README found",
+                    description=(
+                        "The repository has no README file. "
+                        "A README is essential for architectural context."
+                    ),
+                    fix=(
+                            "Create a README.md at the repository root with"
+                            " an architecture overview."
+                    ),
+                )
+            )
+            return findings
+
+        readme_text = readme_path.read_text(encoding="utf-8", errors="replace")
+
+        # Collect actual top-level source directories that contain .py files
+        source_dirs = self._source_directories(parse_results)
+
+        # Collect actual import graph modules for ADR validation
+        actual_imports = self._actual_import_modules(parse_results)
+
+        # Extract directory names using Markdown AST parsing
+        referenced_dirs = _extract_dir_refs_from_ast(readme_text)
+
+        # Check for phantom references: mentioned in README but absent
+        for ref in sorted(referenced_dirs):
+            if _is_noise_dir_reference(ref):
+                continue
+
+            if not _ref_exists_in_repo(repo_path, ref, source_dirs):
+                findings.append(
+                    Finding(
+                        signal_type=self.signal_type,
+                        severity=Severity.LOW,
+                        score=0.3,
+                        title=f"README references missing directory: {ref}/",
+                        description=(
+                            f"README mentions '{ref}/' but no such directory"
+                            f" exists. Documentation may be outdated."
+                        ),
+                        file_path=readme_path.relative_to(repo_path),
+                            fix=(
+                                f"Remove '{ref}/' from README.md or create the"
+                                f" directory."
+                            ),
+                        metadata={
+                            "referenced_dir": ref,
+                            "library_context_candidate": library_repo
+                            and is_library_finding_path(readme_path.relative_to(repo_path)),
+                        },
+                    )
+                )
+
+        # Check for undocumented source directories
+        if source_dirs:
+            readme_lower = readme_text.lower()
+            effective_aux = self._AUXILIARY_DIRS | frozenset(
+                d.lower() for d in getattr(getattr(config, "dia", None), "extra_auxiliary_dirs", [])
+            )
+            for src_dir in sorted(source_dirs):
+                # P1: skip conventional auxiliary directories
+                if src_dir.lower() in effective_aux:
+                    continue
+                if src_dir.lower() not in readme_lower:
+                    findings.append(
+                        Finding(
+                            signal_type=self.signal_type,
+                            severity=Severity.INFO,
+                            score=0.15,
+                            title=(
+                                f"Source directory not mentioned in README:"
+                                f" {src_dir}/"
+                            ),
+                            description=(
+                                f"Directory '{src_dir}/' contains source files "
+                                f"but is not mentioned in README."
+                            ),
+                            file_path=Path(src_dir),
+                            fix=(
+                                    f"Add a section for '{src_dir}/' to README.md"
+                                    f" with a short description of the module."
+                            ),
+                            metadata={
+                                "undocumented_dir": src_dir,
+                                "library_context_candidate": library_repo
+                                and is_library_finding_path(Path(src_dir)),
+                            },
+                        )
+                    )
+
+        # ── ADR / architecture doc scanning ──
+        findings.extend(
+            self._scan_adr_files(
+                parse_results,
+                source_dirs,
+                actual_imports,
+                library_repo=library_repo,
+            )
+        )
+
+        return findings
+
+    def _scan_adr_files(
+        self,
+        parse_results: list[ParseResult],
+        source_dirs: set[str],
+        actual_imports: set[str],
+        *,
+        library_repo: bool,
+    ) -> list[Finding]:
+        """Scan ADR and architecture docs for stale directory claims."""
+        findings: list[Finding] = []
+        adr_dirs = self._discover_adr_dirs()
+        repo_path = self.repo_path
+        if repo_path is None:
+            return findings
+
+        for adr_dir in adr_dirs:
+            if not adr_dir.is_dir():
+                continue
+            for md_file in sorted(adr_dir.glob("*.md")):
+                try:
+                    text = md_file.read_text(encoding="utf-8", errors="replace")
+                except OSError:
+                    continue
+                status = _extract_adr_status(text)
+                if status in _SKIP_ADR_STATUSES:
+                    continue
+                refs = _extract_dir_refs_from_ast(text, trust_codespans=True)
+                for ref in sorted(refs):
+                    if _is_noise_dir_reference(ref):
+                        continue
+                    if not _ref_exists_in_repo(repo_path, ref, source_dirs):
+                        try:
+                            rel_path = md_file.relative_to(repo_path)
+                        except ValueError:
+                            rel_path = md_file
+                        findings.append(
+                            Finding(
+                                signal_type=self.signal_type,
+                                severity=Severity.MEDIUM,
+                                score=0.4,
+                                title=(
+                                    f"ADR references missing directory:"
+                                    f" {ref}/"
+                                ),
+                                description=(
+                                    f"{rel_path} mentions '{ref}/' but no"
+                                    f" such directory exists."
+                                ),
+                                file_path=rel_path,
+                                fix=(
+                                        f"Update {rel_path.name}: remove or correct"
+                                        f" the stale '{ref}/' reference."
+                                ),
+                                metadata={
+                                    "referenced_dir": ref,
+                                    "adr_file": rel_path.as_posix(),
+                                    "library_context_candidate": library_repo
+                                    and is_library_finding_path(rel_path),
+                                },
+                            )
+                        )
+
+        return findings
+
+    def _discover_adr_dirs(self) -> list[Path]:
+        """Discover likely ADR/architecture-doc directories in the repository."""
+        repo_path = self.repo_path
+        if repo_path is None:
+            return []
+        seed_dirs = [
+            repo_path / "docs" / "adr",
+            repo_path / "docs" / "adrs",
+            repo_path / "adr",
+            repo_path / "docs" / "architecture",
+            repo_path / "doc" / "adr",
+            repo_path / "doc" / "adrs",
+            repo_path / "doc" / "decisions",
+            repo_path / "architecture" / "decisions",
+        ]
+        roots_to_scan = [
+            repo_path,
+            repo_path / "docs",
+            repo_path / "doc",
+            repo_path / "architecture",
+        ]
+        discovered: set[Path] = set()
+        for path in seed_dirs:
+            if path.is_dir():
+                discovered.add(path)
+
+        for root in roots_to_scan:
+            if not root.is_dir():
+                continue
+            try:
+                children = list(root.iterdir())
+            except OSError:
+                continue
+            for child in children:
+                if not child.is_dir():
+                    continue
+                name = child.name.lower()
+                if name in {"adr", "adrs", "decisions", "architecture"} or (
+                    "adr" in name and len(name) <= 20
+                ):
+                    discovered.add(child)
+
+        return sorted(discovered)
+
+    def _find_readme(self) -> Path | None:
+        repo_path = self.repo_path
+        if repo_path is None:
+            return None
+        for name in ("README.md", "README.rst", "README.txt", "README"):
+            p = repo_path / name
+            if p.exists():
+                return p
+        return None
+
+    def _source_directories(self, parse_results: list[ParseResult]) -> set[str]:
+        """Return top-level directory names that contain parsed source files."""
+        dirs: set[str] = set()
+        for pr in parse_results:
+            parts = pr.file_path.parts
+            if len(parts) > 1:
+                dirs.add(parts[0])
+        return dirs
+
+    def _actual_import_modules(
+        self, parse_results: list[ParseResult]
+    ) -> set[str]:
+        """Return the set of top-level module names actually imported."""
+        modules: set[str] = set()
+        for pr in parse_results:
+            for imp in pr.imports:
+                top = imp.imported_module.split(".")[0]
+                if top:
+                    modules.add(top)
+        return modules

--- a/packages/drift-engine/src/drift_engine/signals/exception_contract_drift.py
+++ b/packages/drift-engine/src/drift_engine/signals/exception_contract_drift.py
@@ -1,0 +1,549 @@
+"""Signal 13: Exception Contract Drift (ECM).
+
+Detects public functions whose exception profile changed across
+recent commits while their signature (name + parameter count) remained
+stable.  This is a proxy for *contract drift* (ADR-008 Phase 3):
+callers depend on the exception contract, and silent changes break
+that implicit agreement.
+
+MVP implementation: uses ``git show`` to retrieve the previous version
+of each file, then compares per-function exception profiles via AST
+inspection.  Gracefully skips files that cannot be retrieved (e.g.
+shallow clones, new files, binary files).
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import subprocess
+from collections import defaultdict
+from pathlib import Path, PurePosixPath
+
+from drift.config import DriftConfig
+from drift.models import (
+    FileHistory,
+    Finding,
+    ParseResult,
+    Severity,
+    SignalType,
+)
+from drift_engine.signals._ts_support import ts_node_text, ts_parse_source, ts_walk
+from drift_engine.signals._utils import (
+    _SUPPORTED_LANGUAGES,
+    _TS_LANGUAGES,
+)
+from drift_engine.signals.base import BaseSignal, register_signal
+
+logger = logging.getLogger("drift")
+
+# ---------------------------------------------------------------------------
+# AST helpers — exception profile extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_exception_profile(func_node: ast.FunctionDef | ast.AsyncFunctionDef) -> dict:
+    """Extract the exception profile of a function AST node.
+
+    Returns a dict with:
+      - raise_types: sorted list of exception type names raised
+      - handler_types: sorted list of exception type names caught
+      - has_bare_except: bool
+      - has_bare_raise: bool (raise without argument)
+    """
+    raise_types: set[str] = set()
+    handler_types: set[str] = set()
+    has_bare_except = False
+    has_bare_raise = False
+
+    for node in ast.walk(func_node):
+        if isinstance(node, ast.Raise):
+            if node.exc is None:
+                has_bare_raise = True
+            elif isinstance(node.exc, ast.Call):
+                if isinstance(node.exc.func, ast.Name):
+                    raise_types.add(node.exc.func.id)
+                elif isinstance(node.exc, ast.Attribute):
+                    raise_types.add(node.exc.attr)
+            elif isinstance(node.exc, ast.Name):
+                raise_types.add(node.exc.id)
+
+        if isinstance(node, ast.ExceptHandler):
+            if node.type is None:
+                has_bare_except = True
+            elif isinstance(node.type, ast.Name):
+                handler_types.add(node.type.id)
+            elif isinstance(node.type, ast.Tuple):
+                for elt in node.type.elts:
+                    if isinstance(elt, ast.Name):
+                        handler_types.add(elt.id)
+
+    return {
+        "raise_types": sorted(raise_types),
+        "handler_types": sorted(handler_types),
+        "has_bare_except": has_bare_except,
+        "has_bare_raise": has_bare_raise,
+    }
+
+
+def _extract_functions_from_source(source: str) -> dict[str, dict]:
+    """Parse Python source and return {func_name: {param_count, profile}} for public functions."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return dict()
+
+    functions: dict[str, dict] = {}
+    for node in ast.iter_child_nodes(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        name = node.name
+        if name.startswith("_"):
+            continue
+        param_count = len(node.args.args) + len(node.args.posonlyargs) + len(node.args.kwonlyargs)
+        profile = _extract_exception_profile(node)
+        functions[name] = {
+            "param_count": param_count,
+            "profile": profile,
+        }
+    return functions
+
+
+# ---------------------------------------------------------------------------
+# Tree-sitter helpers — TS/JS exception profile extraction
+# ---------------------------------------------------------------------------
+
+
+def _ts_extract_exception_profile(func_node: object, src: bytes) -> dict:
+    """Extract exception profile from a tree-sitter function node."""
+    raise_types: set[str] = set()
+    handler_types: set[str] = set()
+    has_bare_except = False
+    has_bare_raise = False
+
+    for node in ts_walk(func_node):
+        if node.type == "throw_statement":
+            # throw; (bare) vs throw new ErrorType(...)
+            children = [c for c in node.children if c.type not in ("throw", ";")]
+            if not children:
+                has_bare_raise = True
+            else:
+                expr = children[0]
+                if expr.type == "new_expression":
+                    constructor = expr.child_by_field_name("constructor")
+                    if constructor:
+                        raise_types.add(ts_node_text(constructor, src))
+                elif expr.type == "identifier":
+                    raise_types.add(ts_node_text(expr, src))
+
+        if node.type == "catch_clause":
+            param = node.child_by_field_name("parameter")
+            if param is None:
+                has_bare_except = True
+            else:
+                type_ann = next(
+                    (c for c in node.children if c.type == "type_annotation"),
+                    None,
+                )
+                if type_ann:
+                    handler_types.add(
+                        ts_node_text(type_ann, src).lstrip(": ").strip()
+                    )
+                else:
+                    has_bare_except = True  # untyped → catches everything
+
+    return {
+        "raise_types": sorted(raise_types),
+        "handler_types": sorted(handler_types),
+        "has_bare_except": has_bare_except,
+        "has_bare_raise": has_bare_raise,
+    }
+
+
+def _ts_extract_functions_from_source(
+    source: str, language: str,
+) -> dict[str, dict]:
+    """Parse TS/JS source via tree-sitter and return {func_name: {param_count, profile}}."""
+    result = ts_parse_source(source, language)
+    if result is None:
+        _out: dict[str, dict] = {}
+        return _out
+
+    root, src = result
+    functions: dict[str, dict] = {}
+
+    for node in ts_walk(root):
+        name: str | None = None
+        func_node = None
+
+        if node.type == "function_declaration" or node.type == "method_definition":
+            name_nd = node.child_by_field_name("name")
+            name = ts_node_text(name_nd, src) if name_nd else None
+            func_node = node
+
+        elif node.type in ("lexical_declaration", "variable_declaration"):
+            for decl in node.children:
+                if decl.type != "variable_declarator":
+                    continue
+                name_nd = decl.child_by_field_name("name")
+                value_nd = decl.child_by_field_name("value")
+                if (
+                    name_nd
+                    and value_nd
+                    and value_nd.type == "arrow_function"
+                ):
+                    name = ts_node_text(name_nd, src)
+                    func_node = value_nd
+                    break
+
+        if name is None or func_node is None:
+            continue
+        if name.startswith("_"):
+            continue
+
+        # Count parameters
+        params_node = func_node.child_by_field_name("parameters")
+        param_count = 0
+        if params_node:
+            param_count = sum(
+                1 for c in params_node.children
+                if c.type in (
+                    "required_parameter", "optional_parameter",
+                    "rest_parameter", "identifier",
+                )
+            )
+
+        profile = _ts_extract_exception_profile(func_node, src)
+        functions[name] = {
+            "param_count": param_count,
+            "profile": profile,
+        }
+
+    return functions
+
+
+def _profiles_diverged(old_profile: dict, new_profile: dict) -> bool:
+    """Return True if two exception profiles meaningfully diverge."""
+    if old_profile == new_profile:
+        return False
+
+    # Check raise types changed
+    if old_profile["raise_types"] != new_profile["raise_types"]:
+        return True
+    # Check handler types changed
+    if old_profile["handler_types"] != new_profile["handler_types"]:
+        return True
+    # Check bare except added or removed
+    if old_profile["has_bare_except"] != new_profile["has_bare_except"]:
+        return True
+    # Check bare raise added or removed
+    return bool(old_profile["has_bare_raise"] != new_profile["has_bare_raise"])
+
+
+def _git_show_file(repo_path: Path, ref: str, file_posix: str) -> str | None:
+    """Retrieve file content at a given git ref. Returns None on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "show", f"{ref}:{file_posix}"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=str(repo_path),
+            check=True,
+            timeout=10,
+            stdin=subprocess.DEVNULL,
+        )
+        return result.stdout
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
+def _git_show_files_batch(
+    repo_path: Path, ref: str, file_posix_list: list[str],
+) -> dict[str, str | None]:
+    """Retrieve multiple file contents at *ref* in a single git process.
+
+    Uses ``git cat-file --batch`` which is dramatically faster than
+    spawning one ``git show`` subprocess per file (O(1) process instead
+    of O(n)).  Falls back per-file on parse error.
+    """
+    if not file_posix_list:
+        _out: dict[str, str | None] = {}
+        return _out
+
+    results: dict[str, str | None] = {}
+    queries = [f"{ref}:{fp}" for fp in file_posix_list]
+    stdin_data = "\n".join(queries) + "\n"
+
+    try:
+        proc = subprocess.run(
+            ["git", "cat-file", "--batch"],
+            input=stdin_data.encode(),
+            capture_output=True,
+            cwd=str(repo_path),
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        # Fallback: individual calls
+        for fp in file_posix_list:
+            results[fp] = _git_show_file(repo_path, ref, fp)
+        return results
+
+    # Parse batch output: each object is
+    #   <sha> blob <size>\n<content>\n   (on success)
+    #   <query> missing\n                (on miss)
+    raw = proc.stdout
+    offset = 0
+    for fp in file_posix_list:
+        if offset >= len(raw):
+            results[fp] = None
+            continue
+
+        # Find the header line end
+        newline_pos = raw.find(b"\n", offset)
+        if newline_pos == -1:
+            results[fp] = None
+            continue
+
+        header = raw[offset:newline_pos]
+        if header.endswith(b"missing"):
+            results[fp] = None
+            offset = newline_pos + 1
+            continue
+
+        # Parse "<sha> blob <size>"
+        parts = header.split()
+        if len(parts) < 3:
+            results[fp] = None
+            offset = newline_pos + 1
+            continue
+
+        try:
+            blob_size = int(parts[2])
+        except (ValueError, IndexError):
+            results[fp] = None
+            offset = newline_pos + 1
+            continue
+
+        content_start = newline_pos + 1
+        content_end = content_start + blob_size
+        if content_end > len(raw):
+            results[fp] = None
+            break
+
+        try:
+            results[fp] = raw[content_start:content_end].decode("utf-8", errors="replace")
+        except Exception:
+            results[fp] = None
+
+        # Skip past content + trailing newline
+        offset = content_end + 1
+
+    # Fill any remaining files not covered by the batch response
+    for fp in file_posix_list:
+        if fp not in results:
+            results[fp] = None
+
+    return results
+
+
+def _effective_candidate_limit(candidate_count: int, configured_max: int) -> int:
+    """Return an adaptive ECM candidate cap for large repositories.
+
+    ``configured_max`` remains the floor for small/medium repositories. For very
+    large candidate sets we widen the sample window to avoid overfitting on a
+    tiny hot-file subset.
+    """
+    if candidate_count <= configured_max:
+        return candidate_count
+
+    adaptive = max(configured_max, min(300, candidate_count // 20))
+    return min(candidate_count, adaptive)
+
+
+@register_signal
+class ExceptionContractDriftSignal(BaseSignal):
+    """Detect public functions with changed exception profiles."""
+
+    incremental_scope = "git_dependent"
+
+    @property
+    def signal_type(self) -> SignalType:
+        return SignalType.EXCEPTION_CONTRACT_DRIFT
+
+    @property
+    def name(self) -> str:
+        return "Exception Contract Drift"
+
+    def analyze(
+        self,
+        parse_results: list[ParseResult],
+        file_histories: dict[str, FileHistory],
+        config: DriftConfig,
+    ) -> list[Finding]:
+        max_files = config.thresholds.ecm_max_files
+        lookback = config.thresholds.ecm_lookback_commits
+        repo_path = self._repo_path
+        findings: list[Finding] = []
+
+        if repo_path is None:
+            return findings
+
+        # Only analyse files with supported languages that have git history
+        candidates: list[ParseResult] = []
+        for pr in parse_results:
+            if pr.language not in _SUPPORTED_LANGUAGES:
+                continue
+            posix = pr.file_path.as_posix()
+            hist = file_histories.get(posix)
+            if hist is None or hist.total_commits < 2:
+                continue
+            candidates.append(pr)
+
+        if not candidates:
+            return findings
+
+        # Respect performance guardrail with adaptive widening on very large repos.
+        candidate_limit = _effective_candidate_limit(len(candidates), max_files)
+        if len(candidates) > candidate_limit:
+            candidates = sorted(
+                candidates,
+                key=lambda pr: file_histories.get(
+                    pr.file_path.as_posix(), FileHistory(path=pr.file_path)
+                ).total_commits,
+                reverse=True,
+            )[:candidate_limit]
+
+        # Determine comparison ref — use first available lookback commit
+        ref = f"HEAD~{min(lookback, 5)}"
+
+        candidate_posix = [pr.file_path.as_posix() for pr in candidates]
+        if len(candidate_posix) == 1:
+            only_path = candidate_posix[0]
+            old_sources = {only_path: _git_show_file(repo_path, ref, only_path)}
+        else:
+            # Batch-fetch old file contents in a single git process for larger sets.
+            old_sources = _git_show_files_batch(repo_path, ref, candidate_posix)
+
+        # Group divergences by module
+        module_divergences: dict[str, list[tuple[ParseResult, str, dict, dict]]] = defaultdict(list)
+
+        for pr in candidates:
+            posix = pr.file_path.as_posix()
+
+            # Get current source
+            try:
+                current_source = (repo_path / pr.file_path).read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+
+            # Get old source from batch result
+            old_source = old_sources.get(posix)
+            if old_source is None:
+                continue
+
+            if pr.language in _TS_LANGUAGES:
+                current_funcs = _ts_extract_functions_from_source(
+                    current_source, pr.language,
+                )
+                old_funcs = _ts_extract_functions_from_source(
+                    old_source, pr.language,
+                )
+            else:
+                current_funcs = _extract_functions_from_source(current_source)
+                old_funcs = _extract_functions_from_source(old_source)
+
+            if not current_funcs or not old_funcs:
+                continue
+
+            for func_name, current_info in current_funcs.items():
+                old_info = old_funcs.get(func_name)
+                if old_info is None:
+                    continue  # new function — no contract to compare
+
+                # Signature must be stable (same param count)
+                if current_info["param_count"] != old_info["param_count"]:
+                    continue  # signature changed — intentional refactor
+
+                if _profiles_diverged(old_info["profile"], current_info["profile"]):
+                    module_key = PurePosixPath(pr.file_path.parent).as_posix()
+                    module_divergences[module_key].append(
+                        (pr, func_name, old_info["profile"], current_info["profile"])
+                    )
+
+        # Emit findings per module
+        for module_key, divergences in module_divergences.items():
+            if len(divergences) < 1:
+                continue
+
+            # Score: fraction of checked functions that diverged
+            all_checked: set[str] = set()
+            for pr_item in candidates:
+                if PurePosixPath(pr_item.file_path.parent).as_posix() == module_key:
+                    try:
+                        src = (repo_path / pr_item.file_path).read_text(encoding="utf-8")
+                        if pr_item.language in _TS_LANGUAGES:
+                            all_checked.update(
+                                _ts_extract_functions_from_source(
+                                    src, pr_item.language,
+                                ).keys()
+                            )
+                        else:
+                            all_checked.update(
+                                _extract_functions_from_source(src).keys()
+                            )
+                    except (OSError, UnicodeDecodeError):
+                        pass
+
+            ratio = len(divergences) / max(1, len(all_checked))
+            score = min(1.0, ratio * 2)  # scale: 50% diverged → 1.0
+
+            func_names = [d[1] for d in divergences]
+            first_pr = divergences[0][0]
+            first_old = divergences[0][2]
+            first_new = divergences[0][3]
+
+            severity = Severity.HIGH if score >= 0.6 else Severity.MEDIUM
+
+            findings.append(
+                Finding(
+                    signal_type=self.signal_type,
+                    severity=severity,
+                    score=round(score, 3),
+                    title=(
+                        f"Exception contract drift in {module_key}/ "
+                        f"({len(divergences)} function(s))"
+                    ),
+                    description=(
+                        f"In module '{module_key}/', {len(divergences)} public "
+                        f"function(s) changed their exception profile while "
+                        f"keeping a stable signature: {', '.join(func_names[:5])}. "
+                        f"Example: {func_names[0]}() — "
+                        f"raises {first_old.get('raise_types', [])} -> "
+                        f"{first_new.get('raise_types', [])}, "
+                        f"catches {first_old.get('handler_types', [])} -> "
+                        f"{first_new.get('handler_types', [])}."
+                    ),
+                    file_path=first_pr.file_path,
+                    start_line=None,
+                    end_line=None,
+                    related_files=[
+                        d[0].file_path for d in divergences[1:]
+                    ],
+                    fix=(
+                        f"Review exception handling changes in "
+                        f"{', '.join(func_names[:3])}. If the change is "
+                        f"intentional, update callers and documentation. "
+                        f"If accidental, restore the original exception contract."
+                    ),
+                    metadata={
+                        "diverged_functions": func_names,
+                        "divergence_count": len(divergences),
+                        "module_function_count": len(all_checked),
+                        "comparison_ref": ref,
+                    },
+                )
+            )
+
+        return findings

--- a/packages/drift-engine/src/drift_engine/signals/explainability_deficit.py
+++ b/packages/drift-engine/src/drift_engine/signals/explainability_deficit.py
@@ -1,0 +1,432 @@
+"""Signal 4: Explainability Deficit Score (EDS).
+
+Detects functions with high complexity but insufficient documentation,
+test coverage indicators, or commit rationale — especially when
+AI-attributed, indicating "accepted without understanding."
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from drift.config import DriftConfig
+from drift.models import (
+    FileHistory,
+    Finding,
+    FunctionInfo,
+    ParseResult,
+    Severity,
+    SignalType,
+)
+from drift_engine.ingestion.test_detection import classify_file_context
+from drift_engine.signals.base import BaseSignal, register_signal
+
+# Defaults (overridden by config.thresholds)
+HIGH_COMPLEXITY = 10
+MEDIUM_COMPLEXITY = 5
+
+
+def _has_self_documenting_ts_signature(func: FunctionInfo) -> bool:
+    """Return True when TS/TSX signatures already communicate intent well."""
+    if func.language not in ("typescript", "tsx") or not func.parameters:
+        return False
+
+    # Treat signatures as self-documenting only when parameter types are
+    # explicitly declared and not dominated by generic `any` annotations.
+    for parameter in func.parameters:
+        lowered = parameter.lower()
+        if ":" not in parameter:
+            return False
+        if "any" in lowered:
+            return False
+
+    return True
+
+
+def _is_ts_ui_implementation_context(func: FunctionInfo) -> bool:
+    """Return True for TS/TSX paths or names that suggest internal UI wiring."""
+    if func.language not in ("typescript", "tsx"):
+        return False
+
+    file_posix = func.file_path.as_posix().lower()
+    path_markers = (
+        "/web/",
+        "/ui/",
+        "/views/",
+        "/view/",
+        "/dom/",
+        "/components/",
+        "/component/",
+        "app.ts",
+        "app.tsx",
+        "ui-render",
+        "render",
+        "binding",
+        "wizard",
+    )
+    if any(marker in file_posix for marker in path_markers):
+        return True
+
+    function_name = func.name.lower()
+    return function_name.startswith(("render", "bind", "refresh", "mount", "hydrate"))
+
+
+def _is_ts_js_family(language: str) -> bool:
+    return language in ("typescript", "tsx", "javascript", "jsx")
+
+
+def _ts_test_file_candidates(file_path: Path) -> set[Path]:
+    """Return common colocated test file candidates for TS/JS source files."""
+    suffix = file_path.suffix
+    stem = file_path.stem
+    parent = file_path.parent
+
+    candidates = {
+        parent / f"{stem}.test{suffix}",
+        parent / f"{stem}.spec{suffix}",
+        parent / "__tests__" / f"{stem}.test{suffix}",
+        parent / "__tests__" / f"{stem}.spec{suffix}",
+    }
+
+    parts = file_path.parts
+    if "src" in parts:
+        src_index = parts.index("src")
+        rel_after_src = Path(*parts[src_index + 1 :]) if src_index + 1 < len(parts) else Path()
+        tests_root = Path(*parts[:src_index], "tests")
+        tests_base = tests_root / rel_after_src.parent
+        candidates.update(
+            {
+                tests_base / f"{stem}.test{suffix}",
+                tests_base / f"{stem}.spec{suffix}",
+                tests_base / "__tests__" / f"{stem}.test{suffix}",
+                tests_base / "__tests__" / f"{stem}.spec{suffix}",
+            }
+        )
+
+    return candidates
+
+
+def _has_mapped_ts_test_file(
+    file_path: Path,
+    repo_path: Path | None,
+    known_test_paths: set[str],
+) -> bool | None:
+    """Return TS/JS test evidence from path mapping.
+
+    Returns:
+    - True: matching test file was found
+    - False: mapping checked with filesystem access and no test file exists
+    - None: mapping could not be verified (e.g. missing repo_path)
+    """
+    candidates = _ts_test_file_candidates(file_path)
+    candidate_posix = {candidate.as_posix().lower() for candidate in candidates}
+    if any(candidate in known_test_paths for candidate in candidate_posix):
+        return True
+
+    if repo_path is None:
+        return None
+
+    return any((repo_path / candidate).is_file() for candidate in candidates)
+
+
+def _explanation_score(
+    func: FunctionInfo,
+    has_test: bool | None,
+    *,
+    self_documenting_signature: bool = False,
+) -> float:
+    """Calculate how well-explained a function is (0.0=unexplained, 1.0=well-explained)."""
+    evidence = 0.0
+    max_evidence = 4.0 if has_test is not None else 2.5
+
+    if func.has_docstring:
+        evidence += 1.0
+    elif self_documenting_signature:
+        # In TS/TSX, typed signatures often provide the core API explanation.
+        evidence += 1.0
+
+    if has_test is True:
+        evidence += 1.5
+
+    # Decorators suggest framework integration (router, property, etc.)
+    if func.decorators:
+        evidence += 0.5
+
+    # Return type annotation suggests intentional design
+    if func.return_type:
+        evidence += 1.0
+    elif self_documenting_signature:
+        # TS frequently relies on inferred return types from typed parameters/body.
+        evidence += 0.5
+
+    return min(1.0, evidence / max_evidence)
+
+
+@register_signal
+class ExplainabilityDeficitSignal(BaseSignal):
+    """Detect complex functions lacking documentation and tests."""
+
+    incremental_scope = "file_local"
+
+    @property
+    def signal_type(self) -> SignalType:
+        return SignalType.EXPLAINABILITY_DEFICIT
+
+    @property
+    def name(self) -> str:
+        return "Explainability Deficit"
+
+    def analyze(
+        self,
+        parse_results: list[ParseResult],
+        file_histories: dict[str, FileHistory],
+        config: DriftConfig,
+    ) -> list[Finding]:
+        """Flag functions with high cyclomatic complexity but no docstring.
+
+        Thresholds from config: min_function_loc and min_complexity.
+        Test files and functions whose name appears as a test target are excluded.
+        """
+        all_functions: dict[str, FunctionInfo] = {}
+        test_targets: set[str] = set()
+        known_test_paths: set[str] = set()
+        ts_test_mapping_cache: dict[str, bool | None] = {}
+
+        for pr in parse_results:
+            if classify_file_context(pr.file_path) == "test":
+                known_test_paths.add(pr.file_path.as_posix().lower())
+            for fn in pr.functions:
+                all_functions[f"{fn.file_path}:{fn.name}"] = fn
+
+                file_posix = fn.file_path.as_posix().lower()
+                is_test_file = (
+                    "test" in file_posix
+                    or file_posix.endswith(".spec.ts")
+                    or file_posix.endswith(".spec.tsx")
+                )
+
+                # Heuristic: functions in test files suggest tests for other functions
+                if is_test_file:
+                    # Python: test_foo → foo, test_handle_payment → handle_payment
+                    target_name = fn.name.removeprefix("test_")
+                    test_targets.add(target_name)
+                    # Also handle class.method style
+                    if "." in fn.name:
+                        _, method = fn.name.rsplit(".", 1)
+                        test_targets.add(method.removeprefix("test_"))
+
+                    # Decorator-aware: pytest.mark.parametrize hints at
+                    # thorough testing of the target function
+                    for dec in fn.decorators:
+                        if "parametrize" in dec or "fixture" in dec:
+                            test_targets.add(target_name)
+                            break
+
+                    # setUp/tearDown style (unittest)
+                    if fn.name in ("setUp", "tearDown", "setUpClass"):
+                        # Mark all functions in the same file as tested
+                        for other in pr.functions:
+                            if not other.name.startswith("test_"):
+                                test_targets.add(other.name)
+
+                # TS/JS test patterns: describe("Foo", ...), it("should ...", ...)
+                # Functions named it/test/describe inside test files hint at testing
+                if (
+                    fn.language in ("typescript", "tsx", "javascript", "jsx")
+                    and is_test_file
+                    and fn.name
+                    not in (
+                        "describe",
+                        "it",
+                        "test",
+                        "beforeEach",
+                        "afterEach",
+                        "beforeAll",
+                        "afterAll",
+                    )
+                ):
+                    # All non-test-framework functions in spec files
+                    # mark the subjects they exercise as "tested"
+                    test_targets.add(fn.name)
+
+        # Resolve thresholds from config
+        min_complexity = MEDIUM_COMPLEXITY
+        min_func_loc = 10
+        if hasattr(config, "thresholds"):
+            min_complexity = config.thresholds.min_complexity
+            min_func_loc = config.thresholds.min_function_loc
+
+        findings: list[Finding] = []
+        handling = config.test_file_handling or "reduce_severity"
+
+        for _key, func in all_functions.items():
+            # Skip test files and trivial functions
+            path_context = classify_file_context(func.file_path)
+            if path_context == "test" and handling == "exclude":
+                continue
+            # Primary gate: cyclomatic complexity (better proxy for
+            # "needs explanation" than raw LOC)
+            if func.complexity < min_complexity:
+                continue
+            # Secondary gate: skip very short functions even if complex
+            if func.loc < min_func_loc:
+                continue
+
+            # Skip __init__ methods – the class docstring covers their intent
+            base_name = func.name.split(".")[-1] if "." in func.name else func.name
+            if base_name == "__init__":
+                continue
+
+            # Check if there's a corresponding test
+            has_test: bool | None = base_name in test_targets
+            if not has_test and _is_ts_js_family(func.language):
+                file_key = func.file_path.as_posix().lower()
+                mapped_has_test = ts_test_mapping_cache.get(file_key)
+                if mapped_has_test is None and file_key not in ts_test_mapping_cache:
+                    mapped_has_test = _has_mapped_ts_test_file(
+                        func.file_path,
+                        self.repo_path,
+                        known_test_paths,
+                    )
+                    ts_test_mapping_cache[file_key] = mapped_has_test
+                else:
+                    mapped_has_test = ts_test_mapping_cache.get(file_key)
+
+                if mapped_has_test is True:
+                    has_test = True
+                elif mapped_has_test is None:
+                    has_test = None
+            self_documenting_signature = _has_self_documenting_ts_signature(func)
+
+            explanation = _explanation_score(
+                func,
+                has_test,
+                self_documenting_signature=self_documenting_signature,
+            )
+            deficit = 1.0 - explanation
+
+            # Weight by complexity
+            complexity_factor = min(1.0, func.complexity / 20)
+            weighted_score = deficit * complexity_factor
+
+            # Dampen severity for short/simple functions (#151):
+            # Functions with low LOC are less likely to hide critical debt.
+            loc_factor = min(1.0, func.loc / 30)
+            # Private functions (underscore-prefixed) are less critical
+            # for external consumers to understand.
+            is_private = base_name.startswith("_")
+            visibility_factor = 0.7 if is_private else 1.0
+            # Combine complexity-weighted deficit with LOC and visibility.
+            weighted_score = weighted_score * (0.7 + 0.3 * loc_factor) * visibility_factor
+            if self_documenting_signature:
+                # Reduce false positives for typed TS/TSX signatures where JSDoc is optional.
+                weighted_score *= 0.75
+            if path_context == "test" and handling == "reduce_severity":
+                weighted_score *= 0.5
+
+            # Check AI attribution and defect correlation for this file (ADR-048)
+            fpath_str = func.file_path.as_posix()
+            history = file_histories.get(fpath_str)
+            ai_related = history.ai_attributed_commits > 0 if history else False
+            defect_correlated = history is not None and history.defect_correlated_commits > 0
+
+            # Raise threshold for private functions — reduce noise on internal helpers.
+            # Defect-correlated files always keep the lower threshold (actionable).
+            min_threshold = 0.45 if is_private else 0.30
+            if defect_correlated:
+                min_threshold = min(min_threshold, 0.30)
+            # ADR-077: further raise threshold for private micro-helpers (LOC < 40,
+            # no defect correlation) — avoids CXS→EDS oscillation in fix-loops
+            # where freshly-extracted private helpers trigger EDS before docs are added.
+            if is_private and func.loc < 40 and not defect_correlated:
+                min_threshold = max(min_threshold, 0.55)
+            if weighted_score < min_threshold:
+                continue
+
+            severity = Severity.INFO
+            if weighted_score >= 0.7:
+                severity = Severity.HIGH
+            elif weighted_score >= 0.5:
+                severity = Severity.MEDIUM
+            elif weighted_score >= 0.3:
+                severity = Severity.LOW
+
+            if path_context == "test" and handling == "reduce_severity":
+                severity = Severity.LOW
+
+            ts_ui_high_cap_applied = False
+            is_ts_internal_impl = (
+                func.language in ("typescript", "tsx")
+                and not func.is_exported
+                and not func.has_docstring
+                and not self_documenting_signature
+            )
+            if severity == Severity.HIGH and (
+                is_ts_internal_impl or _is_ts_ui_implementation_context(func)
+            ):
+                # Issue #258: avoid escalating internal TS UI wiring code to HIGH
+                # solely due to missing JSDoc when complexity is large.
+                severity = Severity.MEDIUM
+                weighted_score = min(weighted_score, 0.69)
+                ts_ui_high_cap_applied = True
+
+            desc_parts = [
+                f"Complexity: {func.complexity}, LOC: {func.loc}.",
+            ]
+            if not func.has_docstring and not self_documenting_signature:
+                desc_parts.append("No docstring.")
+            if has_test is False:
+                desc_parts.append("No corresponding test found.")
+            elif has_test is None:
+                desc_parts.append("Test coverage status unknown.")
+            if not func.return_type and not self_documenting_signature:
+                desc_parts.append("No return type annotation.")
+            if ai_related:
+                desc_parts.append("File contains AI-attributed commits.")
+
+            missing = []
+            if not func.has_docstring and not self_documenting_signature:
+                missing.append("Docstring")
+            if has_test is False:
+                missing.append("Tests")
+            if not func.return_type and not self_documenting_signature:
+                missing.append("Return-Type")
+            fix = (
+                (
+                    f"Function {func.name} (complexity {func.complexity}): "
+                    f"add {', '.join(missing)}."
+                )
+                if missing
+                else None
+            )
+
+            findings.append(
+                Finding(
+                    signal_type=self.signal_type,
+                    severity=severity,
+                    score=round(weighted_score, 3),
+                    title=f"Unexplained complexity: {func.name}",
+                    description=" ".join(desc_parts),
+                    file_path=func.file_path,
+                    start_line=func.start_line,
+                    end_line=func.end_line,
+                    ai_attributed=ai_related,
+                    fix=fix,
+                    metadata={
+                        "function_name": func.name,
+                        "complexity": func.complexity,
+                        "loc": func.loc,
+                        "has_docstring": func.has_docstring,
+                        "has_test": has_test,
+                        "has_test_unknown": has_test is None,
+                        "has_return_type": func.return_type is not None,
+                        "self_documenting_signature": self_documenting_signature,
+                        "explanation_score": round(explanation, 3),
+                        "ts_ui_high_cap_applied": ts_ui_high_cap_applied,
+                        "finding_context": path_context,
+                    },
+                    finding_context=path_context,
+                )
+            )
+
+        return findings

--- a/packages/drift-engine/src/drift_engine/signals/fan_out_explosion.py
+++ b/packages/drift-engine/src/drift_engine/signals/fan_out_explosion.py
@@ -1,0 +1,139 @@
+"""Signal: Fan-Out Explosion (FOE).
+
+Detects files that import an excessive number of unique modules,
+indicating emerging "god files" that act as central coupling hubs.
+
+High fan-out makes a file fragile: any change in its many dependencies
+can break it, and the file itself becomes hard to reason about in
+isolation.
+
+Deterministic, AST-only, LLM-free.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from drift.config import DriftConfig
+from drift.models import (
+    FileHistory,
+    Finding,
+    ParseResult,
+    Severity,
+    SignalType,
+)
+from drift_engine.signals._utils import _SUPPORTED_LANGUAGES, is_test_file
+from drift_engine.signals.base import BaseSignal, register_signal
+
+# Index / barrel files that re-export are expected to have high fan-out.
+_INDEX_NAMES: frozenset[str] = frozenset(
+    {"__init__.py", "index.ts", "index.tsx", "index.js", "index.jsx"},
+)
+
+
+def _dependency_key(imported_module: str) -> str:
+    """Collapse import paths to a stable dependency identity for fan-out counting."""
+    module = (imported_module or "").strip()
+    if not module:
+        return ""
+
+    # Keep relative imports file-granular; they model local coupling directly.
+    if module.startswith("."):
+        return module
+
+    # JS/TS package sub-path imports (for example vendor/pkg/subpath)
+    # should count as one SDK/package dependency.
+    if "/" in module:
+        parts = [part for part in module.split("/") if part]
+        if not parts:
+            return ""
+        if module.startswith("@") and len(parts) >= 2:
+            return "/".join(parts[:2])
+        if len(parts) >= 2:
+            return "/".join(parts[:2])
+        return parts[0]
+
+    # Python imports: count by top-level package/module.
+    return module.split(".")[0]
+
+
+@register_signal
+class FanOutExplosionSignal(BaseSignal):
+    """Detect files with an excessive number of unique imports."""
+
+    incremental_scope = "file_local"
+
+    @property
+    def signal_type(self) -> SignalType:
+        return SignalType.FAN_OUT_EXPLOSION
+
+    @property
+    def name(self) -> str:
+        return "Fan-Out Explosion"
+
+    def analyze(
+        self,
+        parse_results: list[ParseResult],
+        file_histories: dict[str, FileHistory],
+        config: DriftConfig,
+    ) -> list[Finding]:
+        threshold = config.thresholds.foe_max_imports
+        findings: list[Finding] = []
+
+        for pr in parse_results:
+            if pr.language not in _SUPPORTED_LANGUAGES:
+                continue
+            if is_test_file(pr.file_path):
+                continue
+            if pr.file_path.name in _INDEX_NAMES:
+                continue
+
+            # Count unique imported dependencies
+            unique_modules: set[str] = set()
+            for imp in pr.imports:
+                dep = _dependency_key(imp.imported_module)
+                if dep:
+                    unique_modules.add(dep)
+
+            count = len(unique_modules)
+            if count <= threshold:
+                continue
+
+            overshoot = count - threshold
+            score = round(min(1.0, 0.3 + overshoot * 0.035), 3)
+            severity = Severity.HIGH if score >= 0.7 else Severity.MEDIUM
+
+            related = [
+                Path(mod.replace(".", "/"))
+                for mod in sorted(unique_modules)[:10]
+            ]
+
+            findings.append(
+                Finding(
+                    signal_type=self.signal_type,
+                    severity=severity,
+                    score=score,
+                    title=f"Fan-out explosion in {pr.file_path.name}",
+                    description=(
+                        f"{pr.file_path.as_posix()} imports {count} unique modules "
+                        f"(threshold: {threshold}). High fan-out indicates "
+                        f"a coupling hub that is fragile to upstream changes."
+                    ),
+                    file_path=pr.file_path,
+                    related_files=related,
+                    fix=(
+                        f"Reduce import fan-out of {pr.file_path.name} "
+                        f"(currently {count}, threshold {threshold}): "
+                        f"split responsibilities into focused modules, "
+                        f"introduce a facade or mediator to consolidate deps."
+                    ),
+                    metadata={
+                        "unique_import_count": count,
+                        "threshold": threshold,
+                        "top_imports": sorted(unique_modules)[:20],
+                    },
+                    rule_id="fan_out_explosion",
+                )
+            )
+
+        return findings

--- a/packages/drift-engine/src/drift_engine/signals/guard_clause_deficit.py
+++ b/packages/drift-engine/src/drift_engine/signals/guard_clause_deficit.py
@@ -1,0 +1,460 @@
+"""Signal 10: Guard Clause Deficit (GCD).
+
+Detects modules where public, non-trivial functions uniformly lack
+guard clauses — isinstance checks, assert statements, if-raise/return
+patterns that validate inputs early.
+
+Also detects functions with excessive nesting depth (> configurable
+threshold), which is a related structural problem: deep nesting makes
+control flow hard to follow and often indicates missing early returns.
+
+This is a proxy for *consistent wrongness* (EPISTEMICS §2): when every
+function blindly trusts its inputs, the codebase is structurally
+vulnerable to a single incorrect assumption propagating everywhere.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from drift.config import DriftConfig
+from drift.models import (
+    FileHistory,
+    Finding,
+    FunctionInfo,
+    ParseResult,
+    Severity,
+    SignalType,
+)
+from drift_engine.signals._ts_support import ts_node_text, ts_parse_source, ts_walk
+from drift_engine.signals._utils import (
+    _SUPPORTED_LANGUAGES,
+    _TS_LANGUAGES,
+    is_test_file,
+)
+from drift_engine.signals.base import BaseSignal, register_signal
+
+# Decorators that indicate input validation is handled externally.
+_VALIDATION_DECORATORS: frozenset[str] = frozenset({
+    "validate",
+    "validator",
+    "validates",
+    "check_params",
+    "validate_arguments",
+    "validate_call",
+    "typechecked",
+    "beartype",
+    "enforce_types",
+})
+
+
+def _has_guard(stmt: ast.stmt, param_names: set[str]) -> bool:
+    """Return True if *stmt* is a guard clause referencing a parameter."""
+    # isinstance(param, ...)
+    if (
+        isinstance(stmt, ast.Expr)
+        and isinstance(stmt.value, ast.Call)
+        and isinstance(stmt.value.func, ast.Name)
+        and stmt.value.func.id == "isinstance"
+        and stmt.value.args
+        and isinstance(stmt.value.args[0], ast.Name)
+    ):
+        return stmt.value.args[0].id in param_names
+    # assert <param> ...
+    if isinstance(stmt, ast.Assert):
+        return _references_param(stmt.test, param_names)
+    # if <cond>: raise/return (single-branch guard)
+    if (
+        isinstance(stmt, ast.If)
+        and not stmt.orelse
+        and any(isinstance(s, ast.Raise | ast.Return) for s in stmt.body)
+    ):
+        return _references_param(stmt.test, param_names)
+    return False
+
+
+def _references_param(node: ast.expr, param_names: set[str]) -> bool:
+    """Return True if the expression references at least one parameter name."""
+    return any(
+        isinstance(child, ast.Name) and child.id in param_names
+        for child in ast.walk(node)
+    )
+
+
+def _function_is_guarded(source: str, func_info: FunctionInfo, param_names: set[str]) -> bool:
+    """Parse function body and check first 50% of statements for guards."""
+    # Check for validation decorators first
+    for dec in func_info.decorators:
+        dec_lower = dec.lower()
+        if any(vd in dec_lower for vd in _VALIDATION_DECORATORS):
+            return True
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return True  # benefit of doubt
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        body = node.body
+        if not body:
+            return True
+        check_count = max(1, len(body) * 50 // 100)
+        return any(_has_guard(stmt, param_names) for stmt in body[:check_count])
+    return True  # no function found — benefit of doubt
+
+
+# ── Nesting depth detection ──────────────────────────────────────
+
+_NESTING_STMTS: frozenset[type] = frozenset({
+    ast.If, ast.For, ast.While, ast.With,
+    ast.AsyncFor, ast.AsyncWith, ast.Try,
+    ast.ExceptHandler,
+})
+
+
+def _max_nesting_depth(stmts: list[ast.stmt], depth: int = 0) -> int:
+    """Recursively compute the maximum nesting depth of statements."""
+    max_depth = depth
+    for stmt in stmts:
+        if isinstance(stmt, tuple(_NESTING_STMTS)):
+            for attr in ("body", "orelse", "finalbody", "handlers"):
+                children = getattr(stmt, attr, None)
+                if isinstance(children, list) and children:
+                    child_depth = _max_nesting_depth(children, depth + 1)
+                    max_depth = max(max_depth, child_depth)
+        elif isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            # Nested function — don't count its body against parent depth
+            pass
+        else:
+            for attr in ("body", "orelse", "finalbody", "handlers"):
+                children = getattr(stmt, attr, None)
+                if isinstance(children, list) and children:
+                    child_depth = _max_nesting_depth(children, depth)
+                    max_depth = max(max_depth, child_depth)
+    return max_depth
+
+
+def _function_max_nesting(source: str) -> int | None:
+    """Return the maximum nesting depth of the first function in *source*."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return _max_nesting_depth(node.body)
+    return None
+
+
+# ── TypeScript guard detection (tree-sitter) ─────────────────────
+
+
+def _ts_references_param(node: Any, param_names: set[str], src: bytes) -> bool:
+    """Return True if tree-sitter *node* references at least one parameter."""
+    return any(
+        child.type == "identifier" and ts_node_text(child, src) in param_names
+        for child in ts_walk(node)
+    )
+
+
+def _ts_is_guard_stmt(stmt: Any, param_names: set[str], src: bytes) -> bool:
+    """Return True if *stmt* is a single-branch guard referencing a parameter."""
+    if stmt.type != "if_statement":
+        return False
+    # Must be single-branch (no else)
+    if any(c.type == "else_clause" for c in stmt.children):
+        return False
+    # Consequence must contain throw or return
+    consequence = stmt.child_by_field_name("consequence")
+    if not consequence:
+        return False
+    if not any(
+        c.type in ("throw_statement", "return_statement") for c in ts_walk(consequence)
+    ):
+        return False
+    # Condition must reference a parameter
+    condition = stmt.child_by_field_name("condition")
+    if not condition:
+        return False
+    return _ts_references_param(condition, param_names, src)
+
+
+def _ts_find_body_stmts(root: Any) -> list[Any]:
+    """Return the top-level statements from the first function body."""
+    for node in ts_walk(root):
+        if node.type in (
+            "function_declaration",
+            "method_definition",
+            "arrow_function",
+        ):
+            body = node.child_by_field_name("body")
+            if body and body.type == "statement_block":
+                return [c for c in body.children if c.type not in ("{", "}")]
+    return []
+
+
+_TS_WEAK_TYPES_RE = re.compile(r"\b(any|unknown|object|null|undefined)\b")
+
+
+def _ts_params_are_strongly_typed(source: str, param_names: set[str]) -> bool:
+    """Return True when all params have explicit non-weak TS types."""
+    if not param_names:
+        return False
+
+    header = source.split("{", 1)[0]
+    for param in param_names:
+        canonical = param.strip()
+        if canonical.startswith("..."):
+            canonical = canonical[3:]
+        canonical = canonical.removesuffix("?")
+        if not canonical or canonical in {"this"}:
+            continue
+
+        match = re.search(rf"\b{re.escape(canonical)}\s*\??\s*:\s*([^,\)\n]+)", header)
+        if not match:
+            return False
+
+        type_text = match.group(1).strip().lower()
+        if _TS_WEAK_TYPES_RE.search(type_text):
+            return False
+
+    return True
+
+
+def _ts_has_control_flow(body_stmts: list[Any]) -> bool:
+    """Return True when the function body contains imperative control flow."""
+    flow_nodes = {
+        "if_statement",
+        "switch_statement",
+        "for_statement",
+        "for_in_statement",
+        "while_statement",
+        "do_statement",
+        "try_statement",
+        "catch_clause",
+    }
+    return any(node.type in flow_nodes for stmt in body_stmts for node in ts_walk(stmt))
+
+
+def _ts_is_single_delegation_wrapper(
+    body_stmts: list[Any], param_names: set[str], src: bytes,
+) -> bool:
+    """Return True for one-statement call-through wrappers."""
+    if len(body_stmts) != 1:
+        return False
+
+    stmt = body_stmts[0]
+    if stmt.type not in {"return_statement", "expression_statement"}:
+        return False
+
+    has_call = any(node.type == "call_expression" for node in ts_walk(stmt))
+    if not has_call:
+        return False
+
+    # Wrappers should forward inputs; hardcoded call-throughs are not considered guards.
+    return _ts_references_param(stmt, param_names, src)
+
+
+def _ts_function_is_guarded(
+    source: str, func_info: FunctionInfo, param_names: set[str], language: str,
+) -> bool:
+    """Parse TS function body via tree-sitter and check for guard clauses."""
+    for dec in func_info.decorators:
+        dec_lower = dec.lower()
+        if any(vd in dec_lower for vd in _VALIDATION_DECORATORS):
+            return True
+
+    result = ts_parse_source(source, language)
+    if result is None:
+        return True  # benefit of doubt (tree-sitter unavailable)
+
+    root, src = result
+    body_stmts = _ts_find_body_stmts(root)
+    if not body_stmts:
+        return True
+
+    if _ts_is_single_delegation_wrapper(body_stmts, param_names, src):
+        return True
+
+    if _ts_params_are_strongly_typed(source, param_names) and not _ts_has_control_flow(body_stmts):
+        return True
+
+    check_count = max(1, len(body_stmts) * 50 // 100)
+    return any(
+        _ts_is_guard_stmt(stmt, param_names, src)
+        for stmt in body_stmts[:check_count]
+    )
+
+
+@register_signal
+class GuardClauseDeficitSignal(BaseSignal):
+    """Detect modules with uniformly unguarded public functions."""
+
+    incremental_scope = "file_local"
+
+    @property
+    def signal_type(self) -> SignalType:
+        return SignalType.GUARD_CLAUSE_DEFICIT
+
+    @property
+    def name(self) -> str:
+        return "Guard Clause Deficit"
+
+    def analyze(
+        self,
+        parse_results: list[ParseResult],
+        file_histories: dict[str, FileHistory],
+        config: DriftConfig,
+    ) -> list[Finding]:
+        min_public = config.thresholds.gcd_min_public_functions
+        max_nesting = config.thresholds.gcd_max_nesting_depth
+
+        # Group qualifying functions by module directory
+        module_funcs: dict[str, list[tuple[FunctionInfo, ParseResult]]] = {}
+
+        for pr in parse_results:
+            if pr.language not in _SUPPORTED_LANGUAGES:
+                continue
+            if is_test_file(pr.file_path):
+                continue
+            if pr.file_path.name in (
+                "__init__.py", "index.ts", "index.tsx", "index.js", "index.jsx",
+            ):
+                continue
+
+            for fn in pr.functions:
+                if fn.name.startswith("_"):
+                    continue
+                if len(fn.parameters) < 2:
+                    continue
+                if fn.complexity < 5:
+                    continue
+
+                module_key = PurePosixPath(pr.file_path.parent).as_posix()
+                module_funcs.setdefault(module_key, []).append((fn, pr))
+
+        findings: list[Finding] = []
+
+        for module_key, func_list in module_funcs.items():
+            if len(func_list) < min_public:
+                continue
+
+            guarded = 0
+            total_complexity = 0
+
+            for fn, pr in func_list:
+                param_names = set(fn.parameters)
+                # Read source for the specific function
+                source = _read_function_source(pr.file_path, fn, self._repo_path)
+                if source is None:
+                    guarded += 1  # benefit of doubt
+                    continue
+
+                if pr.language in _TS_LANGUAGES:
+                    is_guarded = _ts_function_is_guarded(
+                        source, fn, param_names, pr.language,
+                    )
+                else:
+                    is_guarded = _function_is_guarded(source, fn, param_names)
+
+                if is_guarded:
+                    guarded += 1
+                else:
+                    total_complexity += fn.complexity
+
+                # ── Nesting depth check (Python only, only when unguarded) ──
+                if not is_guarded and pr.language == "python":
+                    depth = _function_max_nesting(source)
+                    if depth is not None and depth > max_nesting:
+                        nesting_score = round(
+                            min(1.0, 0.3 + (depth - max_nesting) * 0.15), 3,
+                        )
+                        findings.append(
+                            Finding(
+                                signal_type=self.signal_type,
+                                severity=Severity.MEDIUM if nesting_score < 0.6 else Severity.HIGH,
+                                score=nesting_score,
+                                title=f"Deep nesting in {fn.name}()",
+                                description=(
+                                    f"Function '{fn.name}' in {pr.file_path.as_posix()} has "
+                                    f"nesting depth {depth} (threshold: {max_nesting}). "
+                                    f"Deep nesting makes control flow hard to follow."
+                                ),
+                                file_path=pr.file_path,
+                                start_line=fn.start_line,
+                                end_line=fn.end_line,
+                                fix=(
+                                    f"Reduce nesting in '{fn.name}' (depth {depth}, "
+                                    f"threshold {max_nesting}): use early returns, "
+                                    f"extract nested blocks into helpers, or "
+                                    f"invert conditions."
+                                ),
+                                metadata={
+                                    "nesting_depth": depth,
+                                    "threshold": max_nesting,
+                                    "function_name": fn.name,
+                                },
+                                rule_id="deep_nesting",
+                            )
+                        )
+
+            total = len(func_list)
+            guarded_ratio = guarded / total
+
+            if guarded_ratio >= 0.15:
+                continue
+
+            unguarded = total - guarded
+            mean_complexity = total_complexity / max(1, unguarded)
+            score = round(min(1.0, (1.0 - guarded_ratio) * mean_complexity / 20), 3)
+
+            severity = Severity.HIGH if score >= 0.7 else Severity.MEDIUM
+
+            findings.append(
+                Finding(
+                    signal_type=self.signal_type,
+                    severity=severity,
+                    score=score,
+                    title=f"Guard clause deficit in {module_key}/",
+                    description=(
+                        f"{unguarded}/{total} public functions lack guard "
+                        f"clauses (guarded ratio {guarded_ratio:.1%}, "
+                        f"mean unguarded complexity {mean_complexity:.1f})."
+                    ),
+                    file_path=Path(module_key),
+                    fix=(
+                        f"Add guard clauses to {unguarded}/{total} unguarded functions in "
+                        f"{module_key}/ (mean complexity {mean_complexity:.1f}): "
+                        f"isinstance checks, None guards, or assert statements."
+                    ),
+                    metadata={
+                        "total_qualifying": total,
+                        "guarded_count": guarded,
+                        "guarded_ratio": guarded_ratio,
+                        "mean_unguarded_complexity": mean_complexity,
+                    },
+                )
+            )
+
+        return findings
+
+
+def _read_function_source(
+    file_path: Path, fn: FunctionInfo, repo_path: Path | None = None
+) -> str | None:
+    """Read source lines for a single function."""
+    try:
+        target = file_path
+        if repo_path and not file_path.is_absolute():
+            target = repo_path / file_path
+        lines = target.read_text(encoding="utf-8").splitlines()
+        start = fn.start_line - 1
+        end = fn.end_line
+        return "\n".join(lines[start:end])
+    except (OSError, UnicodeDecodeError, AttributeError):
+        return None


### PR DESCRIPTION
Split from #576 (ADR-100 monorepo migration). Part of the PR decomposition into atomic, reviewable units.