### PR TITLE
fix: stop the post-commit hook writing into an already-released version

### DIFF
--- a/scripts/integrate_changelog_entry.py
+++ b/scripts/integrate_changelog_entry.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import re
+import subprocess
 import sys
 import tomllib
 from pathlib import Path
@@ -46,7 +47,9 @@ CONVENTIONAL_RE = re.compile(
     re.IGNORECASE,
 )
 
-VERSION_HEADER_RE = re.compile(r"^## \[(\d+\.\d+[\.\d]*)\]")
+VERSION_HEADER_RE = re.compile(r"^## \[(Unreleased|\d+\.\d+[\.\d]*)\]")
+
+UNRELEASED = "Unreleased"
 SECTION_HEADER_RE = re.compile(r"^### (Added|Fixed|Changed|Removed|Deprecated|Security)")
 
 
@@ -59,6 +62,36 @@ def _read_version() -> str:
     with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
         data = tomllib.load(fh)
     return str(data["project"]["version"])
+
+
+def _is_released(version: str) -> bool:
+    """True if ``v{version}`` is an existing git tag.
+
+    ``pyproject.toml`` keeps carrying the last released version after a
+    release, so writing entries under it would append to a version users
+    have already installed.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "tag", "--list", f"v{version}"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return False
+    return bool(result.stdout.strip())
+
+
+def _target_version() -> str:
+    """Heading to write under: the pyproject version, or ``Unreleased``.
+
+    Post-release commits land under ``## [Unreleased]`` and the release
+    process renames that heading once the version is cut.
+    """
+    version = _read_version()
+    return UNRELEASED if _is_released(version) else version
 
 
 def _parse_commit_msg(path: str) -> tuple[str, str] | None:
@@ -141,21 +174,29 @@ def integrate(
                 if lines[i].strip():
                     insert_at = i + 1
                     break
-            new_lines: list[str] = [f"\n### {section_name}\n", f"{bullet}\n"]
+            # Blank line after the heading keeps markdownlint MD022 quiet.
+            new_lines: list[str] = [f"\n### {section_name}\n", "\n", f"{bullet}\n"]
             lines[insert_at:insert_at] = new_lines
         else:
             # Section present — find insertion point after last bullet.
             limit = next_section if next_section is not None else block_end
             insert_at = section_line + 1
+            last_bullet = insert_at
             while insert_at < limit:
                 stripped = lines[insert_at].rstrip("\n")
                 if stripped.startswith("- "):
                     if stripped == bullet:
                         return False  # already present — idempotent skip
                     insert_at += 1
+                    last_bullet = insert_at
+                elif not stripped:
+                    # Blank line between heading and bullets (MD022). Keep
+                    # scanning: stopping here would miss existing bullets and
+                    # re-insert a duplicate on every commit.
+                    insert_at += 1
                 else:
                     break
-            lines.insert(insert_at, f"{bullet}\n")
+            lines.insert(last_bullet, f"{bullet}\n")
     else:
         # No existing version block — prepend before the first ## [x.y.z] line.
         insert_at = len(lines)
@@ -163,12 +204,17 @@ def integrate(
             if VERSION_HEADER_RE.match(line):
                 insert_at = i
                 break
+        # No "Short version:" line here: for a generated block it would
+        # repeat the bullet verbatim. It is written by hand at release time,
+        # when the release actually has a theme to summarise.
+        heading = (
+            f"## [{version}]\n" if version == UNRELEASED else f"## [{version}] - {date_str}\n"
+        )
         new_block: list[str] = [
-            f"## [{version}] - {date_str}\n",
-            "\n",
-            f"Short version: {message}\n",
+            heading,
             "\n",
             f"### {section_name}\n",
+            "\n",
             f"{bullet}\n",
             "\n",
         ]
@@ -230,7 +276,7 @@ def main() -> int:
         commit_type = args.commit_type
         message = args.message
 
-    version = args.version or _read_version()
+    version = args.version or _target_version()
 
     try:
         changed = integrate(

--- a/tests/test_integrate_changelog_entry.py
+++ b/tests/test_integrate_changelog_entry.py
@@ -1,0 +1,134 @@
+"""Tests for scripts/integrate_changelog_entry.py.
+
+Regression cover for the post-commit hook writing entries under an
+already-released version. See issue #761: the hook read the version from
+pyproject.toml, which still carries the last released version after a
+release, so a commit made after v2.51.1 shipped produced a *second*
+``## [2.51.1]`` block dated today.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "integrate_changelog_entry.py"
+
+_spec = importlib.util.spec_from_file_location("integrate_changelog_entry", _SCRIPT_PATH)
+assert _spec and _spec.loader
+_script = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_script)  # type: ignore[union-attr]
+
+
+_EXISTING = """## [2.51.1] - 2026-05-04
+
+Short version: Something already shipped.
+
+### Fixed
+
+- An earlier fix
+
+"""
+
+
+@pytest.fixture
+def changelog(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "CHANGELOG.md"
+    path.write_text(_EXISTING, encoding="utf-8")
+    monkeypatch.setattr(_script, "REPO_ROOT", tmp_path)
+    return path
+
+
+def _integrate(**kwargs: Any) -> bool:
+    return bool(_script.integrate(**kwargs))
+
+
+def test_released_version_targets_unreleased(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A tagged pyproject version must route entries to Unreleased."""
+    monkeypatch.setattr(_script, "_read_version", lambda: "2.51.1")
+    monkeypatch.setattr(_script, "_is_released", lambda _v: True)
+    assert _script._target_version() == "Unreleased"
+
+
+def test_unreleased_version_targets_itself(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An untagged version is still in flight and keeps its own heading."""
+    monkeypatch.setattr(_script, "_read_version", lambda: "2.52.0")
+    monkeypatch.setattr(_script, "_is_released", lambda _v: False)
+    assert _script._target_version() == "2.52.0"
+
+
+def test_does_not_duplicate_a_released_version_block(changelog: Path) -> None:
+    """The bug from #761: a second block for an already-released version."""
+    _integrate(
+        commit_type="chore",
+        message="make .githooks executable",
+        version="Unreleased",
+        changelog=changelog,
+    )
+    text = changelog.read_text(encoding="utf-8")
+    assert text.count("## [2.51.1]") == 1, "released version block was duplicated"
+    assert "## [Unreleased]" in text
+    assert text.index("## [Unreleased]") < text.index("## [2.51.1]")
+
+
+def test_generated_block_has_no_duplicated_summary(changelog: Path) -> None:
+    """The message must not appear as both 'Short version' and a bullet."""
+    message = "make .githooks executable"
+    _integrate(
+        commit_type="chore",
+        message=message,
+        version="Unreleased",
+        changelog=changelog,
+    )
+    text = changelog.read_text(encoding="utf-8")
+    assert f"Short version: {message}" not in text
+    assert text.count(message) == 1
+
+
+def test_unreleased_heading_carries_no_date(changelog: Path) -> None:
+    """Unreleased is not a release, so it must not be dated."""
+    _integrate(
+        commit_type="fix",
+        message="some fix",
+        version="Unreleased",
+        changelog=changelog,
+    )
+    heading = next(
+        line for line in changelog.read_text(encoding="utf-8").splitlines()
+        if line.startswith("## [Unreleased]")
+    )
+    assert heading.strip() == "## [Unreleased]"
+
+
+def test_second_entry_appends_to_same_unreleased_block(changelog: Path) -> None:
+    """Consecutive commits must not each open their own Unreleased block."""
+    _integrate(commit_type="chore", message="first", version="Unreleased", changelog=changelog)
+    _integrate(commit_type="fix", message="second", version="Unreleased", changelog=changelog)
+    text = changelog.read_text(encoding="utf-8")
+    assert text.count("## [Unreleased]") == 1
+    assert "- first" in text
+    assert "- second" in text
+
+
+def test_repeated_entry_is_skipped(changelog: Path) -> None:
+    """Re-running the hook for the same commit must be a no-op."""
+    _integrate(commit_type="fix", message="same", version="Unreleased", changelog=changelog)
+    second = _integrate(
+        commit_type="fix", message="same", version="Unreleased", changelog=changelog
+    )
+    assert second is False
+    assert changelog.read_text(encoding="utf-8").count("- same") == 1
+
+
+def test_generated_sections_are_markdownlint_shaped(changelog: Path) -> None:
+    """Headings need a blank line after them (MD022) — both code paths."""
+    _integrate(commit_type="chore", message="first", version="Unreleased", changelog=changelog)
+    _integrate(commit_type="fix", message="second", version="Unreleased", changelog=changelog)
+    lines = changelog.read_text(encoding="utf-8").splitlines()
+    for i, line in enumerate(lines[:-1]):
+        if line.startswith("### "):
+            assert lines[i + 1].strip() == "", f"missing blank line after {line!r}"


### PR DESCRIPTION
Closes #761. Surfaced by #759 — the hooks in `.githooks/` were never executable, so this behaviour had been dormant until that PR made them run.

## The bug

The hook read its target version from `pyproject.toml`, which still carries the **last released** version after a release. A commit made after `v2.51.1` shipped therefore produced:

```markdown
## [2.51.1] - 2026-07-29        ← today, but 2.51.1 shipped on 2026-05-04

Short version: make .githooks executable so the documented hooks actually run

### Changed
- make .githooks executable so the documented hooks actually run
```

Three things wrong: a released version claiming two different contents, the commit subject duplicated into both the summary line and the bullet, and a changelog entry that just replays the commit message — which `CONTRIBUTING.md:522` explicitly lists as not allowed.

## The fix

- **Route to `## [Unreleased]`** when `v{version}` is an existing git tag. While a version is still unreleased, it keeps using its own heading.
- **Drop the generated `Short version:` line.** For an auto-generated block it only repeated the bullet. It is written by hand at release time, when a release actually has a theme.
- **No date on `Unreleased`** — it is not a release.
- **Blank line after generated `###` headings** (markdownlint MD022).

## One bug the tests caught in my own fix

Adding that blank line broke idempotency: the duplicate scan stopped at the first non-bullet line, never saw the existing bullets, and re-inserted the same entry on every commit. `test_repeated_entry_is_skipped` failed immediately. The scan now skips blank lines.

## Verification

```
pytest   6788 passed, 6 skipped, 0 failed
ruff     All checks passed
mypy     Success: no issues found in 344 source files
```

8 regression tests in `tests/test_integrate_changelog_entry.py`, covering: released → Unreleased routing, unreleased → own heading, no duplicate released block, no duplicated summary, undated heading, appending to an existing block, idempotency, and MD022 shape of both generation paths.

Generated output produces **0 new markdownlint findings** (139 before and after on `CHANGELOG.md`).

## Not addressed

Whether `post-commit` should write the changelog **at all** — option A in #761 — remains open. This makes the existing behaviour correct rather than deciding that question.