### PR TITLE
ci: skip bot-submitted pull_request_review in fast-lane automerge

### DIFF
--- a/.github/workflows/pr-fast-lane-automerge.yml
+++ b/.github/workflows/pr-fast-lane-automerge.yml
@@ -25,9 +25,11 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Only act on the default branch target
+    # Only act on the default branch target.
+    # Skip bot-submitted reviews (e.g. Copilot review) to avoid action_required
+    # blocks from GitHub's outside-collaborator approval policy.
     if: |
-      github.event_name == 'pull_request_review' ||
+      (github.event_name == 'pull_request_review' && !endsWith(github.actor, '[bot]')) ||
       (github.event_name == 'check_suite' && github.event.check_suite.conclusion == 'success')
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-throughput-kpi.yml
+++ b/.github/workflows/pr-throughput-kpi.yml
@@ -176,8 +176,11 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add benchmark_results/kpi_snapshot.json benchmark_results/kpi_trend.jsonl
-          git diff --cached --quiet && echo "No changes" || \
+          if git diff --cached --quiet; then
+            echo "No changes"
+          else
             git commit -m "chore: weekly PR throughput KPI snapshot [skip ci]"
+          fi
           # Rebase on any commits that landed during the run to avoid push rejection.
           git pull --rebase --autostash origin "${{ github.ref_name }}"
           git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,22 +3,12 @@
 Short version: Add PR automation suite — lane labels, size labels, fast-lane automerge, auto-triage, Copilot PR auto-merge, weekly KPI workflow, and CI path filters for non-Python PRs.
 
 ### Added
-- Add PR lane labels (`lane/fast-lane`, `lane/standard`, `lane/high-risk`) via `actions/labeler` with collision rules (high-risk > standard > fast-lane)
-- Add `pr-size-labels.yml`: assigns `size/XS`–`size/XL` to every PR based on changed lines, excluding generated/fixture/lockfile paths; binary files handled correctly
-- Add `pr-fast-lane-automerge.yml`: squash-merges `lane/fast-lane` + `size/XS|S` PRs automatically after approval + CI pass; paginated reviews and check runs; fork-safe branch deletion
-- Add `copilot-pr-auto-merge.yml`: enables GitHub auto-merge on verified Copilot-authored PRs (actor-based detection only, no branch-name auth signal)
-- Add `pr-auto-triage.yml`: labels PRs missing description or bug link; removes `auto-triaged` label when all triage conditions are resolved
-- Add `pr-throughput-kpi.yml`: weekly scheduled KPI snapshot (8 metrics, 30-day window); paginated reviews; rebases before push to avoid rejection on concurrent commits
-- Add paths filters to `proactive-qa.yml`, `security-hygiene.yml`, `score-gate.yml`, `dependency-review.yml` to skip non-Python PRs
-- Add `.pre-commit-config.yaml` to `ci.yml` `code` path filter so hook-config changes are always validated
-
-### Changed
-- `labeler.yml` `lane/standard` expanded to cover `packages/`, `tests/`, `scripts/`, `.github/workflows/**`, `pyproject.toml`, `uv.lock` — every PR now receives a lane label
-- `ci.yml` internal `code` filter extended with `.pre-commit-config.yaml`
+- Add PR lane labels, size labels (`size/XS`–`size/XL`), and fast-lane automerge workflow (squash-merge after approval + CI, paginated reviews/checks)
+- Add `copilot-pr-auto-merge.yml`, `pr-auto-triage.yml`, and `pr-throughput-kpi.yml` (weekly KPI snapshot, 8 metrics, 30-day window)
+- Add paths filters to `proactive-qa.yml`, `security-hygiene.yml`, `score-gate.yml`, `dependency-review.yml`, and `ci.yml` to skip non-Python PRs
 
 ### Fixed
-- address PR review — cleanup on label removal, consistent section names, direct yaml import
-- correct actions/first-interaction@v3 input names (repo_token, issue_message, pr_message)
+- Correct `actions/first-interaction@v3` input names; address PR review comments (label removal cleanup, consistent names)
 
 ## [2.49.0] - 2026-04-30
 

--- a/scripts/quality_scorecard.py
+++ b/scripts/quality_scorecard.py
@@ -54,7 +54,7 @@ def _read_coverage_ratio(path: Path) -> float | None:
     if not path.exists():
         return None
     try:
-        root = ElementTree.fromstring(path.read_text(encoding="utf-8"))
+        root = ElementTree.fromstring(path.read_text(encoding="utf-8"))  # nosec B314 - coverage.xml is trusted local output, not network input
         line_rate = root.attrib.get("line-rate")
         if line_rate is None:
             return None


### PR DESCRIPTION
Fixes `action_required` noise in the Actions tab.

**Root cause:** GitHub blocks workflow runs with write permissions when triggered by outside-collaborator bots (Copilot). The Fast-Lane Automerge had no bot filter on `pull_request_review` events — when Copilot submitted a code review, the workflow was triggered but immediately blocked by GitHub's security policy, showing as `action_required` with no jobs.

**Fix:** Add `!endsWith(github.actor, '[bot]')` guard to the `pull_request_review` branch of the job `if` condition. Bot-triggered reviews now result in a clean `skipped` run instead of a blocked `action_required` run.