### PR TITLE
docs: repair broken README links and restore the missing precision evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ benchmark_results/*
 !benchmark_results/mutation_benchmark.json
 !benchmark_results/drift_self.json
 !benchmark_results/pr_throughput_baseline.json
+# Precision/recall baselines are cited as evidence from README.md and
+# docs/STUDY.md — they must stay tracked or those claims lose their artifact.
+!benchmark_results/*_precision_recall_baseline.json
 drift_score.json
 work_artifacts/
 master-backlog/*

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ sections complete. See [CONTRIBUTING.md](CONTRIBUTING.md#assigning-tasks-to-copi
 
 ### GitHub Actions
 
-[![Available on GitHub Marketplace](https://img.shields.io/badge/Marketplace-Drift-orange?logo=github)](https://github.com/marketplace/actions/drift-ai-code-coherence-monitor)
+[![GitHub Action](https://img.shields.io/badge/GitHub%20Action-Drift-orange?logo=github)](action.yml)
 
 ```yaml
 # Try it — add this to .github/workflows/drift.yml
@@ -206,28 +206,6 @@ drift kit init   # scaffolds prompt files + VS Code settings — run once per re
 No additional Drift-specific extension install is needed for this workflow; you still need VS Code with GitHub Copilot Chat installed/enabled. `drift kit init` creates `.github/prompts/` with all four prompt files and merges `chat.promptFilesLocations` into `.vscode/settings.json` without touching your existing keys. Idempotent — safe to re-run.
 
 📖 [VS Code Copilot Chat Workflow guide →](https://mick-gsk.github.io/drift/guides/vscode-copilot-workflow/)
-
-### VS Code Extension
-
-The `vscode-drift` extension shows findings as inline **CodeLens** annotations — no terminal needed.
-
-```
-auth/handler.py             [Drift · C · score 0.71 · 3 findings (1 high, 2 medium)]
-  def authenticate(...):    [Drift · PFS · co-change coupling to auth/service.py · high]
-```
-
-**Install from VSIX:**
-```bash
-pip install drift-analyzer          # drift must be on PATH
-code --install-extension vscode-drift-0.1.0.vsix
-```
-
-Download the VSIX from the [Releases](https://github.com/mick-gsk/drift/releases) page, or build from source:
-```bash
-cd extensions/vscode-drift && npm install && npm run compile
-```
-
-📖 [Extension README →](extensions/vscode-drift/README.md)
 
 ### MCP / AI Tools — advanced execution layer
 
@@ -444,7 +422,7 @@ Paste the Markdown output into your README:
 [![Drift Score](https://img.shields.io/badge/drift%20score-0.39-green?style=flat)](https://github.com/mick-gsk/drift)
 ```
 
-**Automate in CI:** The [GitHub Action](https://github.com/marketplace/actions/drift-ai-code-coherence-monitor) exposes a `badge-svg` output — pipe it into your repo or a dashboard.
+**Automate in CI:** The [GitHub Action](action.yml) exposes a `badge-svg` output — pipe it into your repo or a dashboard.
 
 ---
 
@@ -555,7 +533,7 @@ Drift's pipeline is deterministic and benchmark artifacts are published in the r
 | Metric | Value | Artifact |
 |---|---|---|
 | Wild-repo precision | 77 % strict / 95 % lenient (5 repos) | [study §5](https://github.com/mick-gsk/drift/blob/main/docs/STUDY.md) |
-| Ground-truth regression | 0 FP, 0 FN (84 TP, 206 fixtures) | [v2.7.0 baseline](benchmark_results/v2.7.0_precision_recall_baseline.json) |
+| Ground-truth regression | 0 FP, 0 FN (84 TP, 206 fixtures) | [v2.51.1 baseline](benchmark_results/v2.51.1_precision_recall_baseline.json) |
 | Mutation recall | 75 % (75/100 injected) | [mutation benchmark](benchmark_results/mutation_benchmark.json) |
 | Agent session score delta | 0.495→0.506 (1 live run) ² | [Copilot Autopilot artefacts](demos/copilot-autopilot/) |
 
@@ -568,7 +546,7 @@ Drift's pipeline is deterministic and benchmark artifacts are published in the r
 - **The composite score is orientation, not a verdict.** Interpret deltas via `drift trend`, not isolated snapshots.
 - **Own score context (0.36):** Drift's self-score is driven primarily by architecture violations and explainability deficit (undocumented internal functions). Pattern fragmentation in modules with intentionally diverse error-handling contracts (signals, API, calibration, integrations) is suppressed via `path_overrides` — those variations are architectural, not accidental. The score reflects a fast-moving codebase that prioritises signal correctness over internal documentation. See [drift_self.json](benchmark_results/drift_self.json) for the full breakdown.
 - **Signal overlap:** Some signals measure related phenomena (e.g., MDS and PFS both detect code similarity; CCC and TVS both use git history). A formal inter-signal correlation analysis has not been conducted. Overlap does not produce double-counting in the composite score (each signal contributes independently), but it means some findings may describe the same underlying issue from different angles.
-- **Weight derivation:** Default signal weights for the 6 original signals were derived via rank-correlation (Kendall's τ) against manual architectural assessments on 5 open-source repos (single rater). Weights for the 18 newer signals are conservative heuristic assignments pending broader validation. Full methodology: [STUDY.md §1](docs/STUDY.md), [ADR-003](docs/decisions/ADR-003-composite-scoring-model.md).
+- **Weight derivation:** Default signal weights for the 6 original signals were derived via rank-correlation (Kendall's τ) against manual architectural assessments on 5 open-source repos (single rater). Weights for the 18 newer signals are conservative heuristic assignments pending broader validation. Full methodology: [STUDY.md §1](docs/STUDY.md), [scoring model](docs/concepts/scoring.md).
 
 Full methodology: [Benchmarking & Trust](https://mick-gsk.github.io/drift/benchmarking/) · [Full Study](https://github.com/mick-gsk/drift/blob/main/docs/STUDY.md) · [Open Research Questions](RESEARCH.md)
 

--- a/benchmark_results/v2.51.1_precision_recall_baseline.json
+++ b/benchmark_results/v2.51.1_precision_recall_baseline.json
@@ -1,0 +1,231 @@
+{
+  "signals": {
+    "architecture_violation": {
+      "tp": 4,
+      "tn": 6,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "broad_exception_monoculture": {
+      "tp": 3,
+      "tn": 8,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "bypass_accumulation": {
+      "tp": 3,
+      "tn": 6,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "circular_import": {
+      "tp": 2,
+      "tn": 2,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "co_change_coupling": {
+      "tp": 4,
+      "tn": 3,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "cognitive_complexity": {
+      "tp": 4,
+      "tn": 4,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "cohesion_deficit": {
+      "tp": 3,
+      "tn": 6,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "dead_code_accumulation": {
+      "tp": 2,
+      "tn": 2,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "doc_impl_drift": {
+      "tp": 4,
+      "tn": 7,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "exception_contract_drift": {
+      "tp": 1,
+      "tn": 2,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "explainability_deficit": {
+      "tp": 5,
+      "tn": 8,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "fan_out_explosion": {
+      "tp": 1,
+      "tn": 2,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "guard_clause_deficit": {
+      "tp": 4,
+      "tn": 7,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "hardcoded_secret": {
+      "tp": 3,
+      "tn": 4,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "insecure_default": {
+      "tp": 5,
+      "tn": 3,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "missing_authorization": {
+      "tp": 1,
+      "tn": 2,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "mutant_duplicate": {
+      "tp": 5,
+      "tn": 8,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "naming_contract_violation": {
+      "tp": 7,
+      "tn": 9,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "pattern_fragmentation": {
+      "tp": 6,
+      "tn": 4,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "phantom_reference": {
+      "tp": 7,
+      "tn": 18,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "system_misalignment": {
+      "tp": 3,
+      "tn": 2,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "temporal_volatility": {
+      "tp": 2,
+      "tn": 3,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "test_polarity_deficit": {
+      "tp": 3,
+      "tn": 4,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "ts_architecture": {
+      "tp": 1,
+      "tn": 1,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "type_safety_bypass": {
+      "tp": 1,
+      "tn": 1,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    }
+  },
+  "aggregate_f1": 1.0,
+  "total_fixtures": 206
+}

--- a/benchmark_results/v2.7.0_precision_recall_baseline.json
+++ b/benchmark_results/v2.7.0_precision_recall_baseline.json
@@ -1,0 +1,161 @@
+{
+  "signals": {
+    "architecture_violation": {
+      "tp": 3,
+      "tn": 4,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "broad_exception_monoculture": {
+      "tp": 2,
+      "tn": 7,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "bypass_accumulation": {
+      "tp": 3,
+      "tn": 6,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "co_change_coupling": {
+      "tp": 2,
+      "tn": 3,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "cohesion_deficit": {
+      "tp": 2,
+      "tn": 3,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "doc_impl_drift": {
+      "tp": 4,
+      "tn": 6,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "exception_contract_drift": {
+      "tp": 1,
+      "tn": 2,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "explainability_deficit": {
+      "tp": 4,
+      "tn": 6,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "guard_clause_deficit": {
+      "tp": 3,
+      "tn": 6,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "hardcoded_secret": {
+      "tp": 0,
+      "tn": 1,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "missing_authorization": {
+      "tp": 0,
+      "tn": 1,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "mutant_duplicate": {
+      "tp": 4,
+      "tn": 4,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "naming_contract_violation": {
+      "tp": 6,
+      "tn": 6,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "pattern_fragmentation": {
+      "tp": 5,
+      "tn": 3,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "system_misalignment": {
+      "tp": 3,
+      "tn": 2,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "temporal_volatility": {
+      "tp": 2,
+      "tn": 3,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "test_polarity_deficit": {
+      "tp": 3,
+      "tn": 4,
+      "fp": 0,
+      "fn": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    }
+  },
+  "aggregate_f1": 1.0,
+  "total_fixtures": 114,
+  "version": "v2.8.0-dev",
+  "signals_with_fixtures": 17
+}


### PR DESCRIPTION
The README carried **four dead links**. For a project whose pitch is evidence-based analysis, a dead evidence link is the most damaging kind — so this restores the evidence rather than deleting the claims.

## The precision artifact was deleted by accident

`benchmark_results/v2.7.0_precision_recall_baseline.json` is cited from **two** places — the README evidence table and `docs/STUDY.md:67`. It was removed on 2026-04-23 by `869abe4d`, a commit titled *"resolve ruff E501/I001 errors; C1 CLI tidy"* — collateral damage from a lint cleanup. `.gitignore`'s `benchmark_results/*` rule then kept it from coming back.

Recovered it from `869abe4d^`.

But it does **not** support the README's numbers:

| | TP | fixtures |
|---|---|---|
| README claims | 84 | 206 |
| v2.7.0 file | 47 | 114 |

So rather than link an artifact that contradicts the claim, I re-measured with `drift precision --json` on current `main`:

```
TP=84  TN=122  FP=0  FN=0   total=206
aggregate_f1=1.0   signals=25
```

**The claim is exactly right** — it was only the artifact that had gone missing. Added as `v2.51.1_precision_recall_baseline.json` and linked from the table. The v2.7.0 file stays for `STUDY.md`'s historical reference.

`.gitignore` now whitelists `*_precision_recall_baseline.json` so cited evidence cannot vanish silently again.

## Three links pointing at nothing

- **VS Code Extension section — removed.** There is no `extensions/` directory in the repo, none anywhere in its history, and no release carries a `.vsix`. Both documented install paths (`code --install-extension vscode-drift-0.1.0.vsix` and `cd extensions/vscode-drift && npm install`) were dead ends. Reopen when the extension actually ships.
- **`ADR-003-composite-scoring-model.md`** does not exist — ADRs start at `ADR-010`. Now points at `docs/concepts/scoring.md`.
- **Two `github.com/marketplace/actions/...` links → 404.** The action is not published to the Marketplace under that slug (or `drift`, or `drift-analyzer` — all checked). Now point at `action.yml` in the repo, which does exist.

## Verification

| | before | after |
|---|---|---|
| broken local links | 3 | **0** |
| broken repo links | 2 | **0** |
| markdownlint (README) | 5 | **2** |

The one remaining external failure is `api.star-history.com` returning 500 — it is down for every repo, including `facebook/react` and `python/cpython`. Left alone; it is a third-party outage, not repo rot.