### PR TITLE
docs: add ai_quality to remaining negative-context category references

### DIFF
--- a/docs-site/guides/negative-context-agents.md
+++ b/docs-site/guides/negative-context-agents.md
@@ -94,6 +94,7 @@ Each anti-pattern item has this stable shape:
 | `naming` | NBV | Naming convention violations |
 | `complexity` | EDS, GCD, CXS | Unnecessary complexity, missing guards |
 | `completeness` | DIA, BAT, DCA | Missing docs, accumulated bypasses, dead code |
+| `ai_quality` | PHR | AI-hallucinated symbol references |
 
 ### Scopes
 

--- a/docs-site/reference/api-outputs.md
+++ b/docs-site/reference/api-outputs.md
@@ -283,7 +283,7 @@ avoid regenerating known anti-patterns while applying a fix.
 `negative_context` items use this stable shape:
 
 - `anti_pattern_id`: deterministic identifier for deduplication
-- `category`: one of `security`, `error_handling`, `architecture`, `testing`, `naming`, `complexity`, `completeness`
+- `category`: one of `security`, `error_handling`, `architecture`, `testing`, `naming`, `complexity`, `completeness`, `ai_quality`
 - `source_signal`: signal key that generated the item
 - `severity`: `critical`, `high`, `medium`, `low`, or `info`
 - `scope`: one of `file`, `module`, `repo`


### PR DESCRIPTION
Follow-up to #754.

That PR added the `AI_QUALITY` category and updated `docs-site/reference/negative-context.md`, but two further docs still listed the old seven-value set:

- `docs-site/reference/api-outputs.md:286` — the `negative_context` field contract
- `docs-site/guides/negative-context-agents.md:96` — the Categories table, which had no PHR row at all

Both now cover all eight `NegativeContextCategory` values. Verified by deriving the enum values from `src/drift/models/_enums.py` and checking each against all three docs — no gaps remain.

Docs only, no code change. `markdownlint-cli2` produces no new violations (the two MD040 hits in the agents guide are pre-existing on `main`).

Note: CI cannot run on this repo right now — the account is Actions-locked for billing reasons, so every job fails at startup with `The job was not started because your account is locked due to a billing issue.` Verified locally instead.