### PR TITLE
fix(ci): resolve systemic pre-commit and security-hygiene check failures

### DIFF
--- a/.github/workflows/pr-throughput-kpi.yml
+++ b/.github/workflows/pr-throughput-kpi.yml
@@ -176,8 +176,11 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add benchmark_results/kpi_snapshot.json benchmark_results/kpi_trend.jsonl
-          git diff --cached --quiet && echo "No changes" || \
+          if git diff --cached --quiet; then
+            echo "No changes"
+          else
             git commit -m "chore: weekly PR throughput KPI snapshot [skip ci]"
+          fi
           # Rebase on any commits that landed during the run to avoid push rejection.
           git pull --rebase --autostash origin "${{ github.ref_name }}"
           git push

--- a/scripts/quality_scorecard.py
+++ b/scripts/quality_scorecard.py
@@ -54,7 +54,7 @@ def _read_coverage_ratio(path: Path) -> float | None:
     if not path.exists():
         return None
     try:
-        root = ElementTree.fromstring(path.read_text(encoding="utf-8"))
+        root = ElementTree.fromstring(path.read_text(encoding="utf-8"))  # nosec B314 - coverage.xml is trusted local output, not network input
         line_rate = root.attrib.get("line-rate")
         if line_rate is None:
             return None


### PR DESCRIPTION
## Problem

Zwei Checks schlugen auf **nahezu jedem PR** systematisch fehl und blockierten Merges:

| Check | Plattform | Fehler |
|---|---|---|
| `Pre-commit hooks` | ubuntu | `actionlint` SC2015 in `pr-throughput-kpi.yml:175` |
| `Secret and workflow hygiene` | ubuntu | `actionlint` SC2015 in `pr-throughput-kpi.yml:175` |
| `Secret and workflow hygiene` | windows | `bandit` B314 in `scripts/quality_scorecard.py:57` |

## Ursachen & Fixes

### 1. `pr-throughput-kpi.yml` — SC2015 Anti-Pattern

**Vorher:**
```bash
git diff --cached --quiet && echo "No changes" || \
  git commit -m "..."
```

`shellcheck` SC2015: `A && B || C` ist kein if-then-else — `C` kann auch laufen wenn `A` wahr ist.

**Nachher:**
```bash
if git diff --cached --quiet; then
  echo "No changes"
else
  git commit -m "..."
fi
```

### 2. `scripts/quality_scorecard.py` — B314 XML-Parsing

`bandit` flaggte `ElementTree.fromstring()` als potentiell unsicher (CWE-20). Die Quelle ist `coverage.xml` — lokal von pytest generierte Ausgabe, kein Netzwerk-Input. Annotation `# nosec B314` mit Begründung hinzugefügt.

## Impact

Nach Merge dieser beiden Fixes sollten `Pre-commit hooks` und `Secret and workflow hygiene` auf allen bestehenden PRs grün werden (sofern kein anderer Fehler vorliegt).

> `welcome`-Check: bereits durch `34bea79fb` auf main behoben (Input-Namen-Migration auf `actions/first-interaction@v3`).
