### PR TITLE
test: fix four failures that made the suite red on main

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 2.51.x  | :white_check_mark: |
 | 2.50.x  | :white_check_mark: |
 | 2.49.x  | :white_check_mark: |
 | 2.48.x  | :white_check_mark: |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,23 @@
 
 from __future__ import annotations
 
-import subprocess
-import textwrap
-from collections.abc import Callable
-from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+import os
 
-import pytest
+# Silence the HuggingFace model-loading progress bar before anything imports
+# transformers. Tests that assert on CLI output compare against `result.output`,
+# which Click mixes stderr into (8.1 default, and `mix_stderr` is gone in 8.2),
+# so a "Loading weights: ..." bar on stderr corrupts the assertion. Each test
+# repo gets its own `.drift-cache`, which reinitialises the embedding service
+# and re-emits the bar, so this has to be off for the whole session.
+os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+
+import subprocess  # noqa: E402
+import textwrap  # noqa: E402
+from collections.abc import Callable  # noqa: E402
+from pathlib import Path  # noqa: E402
+from typing import TYPE_CHECKING, Literal  # noqa: E402
+
+import pytest  # noqa: E402
 
 if TYPE_CHECKING:
     from drift.models import Finding

--- a/tests/test_property_based.py
+++ b/tests/test_property_based.py
@@ -144,7 +144,16 @@ def test_discover_files_terminates_on_empty_repo(include: list[str], exclude: li
 
 @given(
     file_names=st.lists(
-        st.builds(lambda seg: f"{seg}.py", _path_segment),
+        # `_path_segment` may yield a bare "." or "..", which builds names like
+        # "..py" that pathlib does not regard as Python files at all —
+        # Path("..py").suffix is "" and .stem is "..py", so detect_language()
+        # correctly returns None and discovery skips them. Restrict generation
+        # to names that really do carry a .py suffix, otherwise this test
+        # asserts a property drift never promised. Without this filter the
+        # test is flaky: Hypothesis only sometimes searches its way to ".".
+        st.builds(lambda seg: f"{seg}.py", _path_segment).filter(
+            lambda name: Path(name).suffix == ".py"
+        ),
         min_size=1,
         max_size=5,
         unique=True,


### PR DESCRIPTION
The suite has been red on `main` for months. None of the four failures were product defects — all were harness or metadata issues that went unnoticed because Actions has not executed a single job since early May (account is Actions-locked for billing; every job dies at startup with `The job was not started because your account is locked due to a billing issue`).

## The four

**1–3. `test_badge_command` + two `test_import_command` failures** — one shared cause.

Each test repo gets its own `.drift-cache`, which reinitialises the embedding service and re-emits a `Loading weights: 0%|...` tqdm bar on **stderr**. Click's `CliRunner` mixes stderr into `result.output`, so the bar corrupted assertions that expected clean machine-readable output — the badge snippet and `json.loads(result.output)`.

The product is fine. Verified directly:

```console
$ drift badge --repo /tmp/x --format markdown 2>/dev/null
[![Drift Score](https://img.shields.io/badge/drift%20score-0.00-brightgreen?style=flat)](...)
```

stdout carries only the snippet; the bar goes to stderr, where it belongs.

Fixed by setting `HF_HUB_DISABLE_PROGRESS_BARS` in `tests/conftest.py` before transformers is imported. Deliberately **not** `CliRunner(mix_stderr=False)`: `click>=8.1` has no upper bound and `mix_stderr` was removed in 8.2, so that fix would break on the next upgrade.

**4. `test_model_consistency`** — `SECURITY.md` was missing the `2.51.x` row that `scripts/check_model_consistency.py` requires. One line.

## Bonus: a latent flake

`test_discover_files_finds_all_python_files` was **not** consistently failing — it is a Hypothesis property test that only sometimes searches its way to the bad input. `_path_segment` can yield a bare `.`, producing the filename `..py`, and pathlib does not consider that a Python file at all:

```python
Path("..py").suffix  # ''
Path("..py").stem    # '..py'
```

So `detect_language()` returns `None` and discovery skips it — correctly. The test asserted a property drift never promised. Generation is now restricted to names with a real `.py` suffix.

Quantified across 20 fixed seeds: **1/20 failed before, 0/20 after.**

## Verification

```
pytest    6780 passed, 6 skipped, 0 failed
ruff      All checks passed
mypy      Success: no issues found in 344 source files
check_model_consistency.py   OK
```

Verified locally — CI cannot run until the account lock is resolved.