### PR TITLE
docs: tag 28 untagged code fences and fix the broken MCP anchor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -674,7 +674,7 @@ comment explaining why a dedicated generator is not needed.
 
 ### 5. Write the tests
 
-```
+```text
 tests/test_my_new_signal.py          # unit tests with synthetic ParseResult fixtures
 tests/test_issue_NNN_<description>.py  # regression test if this fixes a bug
 ```

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -21,7 +21,7 @@ Maintainer operations: [docs/MAINTAINER_RUNBOOK.md](docs/MAINTAINER_RUNBOOK.md) 
 
 ## Architecture
 
-```
+```text
 ingestion/          signals/            scoring/           output/
 ┌──────────────┐    ┌──────────────┐    ┌─────────────┐    ┌─────────────┐
 │ file_discovery│───▶│ PFS  AVS  MDS│───▶│ composite   │───▶│ rich (CLI)  │
@@ -42,7 +42,7 @@ ingestion/          signals/            scoring/           output/
 Full analysis runs all signals on every file. The **incremental path** (`drift_nudge`) re-runs
 only the signals affected by changed files:
 
-```
+```text
 BaselineManager.get()  ──┐
                          ├──▶ IncrementalSignalRunner.run(changed_files)
 changed files            │       │
@@ -127,7 +127,7 @@ Adding a new signal: see [CONTRIBUTING.md → Adding a new signal](CONTRIBUTING.
 
 ### Make targets (developer workflow)
 
-```
+```text
 make help        Show all targets
 make install     Dev install + git hooks
 make lint        Ruff check
@@ -147,7 +147,7 @@ make clean       Remove caches
 
 Zusaetzliche Targets speziell fuer Agenten und Automatisierung:
 
-```
+```text
 make feat-start                             Vor dem ersten Edit bei feat: (Policy-Gate + Baseline)
 make fix-start                              Vor dem ersten Edit bei fix: (Baseline + Test-Run)
 make gate-check COMMIT_TYPE=feat            Gates proaktiv pruefen (vor Push)
@@ -161,7 +161,7 @@ make catalog ARGS='--search evidence'       Skript-Katalog nach Stichwort filter
 
 ### CLI subcommands
 
-```
+```text
 drift analyze          Full repo analysis (--format rich|json|sarif)
 drift check            CI diff-mode (--fail-on high, --diff HEAD~1)
 drift scan             Agent-native repository scan

--- a/docs-site/algorithms/deep-dive.md
+++ b/docs-site/algorithms/deep-dive.md
@@ -4,7 +4,7 @@ This page explains the core algorithms that power drift's detection pipeline. No
 
 ## Pipeline Overview
 
-```
+```text
 Repository ──→ File Discovery ──→ AST Parsing ──→ Signals ──→ Scoring ──→ Output
                     │                   │              │           │
               .gitignore +         Python ast     6 independent  Weighted

--- a/docs-site/comparisons/drift-vs-copilot-review.md
+++ b/docs-site/comparisons/drift-vs-copilot-review.md
@@ -15,7 +15,7 @@ These are not competing tools. They are complementary stages in the same workflo
 
 ## Where each tool sits in the workflow
 
-```
+```text
 [drift brief]       → pre-task guardrails (before writing any code)
 [drift nudge]       → inner-loop feedback (while editing, via MCP)
 ─────────────────── code is written ──────────────────────────────

--- a/docs-site/comparisons/drift-vs-sonarqube.md
+++ b/docs-site/comparisons/drift-vs-sonarqube.md
@@ -86,7 +86,7 @@ known-bad patterns. Drift's MCP helps agents avoid architectural fragmentation.
 
 ## Recommended combined use
 
-```
+```text
 SonarQube or Semgrep:  security + policy + enterprise compliance
 drift:                 structural coherence + temporal signals + AI-specific erosion
 ```

--- a/docs-site/comparisons/index.md
+++ b/docs-site/comparisons/index.md
@@ -141,7 +141,7 @@ Source: [benchmark_results/all_results.json](https://github.com/mick-gsk/drift/b
 
 ## Recommended Stack
 
-```
+```text
 Linter (style)        → Ruff, pylint
 Type checker (types)  → mypy, pyright
 Coherence (drift)     → drift analyze / drift check

--- a/docs-site/drift-bot.md
+++ b/docs-site/drift-bot.md
@@ -6,7 +6,7 @@ Install it once on your organization or repository, and every PR gets a **Drift 
 
 ## How it works
 
-```
+```text
 PR opened / updated
        │
        ▼

--- a/docs-site/guides/feedback-calibration.md
+++ b/docs-site/guides/feedback-calibration.md
@@ -6,7 +6,7 @@ Drift includes a **Bayesian learning model** that adjusts signal weights based o
 
 Drift uses three evidence sources to calibrate signal weights:
 
-```
+```text
                     ┌──────────────────┐
                     │  Default Weights  │
                     │  (ablation study) │
@@ -182,7 +182,7 @@ Format: one JSON object per line with fields `signal_type`, `file_path`, `verdic
 
 ## Calibration lifecycle
 
-```
+```text
 Week 1:  drift analyze → review findings → mark TP/FP → calibrate run
 Week 2:  drift analyze (auto-recalibrate) → fewer false alarms
 Week 4:  confidence reaches 100% for active signals

--- a/docs-site/guides/guided-mode.md
+++ b/docs-site/guides/guided-mode.md
@@ -22,7 +22,7 @@ That's it. You'll see one of three colors:
 
 ### GREEN — all clear
 
-```
+```text
 🟢  Dein Projekt sieht gut aus. Du kannst weiterarbeiten.
 
 Du kannst weiterarbeiten.
@@ -30,7 +30,7 @@ Du kannst weiterarbeiten.
 
 ### YELLOW — needs attention
 
-```
+```text
 🟡  Es gibt Stellen, die Aufmerksamkeit brauchen.
 
 Top-3 Auffälligkeiten:
@@ -49,7 +49,7 @@ Tipp: Kopiere einen der Prompts oben und gib ihn deinem KI-Assistenten.
 
 ### RED — needs immediate action
 
-```
+```text
 🔴  Dein Projekt hat ein strukturelles Problem, das du jetzt angehen solltest.
 
 Top-3 Auffälligkeiten:

--- a/docs-site/guides/negative-context-agents.md
+++ b/docs-site/guides/negative-context-agents.md
@@ -43,7 +43,7 @@ drift export-context --format raw -o patterns.json
 
 ## How it works
 
-```
+```text
 drift analyze → Findings → Negative Context Generators → Anti-Pattern Items
                                                               │
                     ┌─────────────────────────────────────────┘
@@ -122,7 +122,7 @@ Markdown with category headings — suitable for `.github/copilot-instructions.m
 
 Compact format for system prompts (minimal tokens):
 
-```
+```text
 AVOID: Bare except Exception: pass (broad_exception_monoculture, high)
 USE INSTEAD: Specific exception types with proper handling
 ---

--- a/docs-site/guides/vscode-copilot-workflow.md
+++ b/docs-site/guides/vscode-copilot-workflow.md
@@ -33,7 +33,7 @@ drift analyze --repo .
 
 At the end of the output you will see a **drift-kit** panel:
 
-```
+```text
 ┌─────────────────────────────── drift-kit ─────────────────────────────┐
 │  Severity  Signal                    File                  Reason      │
 │  high      pattern_fragmentation     src/core/engine.py    …           │
@@ -58,7 +58,7 @@ Open VS Code Copilot Chat (++ctrl+alt+i++) and type one of the following:
 
 ### Recommended workflow
 
-```
+```text
 drift analyze
     │
     └─► /drift-fix-plan          ← what needs fixing and how

--- a/docs-site/integrations.md
+++ b/docs-site/integrations.md
@@ -135,7 +135,7 @@ No MCP server is required. This path works with any editor that supports Copilot
 
 See **[VS Code Copilot Chat Workflow](guides/vscode-copilot-workflow.md)** for the full setup guide.
 
-## MCP server — advanced execution layer
+## MCP server — advanced execution layer {#mcp-server}
 
 MCP is an optional upgrade for agents that need deterministic, programmatic tool invocations — for example Cursor, Claude Code, and Copilot in agentic mode. Most users should start with `drift kit init` above and only add MCP when the session-loop pattern becomes the bottleneck.
 

--- a/docs-site/reference/signals/ccc.md
+++ b/docs-site/reference/signals/ccc.md
@@ -14,7 +14,7 @@ CCC detects **hidden coupling** between files that repeatedly change together in
 
 ### Example finding
 
-```
+```text
 co_change_coupling between services/pricing.py ↔ templates/invoice.html
   Co-change frequency: 8/10 commits (80%)
   Import relationship: none

--- a/docs-site/reference/signals/cir.md
+++ b/docs-site/reference/signals/cir.md
@@ -14,7 +14,7 @@ CIR detects **circular import chains** within Python packages — module A impor
 
 ### Example finding
 
-```
+```text
 circular_import: cycle detected
   services/auth.py → services/user.py → services/auth.py
   Cycle length: 2

--- a/docs-site/reference/signals/cxs.md
+++ b/docs-site/reference/signals/cxs.md
@@ -14,7 +14,7 @@ CXS detects functions exceeding a **cognitive-complexity threshold**. Unlike cyc
 
 ### Example finding
 
-```
+```text
 cognitive_complexity in services/order_processor.py::validate_order
   Cognitive complexity: 23 (threshold: 15)
   Contributors: 4 nested if-blocks, 2 loops with break, 1 recursive call

--- a/docs-site/reference/signals/dca.md
+++ b/docs-site/reference/signals/dca.md
@@ -14,7 +14,7 @@ DCA detects **exported functions and classes that are never imported elsewhere**
 
 ### Example finding
 
-```
+```text
 dead_code_accumulation in utils/legacy_helpers.py
   Unreferenced exports: 5/7 functions
   Functions: format_v1(), parse_old_config(), legacy_transform(),

--- a/docs-site/reference/signals/dia.md
+++ b/docs-site/reference/signals/dia.md
@@ -25,7 +25,7 @@ The application uses a **three-layer architecture**:
 
 But the actual code has:
 
-```
+```text
 src/
 ├── routes/
 ├── services/

--- a/docs-site/reference/signals/ecm.md
+++ b/docs-site/reference/signals/ecm.md
@@ -14,7 +14,7 @@ ECM detects public functions whose **exception profile changed across recent com
 
 ### Example finding
 
-```
+```text
 exception_contract_drift in services/payment.py::process_payment
   Previous exceptions: [ValueError, PaymentError]
   Current exceptions: [ValueError, PaymentError, TimeoutError, ConnectionError]

--- a/docs-site/reference/signals/tsa.md
+++ b/docs-site/reference/signals/tsa.md
@@ -19,7 +19,7 @@ TSA runs **four TypeScript/JavaScript architecture rules** to detect structural 
 
 ### Example finding
 
-```
+```text
 ts_architecture in src/components/UserList.tsx
   Rule: ui_to_infra_import_ban
   Import: import { query } from '../database/connection'

--- a/docs-site/reference/signals/tvs.md
+++ b/docs-site/reference/signals/tvs.md
@@ -27,7 +27,7 @@ If that same helper is edited in commit after commit — one week to trim dots, 
 
 ### Example finding
 
-```
+```text
 temporal_volatility in src/utils/normalizer.py
   Change frequency: 12 commits in 30 days (z-score: 2.4)
   Unique authors: 5  |  AI-attributed: 60%


### PR DESCRIPTION
Two reader-visible defects on the published docs site.

## Broken anchor

`docs-site/getting-started/prompts.md:232` links to `../integrations.md#mcp-server`. The target heading is `## MCP server — advanced execution layer`, which slugifies to something longer, so the link dropped readers at the top of the page instead of the section. mkdocs reported it on every build:

```
Doc file 'getting-started/prompts.md' contains a link '../integrations.md#mcp-server',
but the doc 'integrations.md' does not contain an anchor '#mcp-server'.
```

Added an explicit `{#mcp-server}` anchor, matching the `{#copilot-chat}` pattern already used in that file. That keeps the link short and stable if the heading is ever reworded.

## 28 untagged code fences

They rendered without the code styling used everywhere else in the docs. I checked what is actually inside each one — **none is a programming language**:

| kind | example |
|---|---|
| ASCII architecture diagrams | `Repository ──→ File Discovery ──→ AST Parsing ──→ …` |
| directory trees | `ingestion/  signals/  scoring/  output/` |
| CLI / make output | `make help        Show all targets` |
| example findings | `circular_import: cycle detected` |
| guided-mode output | `🟢  Dein Projekt sieht gut aus.` |

So they are tagged `text` rather than guessing at a syntax that would produce wrong highlighting.

## Verified

| | before | after |
|---|---|---|
| markdownlint total | 80 | **52** |
| MD040 | 28 | **0** |
| `mkdocs build --strict` | exit 0, anchor warning | **exit 0, no warning** |

`git diff -U0` contains only ```text fence lines and the single anchor line — no prose changed.

## Remaining

52 findings left, dominated by 20 × MD036 (emphasis used as heading, mostly `docs-site/product/example-findings.md`) where some uses look deliberate, plus a tail of MD010/MD024/MD029 one-offs. Those need per-case judgement, not a sweep.