### PR TITLE
fix(docs): correct mkdocs hook path so the docs site can build again

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,7 @@ theme:
     repo: fontawesome/brands/github
 
 hooks:
-  - hooks/docs_version.py
+  - src/hooks/docs_version.py
 
 plugins:
   - search


### PR DESCRIPTION
`mkdocs.yml:45` declares:

```yaml
hooks:
  - hooks/docs_version.py
```

That path does not exist. The file lives at `src/hooks/docs_version.py` — it was moved there by `e45183c9` (*"chore: automate changelog follow-up and docs hook relocation"*), and that commit did not touch `mkdocs.yml`. `tests/test_issue_342_docs_version_hook.py:8` already loads it from the new location, so the test suite never noticed.

Every build aborts before it starts:

```
ERROR - Config value 'hooks': The path '.../hooks/docs_version.py' isn't an existing file.
Aborted with a configuration error!
```

## Verified

```
mkdocs build --strict     before: exit 1  (config error)
                          after:  exit 0  ('Documentation built in 5.87 seconds')
```

## Why nobody noticed

<https://mick-gsk.github.io/drift/> still returns 200 because it was last deployed before the relocation. Actions has not executed a job since early May (account Actions-lock), so the docs workflow never ran again. **The first docs deploy after CI is restored would have failed** — this is a latent breakage waiting for the moment the account is unlocked, not a cosmetic issue.

## Note, not fixed here

The build emits one informational message, unrelated to this change:

```
Doc file 'getting-started/prompts.md' contains a link '../integrations.md#mcp-server',
but the doc 'integrations.md' does not contain an anchor '#mcp-server'.
```

It does not fail `--strict`. Left alone to keep this PR to one thing.