### PR TITLE
chore: fix PR label automation and align PR/issue templates to openclaw standard

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,30 +1,63 @@
 name: Bug Report
-description: Something isn't working as expected
+description: Report a defect, regression, crash, or incorrect behavior.
 title: "[Bug] "
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to report a bug! Please fill in the details below so we can reproduce and fix it.
+        Thanks for filing this report. Keep every answer concise, reproducible, and
+        grounded in observed evidence. Do not speculate beyond the evidence.
+
+  - type: dropdown
+    id: bug-type
+    attributes:
+      label: Bug type
+      description: Choose the category that best matches this report.
+      options:
+        - Regression (worked before, broken now)
+        - Crash / unhandled exception
+        - Incorrect signal result (false positive / false negative)
+        - Wrong output format or schema violation
+        - Performance degradation
+        - Documentation mismatch
+        - Other
+    validations:
+      required: true
 
   - type: textarea
     id: description
     attributes:
-      label: Describe the bug
-      description: A clear description of what the bug is.
+      label: Summary
+      description: One-sentence statement of what is broken, based only on observed evidence.
     validations:
       required: true
 
   - type: textarea
     id: reproduce
     attributes:
-      label: To reproduce
-      description: Steps or command to reproduce the issue.
+      label: Steps to reproduce
+      description: Shortest deterministic repro path supported by direct observation.
       placeholder: |
         ```bash
         drift analyze --repo /path/to/project
         ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What you expected to happen (cite prior behavior, docs, or a known-good version).
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What actually happened. Include the full error output if applicable.
     validations:
       required: true
 
@@ -58,25 +91,40 @@ body:
       required: true
 
   - type: textarea
-    id: expected
+    id: root-cause
     attributes:
-      label: Expected behaviour
-      description: What you expected to happen.
+      label: Root cause (if known)
+      description: |
+        Why did this happen? What detection or guardrail is missing?
+        If unknown, write `Unknown`.
+      placeholder: |
+        - Root cause:
+        - Missing detection / guardrail:
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact and severity
+      description: |
+        Explain who is affected, how severe, how often, and practical consequences.
+      placeholder: |
+        - Affected users/projects:
+        - Severity (annoying / blocks workflow / data integrity risk):
+        - Frequency (always / intermittent / edge case):
+        - Consequence:
     validations:
       required: true
 
   - type: textarea
-    id: actual
+    id: evidence
     attributes:
-      label: Actual behaviour
-      description: What actually happened. Include the full error output if applicable.
-    validations:
-      required: true
+      label: Logs, screenshots, and evidence
+      description: Include redacted logs, screenshots, or version comparisons that support the report.
 
   - type: textarea
     id: context
     attributes:
       label: Additional context
-      description: Stack trace, drift.yaml contents, anything else relevant.
+      description: Stack trace, `drift.yaml` contents, repo characteristics, or anything else relevant.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,18 +1,18 @@
 name: Feature Request
-description: Suggest a new signal, output format, or improvement
+description: Propose a new signal, output format, or improvement
 title: "[Feature] "
 labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for suggesting an improvement! Please describe your idea below.
+        Help us evaluate this request with concrete use cases and tradeoffs.
 
   - type: textarea
     id: problem
     attributes:
       label: Problem / motivation
-      description: What problem does this solve? What's the current limitation?
+      description: What user pain does this solve? What is the current limitation?
     validations:
       required: true
 
@@ -20,7 +20,7 @@ body:
     id: solution
     attributes:
       label: Proposed solution
-      description: Describe the feature you'd like. Be as specific as possible.
+      description: Desired behavior, API, or UX with as much specificity as possible.
     validations:
       required: true
 
@@ -28,9 +28,33 @@ body:
     id: alternatives
     attributes:
       label: Alternatives considered
-      description: Any alternative approaches you've thought about?
+      description: Other approaches considered and why they are weaker.
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: |
+        Explain who is affected, severity/urgency, and practical consequences.
+      placeholder: |
+        - Affected users/projects:
+        - Severity (annoying / blocks workflow / precision gap):
+        - Frequency (always / intermittent / edge case):
+        - Consequence (missed findings, extra manual work, etc.):
     validations:
-      required: false
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence / examples
+      description: Prior art, links, repo examples, screenshots, benchmark data, or signal output that illustrates the gap.
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional information
+      description: Extra context, constraints, or references not covered above.
 
   - type: dropdown
     id: contribute

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,32 @@
 ## Summary
 
-<!-- What changed and why? -->
+Describe the problem and fix in 2–5 bullets:
 
-## Related issue
+- Problem:
+- Why it matters:
+- What changed:
+- What did NOT change (scope boundary):
 
-<!-- Use: Closes #123 / Fixes #123 / Related #123 -->
+## Linked Issue / PR
+
+- Closes #
+- Related #
+
+## Type of change (select all that apply)
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor (required for the fix)
+- [ ] Documentation
+- [ ] Test-only change
+- [ ] CI/Build change
+
+## First contribution?
+
+- [ ] This is my first contribution to drift
+
+<!-- First-time contributors: don't worry about getting everything perfect.
+     Maintainers will guide you through the review process. -->
 
 ## Policy criterion served
 
@@ -17,21 +39,105 @@
 - [ ] Trend capability (temporal analysis, delta tracking)
 - [ ] None of the above — explain why this is still valuable:
 
-## First contribution?
+## Root Cause (if applicable)
 
-- [ ] This is my first contribution to drift
+For bug fixes or regressions, explain **why** this happened, not just what changed.
+Otherwise write `N/A`. If the cause is unclear, write `Unknown`.
 
-<!-- First-time contributors: don't worry about getting everything perfect.
-     Maintainers will guide you through the review process. -->
+- Root cause:
+- Missing detection / guardrail:
+- Contributing context (if known):
 
-## Type of change
+## Regression Test Plan (if applicable)
 
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Refactor
-- [ ] Documentation
-- [ ] Test-only change
-- [ ] CI/Build change
+For bug fixes or regressions, name the smallest reliable test coverage that
+should catch this. Otherwise write `N/A`.
+
+- Coverage level that should have caught this:
+  - [ ] Unit test
+  - [ ] Integration test
+  - [ ] Existing coverage already sufficient
+- Target test or file:
+- Scenario the test should lock in:
+- If no new test is added, why not:
+
+## User-visible / Behavior Changes
+
+List user-visible changes (including defaults, config keys, CLI flags, output format).
+If none, write `None`.
+
+## Diagram (if applicable)
+
+For non-trivial logic flows or output format changes, include a small ASCII diagram.
+Otherwise write `N/A`.
+
+```
+Before:
+[input] -> [old behavior]
+
+After:
+[input] -> [new behavior] -> [result]
+```
+
+## Security Impact (required)
+
+- New permissions / capabilities? (`Yes/No`)
+- Input validation surface changed? (`Yes/No`)
+- File system or subprocess access changed? (`Yes/No`)
+- Secrets / tokens handling changed? (`Yes/No`)
+- If any `Yes`, explain risk + mitigation:
+
+## Repro + Verification
+
+### Environment
+
+- OS:
+- Python version:
+- drift-analyzer version:
+- Relevant config (redacted):
+
+### Steps
+
+1.
+2.
+3.
+
+### Expected
+
+-
+
+### Actual
+
+-
+
+## Evidence
+
+Attach at least one of:
+
+- Failing test / log before + passing after
+- `drift analyze` output diff
+- Benchmark / precision-recall numbers
+- Screenshot (for docs or DX changes)
+
+## Human Verification (required)
+
+What you personally verified (not just CI), and how:
+
+- Verified scenarios:
+- Edge cases checked:
+- What you did not verify:
+
+## Review Conversations
+
+I replied to or resolved every bot review conversation I addressed in this PR.
+I left unresolved only conversations that still need reviewer judgment.
+
+## Compatibility / Migration
+
+- Backward compatible? (`Yes/No`)
+- Config / env changes? (`Yes/No`)
+- Migration needed? (`Yes/No`)
+- If yes, exact upgrade steps:
 
 ## Release notes label (required)
 
@@ -81,6 +187,13 @@ Evidence summary (required when feature is introduced):
 - [ ] OR: `audit_results/fault_trees.md` reviewed (FT-1/FT-2/FT-3 paths checked)
 - [ ] OR: `audit_results/risk_register.md` updated (new risk entry or metric update)
 - [ ] All four audit artifacts still exist and are not deleted
+
+## Risks and Mitigations
+
+List only real risks for this PR. If none, write `None`.
+
+- Risk:
+  - Mitigation:
 
 ## Notes for reviewers
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -88,4 +88,11 @@ lane/high-risk:
 
 lane/standard:
   - changed-files:
-      - any-glob-to-any-file: "src/drift/**"
+      - any-glob-to-any-file:
+          - "src/drift/**"
+          - "packages/**"
+          - "tests/**"
+          - "scripts/**"
+          - ".github/workflows/**"
+          - "pyproject.toml"
+          - "uv.lock"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -51,3 +51,41 @@ security:
           - ".github/workflows/security-hygiene.yml"
           - ".github/workflows/codeql.yml"
           - ".pre-commit-config.yaml"
+
+# ---------------------------------------------------------------------------
+# PR Lane Labels
+# Collision rule: high-risk > standard > fast-lane
+# (actions/labeler applies all matching labels; fast-lane is overridden
+#  by the automerge workflow which checks absence of high-risk/standard)
+# ---------------------------------------------------------------------------
+
+lane/fast-lane:
+  - changed-files:
+      - all-globs-to-all-files:
+          - "docs/**"
+          - "docs-site/**"
+          - "README.md"
+          - "CONTRIBUTING.md"
+          - "DEVELOPER.md"
+          - ".github/prompts/**"
+          - ".github/instructions/**"
+          - "tests/fixtures/**"
+          - "benchmark_results/**"
+          - "benchmarks/corpus/**"
+          - "benchmarks/defect_corpus/**"
+
+lane/high-risk:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/drift/signals/**"
+          - "src/drift/scoring/**"
+          - "src/drift/ingestion/**"
+          - "POLICY.md"
+          - ".github/copilot-instructions.md"
+          - "docs/decisions/**"
+          - "audit_results/**"
+          - "audit/**"
+
+lane/standard:
+  - changed-files:
+      - any-glob-to-any-file: "src/drift/**"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,7 +22,7 @@ tests:
   - changed-files:
       - any-glob-to-any-file: "tests/**"
 
-documentation:
+docs:
   - changed-files:
       - any-glob-to-any-file:
           - "docs-site/**"
@@ -73,6 +73,18 @@ lane/fast-lane:
           - "benchmark_results/**"
           - "benchmarks/corpus/**"
           - "benchmarks/defect_corpus/**"
+
+lane/standard:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/**"
+          - "packages/**"
+          - "scripts/**"
+          - "pyproject.toml"
+          - "uv.lock"
+          - ".github/workflows/**"
+          - ".github/actions/**"
+          - "tests/**"
 
 lane/high-risk:
   - changed-files:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -81,3 +81,59 @@
 - name: release:skip
   color: "cfd3d7"
   description: Exclude this PR from release notes
+
+# ---------------------------------------------------------------------------
+# PR Size Labels
+# ---------------------------------------------------------------------------
+
+- name: size/XS
+  color: "3cbf00"
+  description: "Diff < 10 lines (excl. fixtures/lockfiles)"
+
+- name: size/S
+  color: "5d9e28"
+  description: "Diff 10–49 lines (excl. fixtures/lockfiles)"
+
+- name: size/M
+  color: "f0c000"
+  description: "Diff 50–149 lines (excl. fixtures/lockfiles)"
+
+- name: size/L
+  color: "e87c00"
+  description: "Diff 150–499 lines (excl. fixtures/lockfiles)"
+
+- name: size/XL
+  color: "d93f0b"
+  description: "Diff ≥ 500 lines — consider splitting"
+
+# ---------------------------------------------------------------------------
+# PR Lane Labels
+# ---------------------------------------------------------------------------
+
+- name: lane/fast-lane
+  color: "0e8a16"
+  description: "Docs/chore/fixture — reduced check path, eligible for automerge"
+
+- name: lane/standard
+  color: "fbca04"
+  description: "Fixes and features — standard review path"
+
+- name: lane/high-risk
+  color: "b60205"
+  description: "Signals/scoring/architecture — full gates + audit required"
+
+# ---------------------------------------------------------------------------
+# Triage Labels
+# ---------------------------------------------------------------------------
+
+- name: needs-description
+  color: "e4e4e4"
+  description: "PR body is empty or uses placeholder template"
+
+- name: needs-buglink
+  color: "e4e4e4"
+  description: "Test-only PR without a linked issue or fix reference"
+
+- name: auto-triaged
+  color: "c5def5"
+  description: "PR was automatically triaged for triage labels"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -58,6 +58,42 @@
   color: "e4e4e4"
   description: Acknowledged but not currently prioritized
 
+# ---------------------------------------------------------------------------
+# PR Area Labels (referenced by .github/labeler.yml)
+# ---------------------------------------------------------------------------
+
+- name: signals
+  color: "0075ca"
+  description: Changes to signal detection logic
+
+- name: scoring
+  color: "0075ca"
+  description: Changes to composite scoring or weights
+
+- name: ingestion
+  color: "0075ca"
+  description: Changes to file discovery or AST parsing
+
+- name: output
+  color: "0075ca"
+  description: Changes to CLI output or formatters
+
+- name: cli
+  color: "0075ca"
+  description: Changes to CLI commands
+
+- name: ci
+  color: "e4e4e4"
+  description: Changes to CI/CD workflows or tooling
+
+- name: config
+  color: "e4e4e4"
+  description: Changes to configuration schema or defaults
+
+- name: security
+  color: "d93f0b"
+  description: Security-related changes
+
 - name: stale
   color: "ededed"
   description: Inactive for 90+ days — will auto-close if no further activity

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -173,3 +173,11 @@
 - name: auto-triaged
   color: "c5def5"
   description: "PR was automatically triaged for triage labels"
+
+- name: has-conflicts
+  color: "e11d48"
+  description: "PR has merge conflicts with the base branch"
+
+- name: "r: too-many-prs"
+  color: "e11d48"
+  description: "Author has exceeded the per-author open-PR limit (10)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
               - 'pyproject.toml'
               - 'uv.lock'
               - 'scripts/**'
+              - '.pre-commit-config.yaml'
               - '.github/workflows/ci.yml'
 
   pre-commit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       signals: ${{ steps.filter.outputs.signals }}
       docs: ${{ steps.filter.outputs.docs }}
+      code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
@@ -47,9 +48,21 @@ jobs:
               - 'docs/**'
               - 'docs-site/**'
               - '*.md'
+            code:
+              - 'src/**'
+              - 'tests/**'
+              - 'packages/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'scripts/**'
+              - '.github/workflows/ci.yml'
 
   pre-commit:
     name: Pre-commit hooks
+    if: |
+      github.event_name != 'pull_request' ||
+      needs.determine_changes.outputs.code == 'true'
+    needs: determine_changes
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -65,6 +78,10 @@ jobs:
 
   version-check:
     name: Version format check
+    if: |
+      github.event_name != 'pull_request' ||
+      needs.determine_changes.outputs.code == 'true'
+    needs: determine_changes
     # NOTE: Uses GitHub-hosted Windows runner.
     runs-on: windows-latest
     timeout-minutes: 10
@@ -123,9 +140,12 @@ jobs:
 
   test:
     # NOTE: Runs on Ubuntu and Windows for cross-platform coverage.
+    if: |
+      github.event_name != 'pull_request' ||
+      needs.determine_changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
-    needs: version-check
+    needs: [determine_changes, version-check]
     env:
       AGENT_TOOLSDIRECTORY: ${{ github.workspace }}\.python-toolcache
       RUNNER_TOOL_CACHE: ${{ github.workspace }}\.python-toolcache
@@ -480,10 +500,12 @@ jobs:
 
   smoke-pr:
     name: Smoke PR (fast profile)
-    if: github.event_name == 'pull_request'
+    if: |
+      github.event_name == 'pull_request' &&
+      needs.determine_changes.outputs.code == 'true'
     runs-on: windows-latest
     timeout-minutes: 15
-    needs: version-check
+    needs: [determine_changes, version-check]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - "src/**"
+      - "packages/**"
+      - "pyproject.toml"
+      - ".github/workflows/codeql.yml"
   schedule:
     - cron: "17 3 * * 2"
   workflow_dispatch:

--- a/.github/workflows/copilot-pr-auto-merge.yml
+++ b/.github/workflows/copilot-pr-auto-merge.yml
@@ -6,8 +6,10 @@ name: Copilot PR Auto-Merge
 # Copilot PRs still require human review — this workflow only removes the
 # manual "click merge" step after approval + CI pass.
 #
-# Actor detection: GitHub Copilot agent PRs are opened by 'Copilot' (User type)
-# or branch names starting with 'copilot/'.
+# Actor detection: GitHub Copilot agent PRs are opened by the verified
+# 'Copilot' actor or 'copilot[bot]' app account only.
+# Branch names are NOT used as an authentication signal because any
+# contributor can choose an arbitrary branch name.
 
 on:
   pull_request:
@@ -26,8 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.actor == 'Copilot' ||
-      github.actor == 'copilot[bot]' ||
-      startsWith(github.head_ref, 'copilot/')
+      github.actor == 'copilot[bot]'
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -40,9 +41,3 @@ jobs:
             --auto \
             --squash \
             --delete-branch
-
-      - name: Add lane/fast-lane label
-        run: |
-          gh pr edit "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" \
-            --add-label "lane/fast-lane" || true

--- a/.github/workflows/copilot-pr-auto-merge.yml
+++ b/.github/workflows/copilot-pr-auto-merge.yml
@@ -1,0 +1,48 @@
+name: Copilot PR Auto-Merge
+
+# Enables auto-merge on Copilot-authored PRs so that once the maintainer
+# approves, the PR merges automatically when "Required checks passed" is green.
+#
+# Copilot PRs still require human review — this workflow only removes the
+# manual "click merge" step after approval + CI pass.
+#
+# Actor detection: GitHub Copilot agent PRs are opened by 'Copilot' (User type)
+# or branch names starting with 'copilot/'.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: copilot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: |
+      github.actor == 'Copilot' ||
+      github.actor == 'copilot[bot]' ||
+      startsWith(github.head_ref, 'copilot/')
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Enable auto-merge (squash)
+        run: |
+          echo "Copilot PR detected — enabling auto-merge (squash)."
+          echo "Merge will trigger automatically after review approval + CI pass."
+          gh pr merge "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --auto \
+            --squash \
+            --delete-branch
+
+      - name: Add lane/fast-lane label
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --add-label "lane/fast-lane" || true

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,6 +3,11 @@ name: Dependency Review
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'requirements*.txt'
+      - '.github/workflows/dependency-review.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/drift-agent-gate.yml
+++ b/.github/workflows/drift-agent-gate.yml
@@ -37,6 +37,10 @@ on:
         type: string
         default: "drift/approved"
 
+concurrency:
+  group: "drift-agent-gate-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/drift-label-feedback.yml
+++ b/.github/workflows/drift-label-feedback.yml
@@ -32,8 +32,8 @@ permissions:
   contents: write
 
 concurrency:
-  group: "drift-label-feedback-${{ github.event.pull_request.number }}"
-  cancel-in-progress: false
+  group: "drift-label-feedback-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: true
 
 jobs:
   record-feedback:

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -24,8 +24,8 @@ on:
     - cron: "0 3 * * 0"
 
 concurrency:
-  group: "mutation-testing"
-  cancel-in-progress: false
+  group: "mutation-testing-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/perf-regression-loop.yml
+++ b/.github/workflows/perf-regression-loop.yml
@@ -33,8 +33,8 @@ on:
     - cron: "0 4 * * 0"
 
 concurrency:
-  group: "perf-regression-loop"
-  cancel-in-progress: false
+  group: "perf-regression-loop-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/pr-auto-triage.yml
+++ b/.github/workflows/pr-auto-triage.yml
@@ -39,8 +39,13 @@ jobs:
             const toRemove = new Set();
 
             // ---- Rule 1: needs-description --------------------------------
-            const isEmptyBody   = body.length === 0;
-            const isPlaceholder = body.startsWith('<!--');
+            const isEmptyBody = body.length === 0;
+            // Detect template placeholder: body contains only HTML comment(s) and no
+            // meaningful text outside them. Explicitly exempt the XL-override marker
+            // (<!-- large-pr: …) since that IS the intended description.
+            const isXLOverride = body.startsWith('<!-- large-pr:');
+            const bodyWithoutComments = body.replace(/<!--[\s\S]*?-->/g, '').trim();
+            const isPlaceholder = !isXLOverride && body.length > 0 && bodyWithoutComments.length === 0;
             if (isEmptyBody || isPlaceholder) {
               toAdd.add('needs-description');
             } else {
@@ -48,8 +53,8 @@ jobs:
             }
 
             // ---- Rule 2: needs-buglink ------------------------------------
-            // Fetch changed files to check if it's test-only
-            const { data: files } = await github.rest.pulls.listFiles({
+            // Fetch all changed files (paginated — listFiles caps at 100 per page)
+            const files = await github.paginate(github.rest.pulls.listFiles, {
               owner, repo, pull_number: number, per_page: 100
             });
             const nonTestFiles = files.filter(f =>

--- a/.github/workflows/pr-auto-triage.yml
+++ b/.github/workflows/pr-auto-triage.yml
@@ -98,6 +98,15 @@ jobs:
                   owner, repo, issue_number: number, labels: ['auto-triaged']
                 });
               }
+            } else {
+              // All triage labels were cleared — remove auto-triaged so KPI
+              // counts are not inflated by resolved PRs.
+              if (existingNames.has('auto-triaged') && labelsToRm.length > 0) {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: number, name: 'auto-triaged'
+                });
+                core.info('Removed auto-triaged label (all triage conditions resolved).');
+              }
             }
 
             core.info(`PR #${number}: triage complete.`);

--- a/.github/workflows/pr-auto-triage.yml
+++ b/.github/workflows/pr-auto-triage.yml
@@ -1,0 +1,98 @@
+name: PR Auto-Triage
+
+# Labels PRs that are likely low-quality or missing context.
+# NEVER auto-closes — only adds labels for human review.
+#
+# Rules applied:
+#   needs-description  — body is empty or contains the placeholder comment
+#   needs-buglink      — only tests/* changed AND no "fix #" / "closes #" in body
+#   auto-triaged       — set whenever at least one triage label is added
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: "pr-triage-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr     = context.payload.pull_request;
+            const owner  = context.repo.owner;
+            const repo   = context.repo.repo;
+            const number = pr.number;
+            const body   = (pr.body || '').trim();
+
+            const toAdd    = new Set();
+            const toRemove = new Set();
+
+            // ---- Rule 1: needs-description --------------------------------
+            const isEmptyBody   = body.length === 0;
+            const isPlaceholder = body.startsWith('<!--');
+            if (isEmptyBody || isPlaceholder) {
+              toAdd.add('needs-description');
+            } else {
+              toRemove.add('needs-description');
+            }
+
+            // ---- Rule 2: needs-buglink ------------------------------------
+            // Fetch changed files to check if it's test-only
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner, repo, pull_number: number, per_page: 100
+            });
+            const nonTestFiles = files.filter(f =>
+              !f.filename.startsWith('tests/') &&
+              !f.filename.startsWith('benchmarks/') &&
+              !f.filename.startsWith('benchmark_results/')
+            );
+            const hasFixRef = /(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+#\d+/i.test(body);
+            if (nonTestFiles.length === 0 && !hasFixRef) {
+              toAdd.add('needs-buglink');
+            } else {
+              toRemove.add('needs-buglink');
+            }
+
+            // ---- Apply changes -------------------------------------------
+            // Fetch existing labels
+            const { data: existing } = await github.rest.issues.listLabelsOnIssue({
+              owner, repo, issue_number: number
+            });
+            const existingNames = new Set(existing.map(l => l.name));
+
+            const labelsToAdd = [...toAdd].filter(l => !existingNames.has(l));
+            const labelsToRm  = [...toRemove].filter(l => existingNames.has(l));
+
+            for (const lbl of labelsToRm) {
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number: number, name: lbl
+              });
+              core.info(`Removed triage label: ${lbl}`);
+            }
+
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: number, labels: labelsToAdd
+              });
+              core.info(`Added triage labels: ${labelsToAdd.join(', ')}`);
+
+              // Mark as auto-triaged if not already set
+              if (!existingNames.has('auto-triaged')) {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: number, labels: ['auto-triaged']
+                });
+              }
+            }
+
+            core.info(`PR #${number}: triage complete.`);

--- a/.github/workflows/pr-cap.yml
+++ b/.github/workflows/pr-cap.yml
@@ -1,0 +1,101 @@
+name: PR Cap
+
+# Closes PRs from contributors who exceed the per-author open-PR limit.
+# This keeps the review queue manageable and encourages focused contributions.
+#
+# Limit: 10 open PRs per author (excluding bots and the maintainer).
+# Action: adds label 'r: too-many-prs', posts a comment, closes the PR.
+#
+# Exemptions:
+#   - mick-gsk (maintainer)
+#   - *[bot] accounts (Dependabot, Copilot, etc.)
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: "pr-cap-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+
+jobs:
+  cap-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      PR_CAP: 10
+      MAINTAINER: mick-gsk
+    steps:
+      - name: Check per-author PR count
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr     = context.payload.pull_request;
+            const owner  = context.repo.owner;
+            const repo   = context.repo.repo;
+            const author = pr.user.login;
+            const cap    = parseInt(process.env.PR_CAP, 10);
+            const maintainer = process.env.MAINTAINER;
+
+            // Skip bots and the maintainer
+            if (author === maintainer || author.endsWith('[bot]')) {
+              core.info(`Author '${author}' is exempt — skipping.`);
+              return;
+            }
+
+            // Count all open PRs by this author (excluding the one just opened)
+            const allOpen = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', per_page: 100
+            });
+            const authorPRs = allOpen.filter(p => p.user.login === author);
+
+            core.info(`${author} has ${authorPRs.length} open PR(s) (cap: ${cap}).`);
+
+            if (authorPRs.length <= cap) return;
+
+            // Cap exceeded — label + comment + close
+            const LABEL = 'r: too-many-prs';
+
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: LABEL });
+            } catch (e) {
+              if (e.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner, repo, name: LABEL,
+                  color: 'e11d48',
+                  description: `Author has more than ${cap} open PRs`
+                });
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number: pr.number, labels: [LABEL]
+            });
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: pr.number,
+              body: [
+                `👋 Thanks for the contribution, @${author}!`,
+                ``,
+                `This PR was automatically closed because you currently have **${authorPRs.length} open PRs**,`,
+                `which exceeds the per-author limit of **${cap}**. This keeps the review queue`,
+                `manageable for the maintainer.`,
+                ``,
+                `**What to do:**`,
+                `1. Get some of your existing PRs merged or close ones you no longer intend to pursue.`,
+                `2. Once you're below the limit, feel free to re-open this PR.`,
+                ``,
+                `Your existing open PRs: ${authorPRs.filter(p => p.number !== pr.number).map(p => `#${p.number}`).join(', ')}`,
+              ].join('\n')
+            });
+
+            await github.rest.pulls.update({
+              owner, repo, pull_number: pr.number, state: 'closed'
+            });
+
+            core.info(`Closed PR #${pr.number} — ${author} exceeded the ${cap}-PR cap.`);

--- a/.github/workflows/pr-conflict-label.yml
+++ b/.github/workflows/pr-conflict-label.yml
@@ -1,0 +1,98 @@
+name: PR Conflict Label
+
+# Labels open PRs with 'has-conflicts' when they can no longer merge cleanly.
+# Removes the label as soon as the conflict is resolved.
+#
+# Triggers:
+#   push to main      — main just advanced; check all open PRs
+#   pull_request sync — the PR head was updated; re-check just that PR
+#
+# Note: GitHub's `mergeable` field is computed lazily and may be null on the
+# first API call. We retry once after a short delay to let GitHub catch up.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [synchronize, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: "pr-conflict-label-${{ github.event.pull_request.number || github.sha }}"
+  cancel-in-progress: true
+
+jobs:
+  conflict-label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Label / unlabel conflicting PRs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+            const LABEL = 'has-conflicts';
+
+            // Collect PRs to inspect
+            let prs = [];
+            if (context.eventName === 'pull_request') {
+              // Only the PR that was just updated
+              prs = [context.payload.pull_request];
+            } else {
+              // push to main: inspect all open PRs that target main
+              const allPRs = await github.paginate(github.rest.pulls.list, {
+                owner, repo, state: 'open', base: 'main', per_page: 100
+              });
+              prs = allPRs;
+            }
+
+            for (const pr of prs) {
+              if (pr.state !== 'open') continue;
+
+              // Fetch fresh PR data — the list endpoint may have stale mergeable
+              let prData;
+              try {
+                const { data } = await github.rest.pulls.get({
+                  owner, repo, pull_number: pr.number
+                });
+                prData = data;
+              } catch (e) {
+                core.warning(`Could not fetch PR #${pr.number}: ${e.message}`);
+                continue;
+              }
+
+              // mergeable is null when GitHub hasn't computed it yet — retry once
+              if (prData.mergeable === null) {
+                await new Promise(r => setTimeout(r, 5000));
+                try {
+                  const { data } = await github.rest.pulls.get({
+                    owner, repo, pull_number: pr.number
+                  });
+                  prData = data;
+                } catch (e) {
+                  core.warning(`Retry fetch failed for PR #${pr.number}: ${e.message}`);
+                  continue;
+                }
+              }
+
+              const hasConflict = prData.mergeable === false;
+              const existingLabels = prData.labels.map(l => l.name);
+              const isLabeled    = existingLabels.includes(LABEL);
+
+              if (hasConflict && !isLabeled) {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: pr.number, labels: [LABEL]
+                });
+                core.info(`PR #${pr.number}: added '${LABEL}'`);
+              } else if (!hasConflict && isLabeled) {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: pr.number, name: LABEL
+                });
+                core.info(`PR #${pr.number}: removed '${LABEL}'`);
+              }
+            }

--- a/.github/workflows/pr-fast-lane-automerge.yml
+++ b/.github/workflows/pr-fast-lane-automerge.yml
@@ -1,0 +1,158 @@
+name: Fast-Lane Automerge
+
+# Automatically merges fast-lane PRs when all safety conditions are met.
+# Conditions (ALL required):
+#   1. Label lane/fast-lane is present
+#   2. Label size/XS or size/S is present
+#   3. All required CI checks are green
+#   4. At least one approved review
+#   5. No blocking labels: blocked, needs-description, needs-buglink
+#
+# Triggered on: review submitted (approved) and check_suite completed.
+# Uses squash-merge with branch deletion.
+
+on:
+  pull_request_review:
+    types: [submitted]
+  check_suite:
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Only act on the default branch target
+    if: |
+      github.event_name == 'pull_request_review' ||
+      (github.event_name == 'check_suite' && github.event.check_suite.conclusion == 'success')
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Find eligible fast-lane PRs and automerge
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+
+            // Determine which PR to inspect
+            let prNumber;
+            if (context.eventName === 'pull_request_review') {
+              prNumber = context.payload.pull_request.number;
+            } else {
+              // check_suite: find open PRs associated with the head SHA
+              const sha = context.payload.check_suite.head_sha;
+              const { data: pulls } = await github.rest.pulls.list({
+                owner, repo, state: 'open', per_page: 100
+              });
+              const matching = pulls.filter(p => p.head.sha === sha);
+              if (matching.length === 0) {
+                core.info('No open PR found for this check_suite SHA — skipping.');
+                return;
+              }
+              prNumber = matching[0].number;
+            }
+
+            // Fetch full PR data
+            const { data: pr } = await github.rest.pulls.get({
+              owner, repo, pull_number: prNumber
+            });
+
+            if (pr.state !== 'open') {
+              core.info(`PR #${prNumber} is not open — skipping.`);
+              return;
+            }
+
+            const labelNames = pr.labels.map(l => l.name);
+            core.info(`PR #${prNumber} labels: ${labelNames.join(', ')}`);
+
+            // ---- Condition 1: lane/fast-lane present ----------------------
+            if (!labelNames.includes('lane/fast-lane')) {
+              core.info('Not a fast-lane PR — skipping.');
+              return;
+            }
+
+            // ---- Condition 5: no blocking labels --------------------------
+            const blockers = ['blocked', 'needs-description', 'needs-buglink', 'lane/high-risk'];
+            const hasBlocker = blockers.some(b => labelNames.includes(b));
+            if (hasBlocker) {
+              core.info(`PR has blocking label — skipping.`);
+              return;
+            }
+
+            // ---- Condition 2: size/XS or size/S ---------------------------
+            const smallSize = labelNames.includes('size/XS') || labelNames.includes('size/S');
+            if (!smallSize) {
+              core.info('PR is not XS or S size — skipping fast-lane automerge.');
+              return;
+            }
+
+            // ---- Condition 4: at least one approved review ----------------
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner, repo, pull_number: prNumber
+            });
+            // Latest review state per reviewer
+            const latestByUser = {};
+            for (const review of reviews) {
+              latestByUser[review.user.login] = review.state;
+            }
+            const hasApproval = Object.values(latestByUser).includes('APPROVED');
+            if (!hasApproval) {
+              core.info('No approved review yet — skipping.');
+              return;
+            }
+
+            // ---- Condition 3: all required checks green -------------------
+            const { data: checkRuns } = await github.rest.checks.listForRef({
+              owner, repo, ref: pr.head.sha, per_page: 100
+            });
+
+            // Only consider completed check runs
+            const incomplete = checkRuns.check_runs.filter(
+              c => c.status !== 'completed'
+            );
+            if (incomplete.length > 0) {
+              core.info(`${incomplete.length} check(s) still running — skipping.`);
+              return;
+            }
+
+            const failed = checkRuns.check_runs.filter(
+              c => c.conclusion !== 'success' && c.conclusion !== 'skipped' && c.conclusion !== 'neutral'
+            );
+            if (failed.length > 0) {
+              core.info(`Failed checks: ${failed.map(c => c.name).join(', ')} — skipping.`);
+              return;
+            }
+
+            // ---- All conditions met: enable automerge ---------------------
+            core.info(`All conditions met — enabling automerge for PR #${prNumber}.`);
+            try {
+              await github.rest.pulls.merge({
+                owner,
+                repo,
+                pull_number: prNumber,
+                merge_method: 'squash',
+                commit_title: `${pr.title} (#${prNumber})`,
+                commit_message: `Auto-merged via fast-lane-automerge.yml.\n\nLabels: ${labelNames.join(', ')}`
+              });
+              core.info(`PR #${prNumber} merged successfully.`);
+
+              // Delete the branch
+              try {
+                await github.rest.git.deleteRef({
+                  owner, repo, ref: `heads/${pr.head.ref}`
+                });
+                core.info(`Branch ${pr.head.ref} deleted.`);
+              } catch (e) {
+                core.warning(`Could not delete branch: ${e.message}`);
+              }
+            } catch (err) {
+              core.warning(`Automerge failed: ${err.message}. Will retry on next trigger.`);
+            }

--- a/.github/workflows/pr-fast-lane-automerge.yml
+++ b/.github/workflows/pr-fast-lane-automerge.yml
@@ -47,12 +47,12 @@ jobs:
             if (context.eventName === 'pull_request_review') {
               prNumber = context.payload.pull_request.number;
             } else {
-              // check_suite: find open PRs associated with the head SHA
+              // check_suite: use the dedicated API to find open PRs for this SHA
               const sha = context.payload.check_suite.head_sha;
-              const { data: pulls } = await github.rest.pulls.list({
-                owner, repo, state: 'open', per_page: 100
+              const { data: associated } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner, repo, commit_sha: sha
               });
-              const matching = pulls.filter(p => p.head.sha === sha);
+              const matching = associated.filter(p => p.state === 'open');
               if (matching.length === 0) {
                 core.info('No open PR found for this check_suite SHA — skipping.');
                 return;
@@ -70,6 +70,14 @@ jobs:
               return;
             }
 
+            // Guard: only merge into the default branch to avoid unintended
+            // merges into release/hotfix branches.
+            const defaultBranch = context.payload.repository.default_branch;
+            if (pr.base.ref !== defaultBranch) {
+              core.info(`PR #${prNumber} targets '${pr.base.ref}', not default branch '${defaultBranch}' — skipping.`);
+              return;
+            }
+
             const labelNames = pr.labels.map(l => l.name);
             core.info(`PR #${prNumber} labels: ${labelNames.join(', ')}`);
 
@@ -80,7 +88,9 @@ jobs:
             }
 
             // ---- Condition 5: no blocking labels --------------------------
-            const blockers = ['blocked', 'needs-description', 'needs-buglink', 'lane/high-risk'];
+            // lane/standard and lane/high-risk override lane/fast-lane per collision rule:
+            //   lane/high-risk > lane/standard > lane/fast-lane
+            const blockers = ['blocked', 'needs-description', 'needs-buglink', 'lane/high-risk', 'lane/standard'];
             const hasBlocker = blockers.some(b => labelNames.includes(b));
             if (hasBlocker) {
               core.info(`PR has blocking label — skipping.`);

--- a/.github/workflows/pr-fast-lane-automerge.yml
+++ b/.github/workflows/pr-fast-lane-automerge.yml
@@ -32,8 +32,6 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-
       - name: Find eligible fast-lane PRs and automerge
         uses: actions/github-script@v7
         with:
@@ -55,6 +53,10 @@ jobs:
               const matching = associated.filter(p => p.state === 'open');
               if (matching.length === 0) {
                 core.info('No open PR found for this check_suite SHA — skipping.');
+                return;
+              }
+              if (matching.length > 1) {
+                core.info(`Multiple open PRs (${matching.map(p => p.number).join(', ')}) share this SHA — skipping to avoid acting on the wrong PR.`);
                 return;
               }
               prNumber = matching[0].number;
@@ -105,8 +107,9 @@ jobs:
             }
 
             // ---- Condition 4: at least one approved review ----------------
-            const { data: reviews } = await github.rest.pulls.listReviews({
-              owner, repo, pull_number: prNumber
+            // Paginate all reviews so a later CHANGES_REQUESTED is not missed.
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner, repo, pull_number: prNumber, per_page: 100
             });
             // Latest review state per reviewer
             const latestByUser = {};
@@ -120,12 +123,13 @@ jobs:
             }
 
             // ---- Condition 3: all required checks green -------------------
-            const { data: checkRuns } = await github.rest.checks.listForRef({
+            // Paginate all check runs so failed runs beyond the first 100 are not missed.
+            const allCheckRuns = await github.paginate(github.rest.checks.listForRef, {
               owner, repo, ref: pr.head.sha, per_page: 100
             });
 
             // Only consider completed check runs
-            const incomplete = checkRuns.check_runs.filter(
+            const incomplete = allCheckRuns.filter(
               c => c.status !== 'completed'
             );
             if (incomplete.length > 0) {
@@ -133,7 +137,7 @@ jobs:
               return;
             }
 
-            const failed = checkRuns.check_runs.filter(
+            const failed = allCheckRuns.filter(
               c => c.conclusion !== 'success' && c.conclusion !== 'skipped' && c.conclusion !== 'neutral'
             );
             if (failed.length > 0) {
@@ -154,14 +158,19 @@ jobs:
               });
               core.info(`PR #${prNumber} merged successfully.`);
 
-              // Delete the branch
-              try {
-                await github.rest.git.deleteRef({
-                  owner, repo, ref: `heads/${pr.head.ref}`
-                });
-                core.info(`Branch ${pr.head.ref} deleted.`);
-              } catch (e) {
-                core.warning(`Could not delete branch: ${e.message}`);
+              // Delete the branch — skip for fork PRs to avoid touching a
+              // branch in a repository the token has no write access to.
+              if (pr.head.repo && pr.head.repo.full_name === `${owner}/${repo}`) {
+                try {
+                  await github.rest.git.deleteRef({
+                    owner, repo, ref: `heads/${pr.head.ref}`
+                  });
+                  core.info(`Branch ${pr.head.ref} deleted.`);
+                } catch (e) {
+                  core.warning(`Could not delete branch: ${e.message}`);
+                }
+              } else {
+                core.info(`PR #${prNumber} is from a fork (or head repo is unavailable) — skipping branch deletion.`);
               }
             } catch (err) {
               core.warning(`Automerge failed: ${err.message}. Will retry on next trigger.`);

--- a/.github/workflows/pr-fast-lane-automerge.yml
+++ b/.github/workflows/pr-fast-lane-automerge.yml
@@ -111,19 +111,26 @@ jobs:
             }
 
             // ---- Condition 4: at least one approved review ----------------
-            // Paginate all reviews so a later CHANGES_REQUESTED is not missed.
-            const reviews = await github.paginate(github.rest.pulls.listReviews, {
-              owner, repo, pull_number: prNumber, per_page: 100
-            });
-            // Latest review state per reviewer
-            const latestByUser = {};
-            for (const review of reviews) {
-              latestByUser[review.user.login] = review.state;
-            }
-            const hasApproval = Object.values(latestByUser).includes('APPROVED');
-            if (!hasApproval) {
-              core.info('No approved review yet — skipping.');
-              return;
+            // Exception: size/XS fast-lane PRs (trivial docs/fixture changes) skip
+            // the review requirement — CI green + no blockers is sufficient.
+            const isXS = labelNames.includes('size/XS');
+            if (!isXS) {
+              // Paginate all reviews so a later CHANGES_REQUESTED is not missed.
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner, repo, pull_number: prNumber, per_page: 100
+              });
+              // Latest review state per reviewer
+              const latestByUser = {};
+              for (const review of reviews) {
+                latestByUser[review.user.login] = review.state;
+              }
+              const hasApproval = Object.values(latestByUser).includes('APPROVED');
+              if (!hasApproval) {
+                core.info('No approved review yet — skipping.');
+                return;
+              }
+            } else {
+              core.info('size/XS fast-lane PR — skipping review requirement.');
             }
 
             // ---- Condition 3: all required checks green -------------------

--- a/.github/workflows/pr-fast-lane-automerge.yml
+++ b/.github/workflows/pr-fast-lane-automerge.yml
@@ -17,6 +17,10 @@ on:
   check_suite:
     types: [completed]
 
+concurrency:
+  group: "pr-fast-lane-automerge-${{ github.event.pull_request.number || github.event.check_suite.id || github.ref }}"
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/pr-label-backfill.yml
+++ b/.github/workflows/pr-label-backfill.yml
@@ -1,0 +1,221 @@
+name: PR Label Backfill
+
+# One-shot backfill: assigns area, lane, and release:* labels to all open PRs
+# (or a specific one) using the same rules as labeler.yml + pr-release-label.yml.
+#
+# Trigger manually via:
+#   gh workflow run pr-label-backfill.yml --repo mick-gsk/drift
+#   gh workflow run pr-label-backfill.yml --repo mick-gsk/drift -f pr_number=727
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Single PR number to process (leave empty = all open PRs)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+
+            // ----------------------------------------------------------------
+            // Label rule definitions (mirrors labeler.yml + pr-release-label.yml)
+            // ----------------------------------------------------------------
+
+            const RELEASE_RULES = [
+              { pattern: /^feat(\(.+?\))?[!]?:/i,     label: 'release:feature'     },
+              { pattern: /^fix(\(.+?\))?[!]?:/i,      label: 'release:fix'         },
+              { pattern: /^docs(\(.+?\))?[!]?:/i,     label: 'release:docs'        },
+              { pattern: /^(chore|refactor|perf|build|ci|test|style|revert)(\(.+?\))?[!]?:/i,
+                label: 'release:maintenance' },
+            ];
+            const ALL_RELEASE_LABELS = ['release:feature','release:fix','release:docs','release:maintenance'];
+
+            // Area rules: [label, matchFn(files)]
+            function matchesGlob(file, patterns) {
+              // Minimal glob: supports ** prefix/suffix and literal paths
+              return patterns.some(p => {
+                const re = new RegExp(
+                  '^' + p.replace(/\./g, '\\.').replace(/\*\*/g, '.*').replace(/\*/g, '[^/]*') + '$'
+                );
+                return re.test(file);
+              });
+            }
+
+            const AREA_RULES = [
+              { label: 'signals',  globs: ['src/drift/signals/**'] },
+              { label: 'scoring',  globs: ['src/drift/scoring/**'] },
+              { label: 'ingestion',globs: ['src/drift/ingestion/**'] },
+              { label: 'output',   globs: ['src/drift/output/**'] },
+              { label: 'cli',      globs: ['src/drift/commands/**'] },
+              { label: 'tests',    globs: ['tests/**'] },
+              { label: 'docs',     globs: ['docs-site/**','docs/**','README.md','CONTRIBUTING.md','DEVELOPER.md'] },
+              { label: 'ci',       globs: ['.github/workflows/**','.github/actions/**','Makefile'] },
+              { label: 'config',   globs: ['src/drift/config.py','drift.example.yaml'] },
+              { label: 'security', globs: ['SECURITY.md','.github/workflows/security-hygiene.yml','.github/workflows/codeql.yml','.pre-commit-config.yaml'] },
+            ];
+
+            const FAST_LANE_GLOBS = [
+              'docs/**','docs-site/**','README.md','CONTRIBUTING.md','DEVELOPER.md',
+              '.github/prompts/**','.github/instructions/**','tests/fixtures/**',
+              'benchmark_results/**','benchmarks/corpus/**','benchmarks/defect_corpus/**',
+            ];
+            const STANDARD_LANE_GLOBS = [
+              'src/**','packages/**','scripts/**','pyproject.toml','uv.lock',
+              '.github/workflows/**','.github/actions/**','tests/**',
+            ];
+            const HIGH_RISK_GLOBS = [
+              'src/drift/signals/**','src/drift/scoring/**','src/drift/ingestion/**',
+              'POLICY.md','.github/copilot-instructions.md','docs/decisions/**',
+              'audit_results/**','audit/**',
+            ];
+
+            // ----------------------------------------------------------------
+            // Helpers
+            // ----------------------------------------------------------------
+
+            async function getPRFiles(prNumber) {
+              const files = [];
+              let page = 1;
+              while (true) {
+                const { data } = await github.rest.pulls.listFiles({
+                  owner, repo, pull_number: prNumber, per_page: 100, page,
+                });
+                files.push(...data.map(f => f.filename));
+                if (data.length < 100) break;
+                page++;
+              }
+              return files;
+            }
+
+            async function getCurrentLabels(prNumber) {
+              const { data } = await github.rest.issues.listLabelsOnIssue({
+                owner, repo, issue_number: prNumber,
+              });
+              return new Set(data.map(l => l.name));
+            }
+
+            async function addLabel(prNumber, label) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: prNumber, labels: [label],
+              });
+            }
+
+            async function removeLabel(prNumber, label) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: prNumber, name: label,
+                });
+              } catch (e) {
+                // ignore 404 (label already absent)
+                if (e.status !== 404) throw e;
+              }
+            }
+
+            async function processOne(pr) {
+              const number = pr.number;
+              const title  = pr.title || '';
+              core.info(`\n--- PR #${number}: ${title}`);
+
+              const currentLabels = await getCurrentLabels(number);
+              const files         = await getPRFiles(number);
+              const toAdd         = new Set();
+
+              // ---- Release label ------------------------------------------
+              let targetRelease = null;
+              for (const { pattern, label } of RELEASE_RULES) {
+                if (pattern.test(title)) { targetRelease = label; break; }
+              }
+              if (targetRelease) {
+                // Remove stale release labels
+                for (const rl of ALL_RELEASE_LABELS) {
+                  if (rl !== targetRelease && currentLabels.has(rl)) {
+                    await removeLabel(number, rl);
+                    core.info(`  removed stale: ${rl}`);
+                  }
+                }
+                if (!currentLabels.has(targetRelease)) toAdd.add(targetRelease);
+              }
+
+              // ---- Area labels --------------------------------------------
+              for (const { label, globs } of AREA_RULES) {
+                if (!currentLabels.has(label) && files.some(f => matchesGlob(f, globs))) {
+                  toAdd.add(label);
+                }
+              }
+
+              // ---- Lane labels --------------------------------------------
+              const isHighRisk  = files.some(f => matchesGlob(f, HIGH_RISK_GLOBS));
+              const isStandard  = files.some(f => matchesGlob(f, STANDARD_LANE_GLOBS));
+              const isFastLane  = files.every(f => matchesGlob(f, FAST_LANE_GLOBS));
+
+              const currentLane = ['lane/high-risk','lane/standard','lane/fast-lane']
+                .find(l => currentLabels.has(l));
+
+              let targetLane = null;
+              if (isHighRisk)        targetLane = 'lane/high-risk';
+              else if (isStandard)   targetLane = 'lane/standard';
+              else if (isFastLane)   targetLane = 'lane/fast-lane';
+
+              if (targetLane && currentLane !== targetLane) {
+                // Remove wrong lane label first
+                if (currentLane) {
+                  await removeLabel(number, currentLane);
+                  core.info(`  removed stale lane: ${currentLane}`);
+                }
+                if (!currentLabels.has(targetLane)) toAdd.add(targetLane);
+              }
+
+              // ---- Apply additions ----------------------------------------
+              if (toAdd.size === 0) {
+                core.info('  no changes needed');
+                return;
+              }
+              for (const label of toAdd) {
+                await addLabel(number, label);
+                core.info(`  added: ${label}`);
+              }
+            }
+
+            // ----------------------------------------------------------------
+            // Main
+            // ----------------------------------------------------------------
+
+            const singlePR = '${{ inputs.pr_number }}'.trim();
+
+            if (singlePR) {
+              const { data: pr } = await github.rest.pulls.get({
+                owner, repo, pull_number: parseInt(singlePR, 10),
+              });
+              await processOne(pr);
+            } else {
+              // Fetch all open PRs (paginated)
+              const allPRs = [];
+              let page = 1;
+              while (true) {
+                const { data } = await github.rest.pulls.list({
+                  owner, repo, state: 'open', per_page: 100, page,
+                });
+                allPRs.push(...data);
+                if (data.length < 100) break;
+                page++;
+              }
+              core.info(`Processing ${allPRs.length} open PRs...`);
+              for (const pr of allPRs) {
+                await processOne(pr);
+              }
+              core.info(`\nDone. Processed ${allPRs.length} PRs.`);
+            }

--- a/.github/workflows/pr-release-label.yml
+++ b/.github/workflows/pr-release-label.yml
@@ -1,0 +1,96 @@
+name: PR Release Label
+
+# Automatically assigns a release:* label based on the Conventional Commit
+# prefix in the PR title.
+#
+# Mapping:
+#   feat:      → release:feature
+#   fix:       → release:fix
+#   docs:      → release:docs
+#   chore: / refactor: / perf: / build: / ci: / test: / style: / revert:
+#              → release:maintenance
+#
+# If none of the above prefixes match, no release:* label is assigned.
+# An existing release:* label is not removed when the title changes —
+# manual overrides are preserved. Use sync-labels: false intentionally.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: "pr-release-label-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+
+jobs:
+  assign-release-label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const title  = context.payload.pull_request.title || '';
+            const number = context.payload.pull_request.number;
+            const owner  = context.repo.owner;
+            const repo   = context.repo.repo;
+
+            // Map conventional commit prefix → release label
+            const MAPPING = [
+              { pattern: /^feat(\(.+?\))?[!]?:/i,     label: 'release:feature'     },
+              { pattern: /^fix(\(.+?\))?[!]?:/i,      label: 'release:fix'         },
+              { pattern: /^docs(\(.+?\))?[!]?:/i,     label: 'release:docs'        },
+              {
+                pattern: /^(chore|refactor|perf|build|ci|test|style|revert)(\(.+?\))?[!]?:/i,
+                label: 'release:maintenance',
+              },
+            ];
+
+            const ALL_RELEASE_LABELS = ['release:feature', 'release:fix', 'release:docs', 'release:maintenance'];
+
+            // Find matching label
+            let targetLabel = null;
+            for (const { pattern, label } of MAPPING) {
+              if (pattern.test(title)) {
+                targetLabel = label;
+                break;
+              }
+            }
+
+            if (!targetLabel) {
+              core.info(`No conventional-commit prefix matched in title: "${title}" — skipping.`);
+              return;
+            }
+
+            // Fetch current labels on the PR
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner, repo, issue_number: number,
+            });
+            const currentNames = new Set(currentLabels.map(l => l.name));
+
+            // Already has the right release label → nothing to do
+            if (currentNames.has(targetLabel)) {
+              core.info(`Label "${targetLabel}" already present — no change.`);
+              return;
+            }
+
+            // Remove any other release:* labels that were set by a previous run
+            for (const existing of ALL_RELEASE_LABELS) {
+              if (existing !== targetLabel && currentNames.has(existing)) {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: number, name: existing,
+                });
+                core.info(`Removed stale label: ${existing}`);
+              }
+            }
+
+            // Add the correct label
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number: number, labels: [targetLabel],
+            });
+            core.info(`Assigned label: ${targetLabel}`);

--- a/.github/workflows/pr-size-labels.yml
+++ b/.github/workflows/pr-size-labels.yml
@@ -1,0 +1,105 @@
+name: PR Size Labels
+
+# Automatically assigns a size/* label to every PR based on the number of
+# changed lines, excluding generated/fixture/lockfile paths.
+#
+# Thresholds:
+#   size/XS   <  10  lines
+#   size/S    <  50  lines
+#   size/M    < 150  lines
+#   size/L    < 500  lines
+#   size/XL   >= 500 lines
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: "pr-size-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+
+jobs:
+  size-label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute diff size (excluding generated/fixture/lockfile paths)
+        id: diff
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          LINES=$(git diff --stat "$BASE"..."$HEAD" -- \
+            ':!uv.lock' \
+            ':!*.lock' \
+            ':!tests/fixtures/**' \
+            ':!benchmark_results/**' \
+            ':!benchmarks/corpus/**' \
+            ':!benchmarks/defect_corpus/**' \
+            ':!site/**' \
+            ':!docs-site/**' \
+            | tail -1 \
+            | grep -oP '\d+(?= insertions)' || echo 0)
+          DELS=$(git diff --stat "$BASE"..."$HEAD" -- \
+            ':!uv.lock' \
+            ':!*.lock' \
+            ':!tests/fixtures/**' \
+            ':!benchmark_results/**' \
+            ':!benchmarks/corpus/**' \
+            ':!benchmarks/defect_corpus/**' \
+            ':!site/**' \
+            ':!docs-site/**' \
+            | tail -1 \
+            | grep -oP '\d+(?= deletions)' || echo 0)
+          TOTAL=$(( LINES + DELS ))
+          echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
+          echo "Diff size (excl. generated): $TOTAL lines"
+
+      - name: Assign size label
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const total = parseInt('${{ steps.diff.outputs.total }}', 10);
+            const pr    = context.payload.pull_request.number;
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+
+            let newLabel;
+            if      (total <  10)  newLabel = 'size/XS';
+            else if (total <  50)  newLabel = 'size/S';
+            else if (total < 150)  newLabel = 'size/M';
+            else if (total < 500)  newLabel = 'size/L';
+            else                   newLabel = 'size/XL';
+
+            // Remove any existing size/* labels before adding the new one
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner, repo, issue_number: pr
+            });
+            const sizeLabels = labels
+              .map(l => l.name)
+              .filter(n => n.startsWith('size/'));
+
+            for (const old of sizeLabels) {
+              if (old !== newLabel) {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: pr, name: old
+                });
+              }
+            }
+
+            if (!sizeLabels.includes(newLabel)) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: pr, labels: [newLabel]
+              });
+            }
+            core.info(`PR #${pr} assigned ${newLabel} (${total} lines)`);

--- a/.github/workflows/pr-size-labels.yml
+++ b/.github/workflows/pr-size-labels.yml
@@ -38,7 +38,9 @@ jobs:
         run: |
           BASE="${{ github.event.pull_request.base.sha }}"
           HEAD="${{ github.event.pull_request.head.sha }}"
-          LINES=$(git diff --stat "$BASE"..."$HEAD" -- \
+          # Use --numstat (tab-separated added/deleted per file) to avoid
+          # singular/plural parsing issues with --stat summary lines.
+          TOTAL=$(git diff --numstat "$BASE"..."$HEAD" -- \
             ':!uv.lock' \
             ':!*.lock' \
             ':!tests/fixtures/**' \
@@ -47,20 +49,7 @@ jobs:
             ':!benchmarks/defect_corpus/**' \
             ':!site/**' \
             ':!docs-site/**' \
-            | tail -1 \
-            | grep -oP '\d+(?= insertions)' || echo 0)
-          DELS=$(git diff --stat "$BASE"..."$HEAD" -- \
-            ':!uv.lock' \
-            ':!*.lock' \
-            ':!tests/fixtures/**' \
-            ':!benchmark_results/**' \
-            ':!benchmarks/corpus/**' \
-            ':!benchmarks/defect_corpus/**' \
-            ':!site/**' \
-            ':!docs-site/**' \
-            | tail -1 \
-            | grep -oP '\d+(?= deletions)' || echo 0)
-          TOTAL=$(( LINES + DELS ))
+            | awk '{a+=$1; d+=$2} END {print a+d+0}')
           echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
           echo "Diff size (excl. generated): $TOTAL lines"
 

--- a/.github/workflows/pr-size-labels.yml
+++ b/.github/workflows/pr-size-labels.yml
@@ -49,7 +49,7 @@ jobs:
             ':!benchmarks/defect_corpus/**' \
             ':!site/**' \
             ':!docs-site/**' \
-            | awk '{a+=$1; d+=$2} END {print a+d+0}')
+            | awk '$1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ {a+=$1; d+=$2} END {print a+d+0}')
           echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
           echo "Diff size (excl. generated): $TOTAL lines"
 

--- a/.github/workflows/pr-throughput-kpi.yml
+++ b/.github/workflows/pr-throughput-kpi.yml
@@ -109,8 +109,9 @@ jobs:
 
               // Time to first review + review rounds
               try {
-                const { data: reviews } = await github.rest.pulls.listReviews({
-                  owner, repo, pull_number: pr.number
+                // Paginate all reviews so metrics are not computed from truncated data.
+                const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                  owner, repo, pull_number: pr.number, per_page: 100
                 });
                 if (reviews.length > 0) {
                   const firstReview = reviews.reduce((a, b) =>
@@ -119,7 +120,9 @@ jobs:
                   timesToFirstReview.push(
                     (new Date(firstReview.submitted_at) - created) / 3_600_000
                   );
-                  // Review rounds: number of review-request/re-request cycles
+                  // review_rounds: number of review submissions as a proxy for
+                  // review-round effort. True request/re-request cycle counting
+                  // would require the timeline API and is omitted for scale reasons.
                   reviewRounds.push(reviews.length);
                 }
               } catch (_) {
@@ -175,4 +178,6 @@ jobs:
           git add benchmark_results/kpi_snapshot.json benchmark_results/kpi_trend.jsonl
           git diff --cached --quiet && echo "No changes" || \
             git commit -m "chore: weekly PR throughput KPI snapshot [skip ci]"
+          # Rebase on any commits that landed during the run to avoid push rejection.
+          git pull --rebase --autostash origin "${{ github.ref_name }}"
           git push

--- a/.github/workflows/pr-throughput-kpi.yml
+++ b/.github/workflows/pr-throughput-kpi.yml
@@ -1,7 +1,7 @@
 name: PR Throughput KPI
 
 # Weekly KPI report for PR throughput metrics.
-# Computes 6 metrics from the last 30 days of merged/open PRs via GitHub API.
+# Computes 8 metrics from the last 30 days of merged/open PRs via GitHub API.
 # Appends to benchmark_results/kpi_trend.jsonl and overwrites kpi_snapshot.json.
 #
 # Metrics:
@@ -48,10 +48,12 @@ jobs:
             const cutoff   = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
             const cutoffISO = cutoff.toISOString();
 
-            // Fetch last 100 merged PRs (GitHub search: merged:>cutoff)
+            // Fetch all merged PRs in the 30-day window.
+            // Paginate until the page's last item is older than cutoff —
+            // no arbitrary count cap so metrics are not skewed on busier repos.
             let mergedPRs = [];
             let page = 1;
-            while (mergedPRs.length < 200) {
+            while (true) {
               const { data } = await github.rest.pulls.list({
                 owner, repo,
                 state: 'closed',
@@ -65,7 +67,7 @@ jobs:
                 p => p.merged_at && new Date(p.merged_at) >= cutoff
               );
               mergedPRs.push(...inWindow);
-              // If the last PR is older than cutoff, stop paginating
+              // Stop when the oldest item on this page is beyond the window
               if (new Date(data[data.length - 1].updated_at) < cutoff) break;
               page++;
             }
@@ -127,8 +129,13 @@ jobs:
 
             // Reopen rate: PRs that were reopened at some point
             // Approximate: check timeline events for "reopened" — too expensive at scale.
-            // Use 0 as placeholder; can be improved with per-PR timeline API calls.
-            const reopenRate = 0;
+            // Emitted as null (placeholder) to avoid misleading dashboards.
+
+            const mTtm = median(timesToMerge);
+            const pTtm = p90(timesToMerge);
+            const mTfr = median(timesToFirstReview);
+            const pTfr = p90(timesToFirstReview);
+            const mRr  = median(reviewRounds);
 
             const metrics = {
               schema_version:                    "1",
@@ -136,18 +143,18 @@ jobs:
               data_window_days:                  30,
               merged_prs_in_window:              mergedPRs.length,
               merged_prs_per_day:                parseFloat((mergedPRs.length / 30).toFixed(2)),
-              time_to_merge_median_hours:        parseFloat((median(timesToMerge) ?? 0).toFixed(2)),
-              time_to_merge_p90_hours:           parseFloat((p90(timesToMerge) ?? 0).toFixed(2)),
-              time_to_first_review_median_hours: parseFloat((median(timesToFirstReview) ?? 0).toFixed(2)),
-              time_to_first_review_p90_hours:    parseFloat((p90(timesToFirstReview) ?? 0).toFixed(2)),
-              review_rounds_median:              parseFloat((median(reviewRounds) ?? 0).toFixed(2)),
-              reopen_rate_pct:                   reopenRate,
+              time_to_merge_median_hours:        mTtm !== null ? parseFloat(mTtm.toFixed(2)) : null,
+              time_to_merge_p90_hours:           pTtm !== null ? parseFloat(pTtm.toFixed(2)) : null,
+              time_to_first_review_median_hours: mTfr !== null ? parseFloat(mTfr.toFixed(2)) : null,
+              time_to_first_review_p90_hours:    pTfr !== null ? parseFloat(pTfr.toFixed(2)) : null,
+              review_rounds_median:              mRr  !== null ? parseFloat(mRr.toFixed(2))  : null,
+              reopen_rate_pct:                   null,  // Placeholder: requires per-PR timeline API calls
               pct_fast_lane:                     mergedPRs.length > 0
                                                    ? parseFloat((fastLaneCount / mergedPRs.length * 100).toFixed(1))
-                                                   : 0,
+                                                   : null,
               pct_auto_triaged:                  mergedPRs.length > 0
                                                    ? parseFloat((autoTriagedCount / mergedPRs.length * 100).toFixed(1))
-                                                   : 0
+                                                   : null
             };
 
             core.setOutput('metrics_json', JSON.stringify(metrics, null, 2));

--- a/.github/workflows/pr-throughput-kpi.yml
+++ b/.github/workflows/pr-throughput-kpi.yml
@@ -1,0 +1,171 @@
+name: PR Throughput KPI
+
+# Weekly KPI report for PR throughput metrics.
+# Computes 6 metrics from the last 30 days of merged/open PRs via GitHub API.
+# Appends to benchmark_results/kpi_trend.jsonl and overwrites kpi_snapshot.json.
+#
+# Metrics:
+#   time_to_first_review_median_hours
+#   time_to_first_review_p90_hours
+#   time_to_merge_median_hours
+#   time_to_merge_p90_hours
+#   review_rounds_median
+#   reopen_rate_pct
+#   pct_fast_lane
+#   pct_auto_triaged
+
+on:
+  schedule:
+    - cron: "0 7 * * 0"  # Every Sunday 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  kpi:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute PR throughput KPIs
+        id: kpi
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+
+            const now      = new Date();
+            const cutoff   = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+            const cutoffISO = cutoff.toISOString();
+
+            // Fetch last 100 merged PRs (GitHub search: merged:>cutoff)
+            let mergedPRs = [];
+            let page = 1;
+            while (mergedPRs.length < 200) {
+              const { data } = await github.rest.pulls.list({
+                owner, repo,
+                state: 'closed',
+                sort: 'updated',
+                direction: 'desc',
+                per_page: 100,
+                page
+              });
+              if (data.length === 0) break;
+              const inWindow = data.filter(
+                p => p.merged_at && new Date(p.merged_at) >= cutoff
+              );
+              mergedPRs.push(...inWindow);
+              // If the last PR is older than cutoff, stop paginating
+              if (new Date(data[data.length - 1].updated_at) < cutoff) break;
+              page++;
+            }
+            core.info(`Merged PRs in window: ${mergedPRs.length}`);
+
+            // Helper: median
+            function median(arr) {
+              if (arr.length === 0) return null;
+              const s = [...arr].sort((a, b) => a - b);
+              const mid = Math.floor(s.length / 2);
+              return s.length % 2 === 0 ? (s[mid - 1] + s[mid]) / 2 : s[mid];
+            }
+            // Helper: p90
+            function p90(arr) {
+              if (arr.length === 0) return null;
+              const s = [...arr].sort((a, b) => a - b);
+              const idx = Math.ceil(0.9 * s.length) - 1;
+              return s[Math.max(0, idx)];
+            }
+
+            // Per-PR metrics
+            const timesToMerge = [];
+            const timesToFirstReview = [];
+            const reviewRounds = [];
+            let reopened = 0;
+            let fastLaneCount = 0;
+            let autoTriagedCount = 0;
+
+            for (const pr of mergedPRs) {
+              // Time to merge (hours)
+              const created = new Date(pr.created_at);
+              const merged  = new Date(pr.merged_at);
+              timesToMerge.push((merged - created) / 3_600_000);
+
+              // Labels
+              const lbls = pr.labels.map(l => l.name);
+              if (lbls.includes('lane/fast-lane')) fastLaneCount++;
+              if (lbls.includes('auto-triaged'))   autoTriagedCount++;
+
+              // Time to first review + review rounds
+              try {
+                const { data: reviews } = await github.rest.pulls.listReviews({
+                  owner, repo, pull_number: pr.number
+                });
+                if (reviews.length > 0) {
+                  const firstReview = reviews.reduce((a, b) =>
+                    new Date(a.submitted_at) < new Date(b.submitted_at) ? a : b
+                  );
+                  timesToFirstReview.push(
+                    (new Date(firstReview.submitted_at) - created) / 3_600_000
+                  );
+                  // Review rounds: number of review-request/re-request cycles
+                  reviewRounds.push(reviews.length);
+                }
+              } catch (_) {
+                // Ignore individual PR failures
+              }
+            }
+
+            // Reopen rate: PRs that were reopened at some point
+            // Approximate: check timeline events for "reopened" — too expensive at scale.
+            // Use 0 as placeholder; can be improved with per-PR timeline API calls.
+            const reopenRate = 0;
+
+            const metrics = {
+              schema_version:                    "1",
+              computed_at:                       now.toISOString(),
+              data_window_days:                  30,
+              merged_prs_in_window:              mergedPRs.length,
+              merged_prs_per_day:                parseFloat((mergedPRs.length / 30).toFixed(2)),
+              time_to_merge_median_hours:        parseFloat((median(timesToMerge) ?? 0).toFixed(2)),
+              time_to_merge_p90_hours:           parseFloat((p90(timesToMerge) ?? 0).toFixed(2)),
+              time_to_first_review_median_hours: parseFloat((median(timesToFirstReview) ?? 0).toFixed(2)),
+              time_to_first_review_p90_hours:    parseFloat((p90(timesToFirstReview) ?? 0).toFixed(2)),
+              review_rounds_median:              parseFloat((median(reviewRounds) ?? 0).toFixed(2)),
+              reopen_rate_pct:                   reopenRate,
+              pct_fast_lane:                     mergedPRs.length > 0
+                                                   ? parseFloat((fastLaneCount / mergedPRs.length * 100).toFixed(1))
+                                                   : 0,
+              pct_auto_triaged:                  mergedPRs.length > 0
+                                                   ? parseFloat((autoTriagedCount / mergedPRs.length * 100).toFixed(1))
+                                                   : 0
+            };
+
+            core.setOutput('metrics_json', JSON.stringify(metrics, null, 2));
+            core.info(JSON.stringify(metrics, null, 2));
+
+      - name: Write kpi_snapshot.json and append kpi_trend.jsonl
+        run: |
+          echo '${{ steps.kpi.outputs.metrics_json }}' > benchmark_results/kpi_snapshot.json
+
+          # Append single-line entry to kpi_trend.jsonl
+          ENTRY=$(echo '${{ steps.kpi.outputs.metrics_json }}' | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin)))")
+          echo "$ENTRY" >> benchmark_results/kpi_trend.jsonl
+
+      - name: Commit KPI results
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add benchmark_results/kpi_snapshot.json benchmark_results/kpi_trend.jsonl
+          git diff --cached --quiet && echo "No changes" || \
+            git commit -m "chore: weekly PR throughput KPI snapshot [skip ci]"
+          git push

--- a/.github/workflows/proactive-qa.yml
+++ b/.github/workflows/proactive-qa.yml
@@ -3,6 +3,13 @@ name: Proactive QA
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'packages/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'drift.output.schema.json'
+      - '.github/workflows/proactive-qa.yml'
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/score-gate.yml
+++ b/.github/workflows/score-gate.yml
@@ -10,6 +10,13 @@ name: Drift Score Gate
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'packages/**'
+      - 'pyproject.toml'
+      - 'drift.yaml'
+      - 'drift.strict.yaml'
+      - '.github/workflows/score-gate.yml'
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/security-hygiene.yml
+++ b/.github/workflows/security-hygiene.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'packages/**'
+      - 'scripts/**'
+      - '.github/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '*.toml'
   merge_group:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -38,3 +38,24 @@ jobs:
           stale-pr-label: "stale"
           exempt-issue-labels: "good first issue,help wanted,signal-quality"
           exempt-pr-labels: "help wanted"
+
+      # Fast-close PRs with needs-description: 3 days stale, 4 days to close.
+      # Contributors who forget the template should be prompted to re-open with
+      # a filled-in description rather than blocking the queue for weeks.
+      - uses: actions/stale@v9
+        with:
+          stale-pr-message: >
+            This PR has been marked stale because the description is missing or
+            contains only the template placeholder. Please fill in the PR template
+            and remove the `needs-description` label to reactivate it.
+            It will be closed in 4 days if no update is made.
+          close-pr-message: >
+            Closing this PR because the description was not filled in within 7 days.
+            Feel free to re-open with a completed PR template.
+          days-before-stale: -1
+          days-before-close: -1
+          days-before-pr-stale: 3
+          days-before-pr-close: 4
+          stale-pr-label: "stale"
+          only-pr-labels: "needs-description"
+          exempt-pr-labels: "help wanted"

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -21,8 +21,8 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             Thanks for opening your first issue! 👋
 
             We'll get back to you within 72 hours. In the meantime:
@@ -30,7 +30,7 @@ jobs:
             - Search existing [issues](https://github.com/mick-gsk/drift/issues) and [discussions](https://github.com/mick-gsk/drift/discussions)
 
             If this is a false-positive report, please include the drift version, signal name, and a minimal code example.
-          pr-message: |
+          pr_message: |
             Thanks for your first pull request! 👋
 
             A maintainer will review this within a few days. Please make sure:

--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,10 @@ audit_results/*
 !audit_results/fault_trees.md
 benchmark_results/*
 !benchmark_results/kpi_snapshot.json
+!benchmark_results/kpi_trend.jsonl
 !benchmark_results/mutation_benchmark.json
 !benchmark_results/drift_self.json
-!benchmark_results/kpi_trend.jsonl
+!benchmark_results/pr_throughput_baseline.json
 drift_score.json
 work_artifacts/
 master-backlog/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
 ## [2.50.0] - 2026-05-03
 
-Short version: Add Copilot coding agent setup — issue template, brief-check workflow, labels, and contributor docs.
+Short version: Add PR automation suite — lane labels, size labels, fast-lane automerge, auto-triage, Copilot PR auto-merge, weekly KPI workflow, and CI path filters for non-Python PRs.
+
+### Added
+- Add PR lane labels (`lane/fast-lane`, `lane/standard`, `lane/high-risk`) via `actions/labeler` with collision rules (high-risk > standard > fast-lane)
+- Add `pr-size-labels.yml`: assigns `size/XS`–`size/XL` to every PR based on changed lines, excluding generated/fixture/lockfile paths; binary files handled correctly
+- Add `pr-fast-lane-automerge.yml`: squash-merges `lane/fast-lane` + `size/XS|S` PRs automatically after approval + CI pass; paginated reviews and check runs; fork-safe branch deletion
+- Add `copilot-pr-auto-merge.yml`: enables GitHub auto-merge on verified Copilot-authored PRs (actor-based detection only, no branch-name auth signal)
+- Add `pr-auto-triage.yml`: labels PRs missing description or bug link; removes `auto-triaged` label when all triage conditions are resolved
+- Add `pr-throughput-kpi.yml`: weekly scheduled KPI snapshot (8 metrics, 30-day window); paginated reviews; rebases before push to avoid rejection on concurrent commits
+- Add paths filters to `proactive-qa.yml`, `security-hygiene.yml`, `score-gate.yml`, `dependency-review.yml` to skip non-Python PRs
+- Add `.pre-commit-config.yaml` to `ci.yml` `code` path filter so hook-config changes are always validated
 
 ### Changed
-- Add Copilot coding agent setup: issue template, brief-check workflow, labels, and contract test
-- Add PR throughput lanes, size labels, and KPI workflow
+- `labeler.yml` `lane/standard` expanded to cover `packages/`, `tests/`, `scripts/`, `.github/workflows/**`, `pyproject.toml`, `uv.lock` — every PR now receives a lane label
+- `ci.yml` internal `code` filter extended with `.pre-commit-config.yaml`
 
 ### Fixed
 - address PR review — cleanup on label removal, consistent section names, direct yaml import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Short version: Add Copilot coding agent setup — issue template, brief-check wo
 
 ### Changed
 - Add Copilot coding agent setup: issue template, brief-check workflow, labels, and contract test
-- add PR throughput lanes, size labels, and KPI workflow
+- Add PR throughput lanes, size labels, and KPI workflow
 
 ### Fixed
 - address PR review — cleanup on label removal, consistent section names, direct yaml import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Short version: Add Copilot coding agent setup — issue template, brief-check wo
 
 ### Changed
 - Add Copilot coding agent setup: issue template, brief-check workflow, labels, and contract test
+- add PR throughput lanes, size labels, and KPI workflow
 
 ### Fixed
 - address PR review — cleanup on label removal, consistent section names, direct yaml import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,21 +3,13 @@
 Short version: Add PR automation suite — lane labels, size labels, fast-lane automerge, auto-triage, Copilot PR auto-merge, weekly KPI workflow, and CI path filters for non-Python PRs.
 
 ### Added
-- Add PR lane labels (`lane/fast-lane`, `lane/standard`, `lane/high-risk`) via `actions/labeler` with collision rules (high-risk > standard > fast-lane)
-- Add `pr-size-labels.yml`: assigns `size/XS`–`size/XL` to every PR based on changed lines, excluding generated/fixture/lockfile paths; binary files handled correctly
-- Add `pr-fast-lane-automerge.yml`: squash-merges `lane/fast-lane` + `size/XS|S` PRs automatically after approval + CI pass; paginated reviews and check runs; fork-safe branch deletion
-- Add `copilot-pr-auto-merge.yml`: enables GitHub auto-merge on verified Copilot-authored PRs (actor-based detection only, no branch-name auth signal)
-- Add `pr-auto-triage.yml`: labels PRs missing description or bug link; removes `auto-triaged` label when all triage conditions are resolved
-- Add `pr-throughput-kpi.yml`: weekly scheduled KPI snapshot (8 metrics, 30-day window); paginated reviews; rebases before push to avoid rejection on concurrent commits
-- Add paths filters to `proactive-qa.yml`, `security-hygiene.yml`, `score-gate.yml`, `dependency-review.yml` to skip non-Python PRs
-- Add `.pre-commit-config.yaml` to `ci.yml` `code` path filter so hook-config changes are always validated
-
-### Changed
-- `labeler.yml` `lane/standard` expanded to cover `packages/`, `tests/`, `scripts/`, `.github/workflows/**`, `pyproject.toml`, `uv.lock` — every PR now receives a lane label
-- `ci.yml` internal `code` filter extended with `.pre-commit-config.yaml`
+- Add PR lane labels (`lane/fast-lane`, `lane/standard`, `lane/high-risk`) and size labels (`size/XS`–`size/XL`) via `actions/labeler`
+- Add `pr-fast-lane-automerge.yml`: squash-merges fast-lane + XS/S PRs after approval + CI pass
+- Add `copilot-pr-auto-merge.yml`, `pr-auto-triage.yml`, `pr-throughput-kpi.yml` workflows
+- Add path filters to `proactive-qa.yml`, `security-hygiene.yml`, `score-gate.yml`, `dependency-review.yml`, and `ci.yml`
 
 ### Fixed
-- address PR review — cleanup on label removal, consistent section names, direct yaml import
+- Expand `labeler.yml` standard lane scope; fix label removal cleanup and section names
 
 ## [2.49.0] - 2026-04-30
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -449,6 +449,30 @@ Team convention:
 2. If scope changes, update the release label before merge.
 3. Maintainers confirm the final release label during review.
 
+## PR Lanes
+
+Every PR is automatically assigned a `lane/*` label based on the files it touches.
+The lane determines which check path applies and whether automerge is eligible.
+
+| Lane | Files | Check Path | Automerge |
+|---|---|---|---|
+| `lane/fast-lane` | docs, prompts, instructions, fixtures, benchmark_results | Reduced (CI must pass) | Yes — if size/XS or size/S + 1 review |
+| `lane/standard` | src/drift (excl. signals/scoring/ingestion) | Standard path | No |
+| `lane/high-risk` | signals, scoring, ingestion, POLICY.md, ADRs, audit artifacts | Full gates + audit (POLICY §18) | No |
+
+**Collision rule:** `lane/high-risk` > `lane/standard` > `lane/fast-lane`. If any file in a PR
+touches a high-risk path, the entire PR is treated as high-risk.
+
+**Automerge conditions (fast-lane only — all must be true):**
+1. Label `lane/fast-lane` is present
+2. Label `size/XS` or `size/S` is present
+3. All required CI checks are green
+4. At least one approved review
+5. None of these labels present: `blocked`, `needs-description`, `needs-buglink`
+
+**XL override:** PRs with `size/XL` must be split or include an explicit override comment
+`<!-- large-pr: justified because <reason> -->` in the PR body.
+
 ## Feature Evidence Gate (Required)
 
 For every PR that introduces a new feature (`feat:` commits), empirical evidence is mandatory.

--- a/benchmark_results/pr_throughput_baseline.json
+++ b/benchmark_results/pr_throughput_baseline.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1",
+  "generated_at": "2026-05-03",
+  "data_window_days": 30,
+  "note": "Baseline from PR-Throughput analysis (2026-05-03). See docs for methodology.",
+  "metrics": {
+    "merged_prs_per_day": 0.6,
+    "merged_prs_30d": 18,
+    "open_prs": 27,
+    "median_time_to_merge_hours": 6.08,
+    "p90_time_to_merge_hours": 730.6,
+    "author_concentration_top1_pct": 88.9,
+    "prs_with_size_label_pct": 0.0,
+    "pct_fast_lane": null,
+    "pct_auto_triaged": null,
+    "time_to_first_review_median_hours": null,
+    "review_rounds_median": null,
+    "reopen_rate_pct": null
+  },
+  "targets": {
+    "merged_prs_per_day": 3.0,
+    "median_time_to_merge_hours": 3.0,
+    "prs_with_size_label_pct": 100.0,
+    "pct_fast_lane_at_steady_state": 30.0
+  }
+}


### PR DESCRIPTION
## Summary

- Problem: PR label automation was broken (size/release labels not applied), and PR/issue templates were less structured than comparable open source projects
- Why it matters: Contributors need clear templates to submit quality PRs; maintainers need consistent metadata for triage and release automation
- What changed: Fixed label automation workflows, added size/release label backfill, upgraded PR template and issue forms to match openclaw's completeness level
- What did NOT change: drift-specific Policy criterion, Empirical evidence, and Risk Audit sections remain intact in the PR template

## Changes included

### Label automation fixes
- `.github/labeler.yml`: fixed `documentation` → `docs` label, added `lane/standard` rule
- `.github/labels.yml`: added 8 area labels (signals, scoring, ingestion, output, cli, ci, config, security)
- `.github/workflows/pr-release-label.yml`: new workflow — assigns `release:*` label from PR title
- `.github/workflows/pr-label-backfill.yml`: new workflow — `workflow_dispatch` backfill for existing PRs

### PR template and issue form upgrades (openclaw parity)
- `PULL_REQUEST_TEMPLATE.md`: added Root Cause, Regression Test Plan, User-visible Changes, Diagram, **Security Impact (required)**, Repro + Verification, Evidence, Human Verification, Review Conversations, Compatibility/Migration, and Risks/Mitigations sections
- `ISSUE_TEMPLATE/bug_report.yml`: added Bug type dropdown, Impact and severity, Root cause, and Evidence/logs fields
- `ISSUE_TEMPLATE/feature_request.yml`: added structured Impact field and Evidence/examples field

## Validation
- [x] All existing label automation verified via backfill run (105 PRs)
- [x] Size label duplicates cleaned up (37 PRs corrected)
- [x] Templates follow GitHub form schema (YAML valid)