### PR TITLE
fix: classify phantom references under AI quality

### DIFF
--- a/docs-site/reference/negative-context.md
+++ b/docs-site/reference/negative-context.md
@@ -30,6 +30,7 @@ an already known anti-pattern elsewhere.
 - `naming`
 - `complexity`
 - `completeness`
+- `ai_quality`
 
 `NegativeContextScope` values:
 

--- a/src/drift/models/_enums.py
+++ b/src/drift/models/_enums.py
@@ -178,6 +178,7 @@ class NegativeContextCategory(StrEnum):
     NAMING = "naming"
     COMPLEXITY = "complexity"
     COMPLETENESS = "completeness"
+    AI_QUALITY = "ai_quality"
 
 
 class NegativeContextScope(StrEnum):

--- a/src/drift/negative_context/core.py
+++ b/src/drift/negative_context/core.py
@@ -74,7 +74,7 @@ _SIGNAL_CATEGORY: dict[str, NegativeContextCategory] = {
     SignalType.FAN_OUT_EXPLOSION: NegativeContextCategory.ARCHITECTURE,
     SignalType.TS_ARCHITECTURE: NegativeContextCategory.ARCHITECTURE,
     SignalType.COGNITIVE_COMPLEXITY: NegativeContextCategory.COMPLEXITY,
-    SignalType.PHANTOM_REFERENCE: NegativeContextCategory.COMPLETENESS,
+    SignalType.PHANTOM_REFERENCE: NegativeContextCategory.AI_QUALITY,
 }
 
 

--- a/src/drift/negative_context/export.py
+++ b/src/drift/negative_context/export.py
@@ -31,6 +31,7 @@ _CATEGORY_HEADING: dict[NegativeContextCategory, str] = {
     NegativeContextCategory.NAMING: "Naming Anti-Patterns",
     NegativeContextCategory.COMPLEXITY: "Complexity Anti-Patterns",
     NegativeContextCategory.COMPLETENESS: "Completeness Anti-Patterns",
+    NegativeContextCategory.AI_QUALITY: "AI-Generated Code Anti-Patterns",
 }
 
 _SEVERITY_ICON: dict[Severity, str] = {

--- a/src/drift/negative_context/generators.py
+++ b/src/drift/negative_context/generators.py
@@ -1200,7 +1200,7 @@ def _gen_phr(finding: Finding) -> list[NegativeContext]:
 
     return [NegativeContext(
         anti_pattern_id=_neg_id(SignalType.PHANTOM_REFERENCE, finding),
-        category=NegativeContextCategory.COMPLETENESS,
+        category=NegativeContextCategory.AI_QUALITY,
         source_signal=SignalType.PHANTOM_REFERENCE,
         severity=finding.severity,
         scope=_scope_from_finding(finding),

--- a/tests/test_issue_473_ai_quality_category.py
+++ b/tests/test_issue_473_ai_quality_category.py
@@ -1,0 +1,86 @@
+"""Regression tests for issue #473: PHR findings must use the AI_QUALITY category.
+
+Phantom references detect AI-hallucinated symbol usage. They were previously
+exported under the generic COMPLETENESS category, which hid them from
+consumers filtering for AI-specific anti-patterns and diverged from the
+``ai_quality`` category already used in signal_registry.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from drift.models import (
+    Finding,
+    NegativeContextCategory,
+    Severity,
+    SignalType,
+)
+from drift.negative_context import findings_to_negative_context
+from drift.negative_context.core import _SIGNAL_CATEGORY
+from drift.negative_context.export import (
+    _CATEGORY_HEADING,
+    render_negative_context_markdown,
+)
+
+
+def _phr_finding() -> Finding:
+    return Finding(
+        signal_type=SignalType.PHANTOM_REFERENCE,
+        severity=Severity.MEDIUM,
+        score=0.7,
+        title="2 unresolvable references in api/client.py",
+        description="Unresolvable names detected",
+        file_path=Path("api/client.py"),
+        start_line=10,
+        end_line=30,
+        metadata={
+            "phantom_names": [
+                {"name": "fetch_remote_config", "line": 15},
+                {"name": "validate_token", "line": 22},
+            ],
+            "phantom_count": 2,
+        },
+    )
+
+
+class TestPhantomReferenceAIQualityCategory:
+    def test_phantom_reference_uses_ai_quality_category(self) -> None:
+        """The signal-to-category map must classify PHR as AI_QUALITY."""
+        assert (
+            _SIGNAL_CATEGORY[SignalType.PHANTOM_REFERENCE]
+            == NegativeContextCategory.AI_QUALITY
+        )
+
+    def test_ai_quality_category_has_export_heading(self) -> None:
+        """AI_QUALITY must render under its own section heading."""
+        assert (
+            _CATEGORY_HEADING[NegativeContextCategory.AI_QUALITY]
+            == "AI-Generated Code Anti-Patterns"
+        )
+
+    def test_all_categories_have_export_headings(self) -> None:
+        """Every category should have an explicit heading so no section
+        silently falls back to a title-cased enum value."""
+        for category in NegativeContextCategory:
+            assert category in _CATEGORY_HEADING
+
+    def test_phr_finding_generates_ai_quality_item(self) -> None:
+        """End to end: a PHR finding produces an AI_QUALITY context item."""
+        items = findings_to_negative_context([_phr_finding()])
+        assert len(items) == 1
+        assert items[0].category == NegativeContextCategory.AI_QUALITY
+        assert items[0].source_signal == SignalType.PHANTOM_REFERENCE
+
+    def test_phr_item_renders_under_ai_quality_section(self) -> None:
+        """End to end: the rendered export places PHR items in the
+        AI-Generated Code Anti-Patterns section, not Completeness."""
+        items = findings_to_negative_context([_phr_finding()])
+        rendered = render_negative_context_markdown(
+            items,
+            fmt="instructions",
+            drift_score=0.4,
+            severity=Severity.MEDIUM,
+        )
+        assert "## AI-Generated Code Anti-Patterns" in rendered
+        assert "## Completeness Anti-Patterns" not in rendered

--- a/tests/test_negative_context.py
+++ b/tests/test_negative_context.py
@@ -716,7 +716,7 @@ class TestPhantomReferenceGenerator:
         assert len(result) >= 1
         nc = result[0]
         assert nc.source_signal == SignalType.PHANTOM_REFERENCE
-        assert nc.category == NegativeContextCategory.COMPLETENESS
+        assert nc.category == NegativeContextCategory.AI_QUALITY
         assert "client.py" in nc.description
         assert "fetch_remote_config" in nc.description
         assert nc.confidence >= 0.6


### PR DESCRIPTION
## Summary

Adds a dedicated `AI_QUALITY` negative-context category and uses it for phantom-reference findings, as proposed in #473.

## Problem

Phantom references identify hallucinated symbol usage from AI-assisted coding, but they were exported under the generic "Completeness Anti-Patterns" section. This diverged from `signal_registry.py`, which already categorizes PHR as `ai_quality`, and made it impossible for agent consumers to filter AI-specific constraints from negative-context output.

## Changes

- Added `AI_QUALITY = "ai_quality"` to `NegativeContextCategory` (`models/_enums.py`)
- Mapped `SignalType.PHANTOM_REFERENCE` to `AI_QUALITY` in `_SIGNAL_CATEGORY` (`negative_context/core.py`)
- Added the `AI-Generated Code Anti-Patterns` heading to `_CATEGORY_HEADING` (`negative_context/export.py`)
- Updated `_gen_phr` in `generators.py`, which hardcoded `COMPLETENESS`
- Updated the existing PHR category assertion in `tests/test_negative_context.py`
- Added `tests/test_issue_473_ai_quality_category.py`: the mapping, the heading, a completeness check that every category has a heading, and end-to-end tests that a PHR finding produces an `AI_QUALITY` item rendered under the new section
- Added `ai_quality` to the category list in `docs-site/reference/negative-context.md`

Checked `drift.output.schema.json` / `drift.schema.json` — neither enumerates `NegativeContextCategory` values, so no schema regeneration is needed.

## Note for consumers

Raw/JSON export now emits `"category": "ai_quality"` for PHR items where consumers previously saw `"completeness"` (asked about this in #473 — happy to add a changelog note if wanted).

## Validation

- `pytest` — 6682 passed. Excluded on my machine only: `TestCalibrateRunWriteGuard` (click 8.2 removed `mix_stderr`), `test_date_parsing` (timezone-dependent assertion, passes under UTC=+0 only), `test_model_consistency_check_passes` (SECURITY.md missing 2.51.x, pre-existing on main), and one rich-output snapshot test — all verified failing on a clean checkout of `main` as well
- New regression tests verified to fail against unpatched `main` and pass with this change
- `ruff check src/ tests/` — clean
- `mypy src/drift` — no new errors (same 2 pre-existing `cli.py` errors as `main`)

Closes #473
