### PR TITLE
fix: correct stale release line in SECURITY.md and guard it against drift

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,7 +50,7 @@
 | 2.4.x   | :white_check_mark: |
 | < 2.4   | :x:                |
 
-Current release line: **v2.49.0**.
+Current release line: **v2.51.1**.
 
 ## Reporting a Vulnerability
 

--- a/scripts/check_model_consistency.py
+++ b/scripts/check_model_consistency.py
@@ -311,6 +311,29 @@ def _check_security_version(version: str) -> tuple[list[str], list[dict[str, Any
                 fix_suggestion=f"Add '{pattern}' to the supported versions table in SECURITY.md",
             )
         )
+
+    # The prose line below the table is a second copy of the version and was
+    # not covered here, so it silently drifted (it still read v2.49.0 at
+    # v2.51.1). Pin it too, otherwise the check only guards half the file.
+    release_line = re.search(r"^Current release line: \*\*v([^*]+)\*\*\.", text, re.MULTILINE)
+    if release_line and release_line.group(1) != version:
+        msg = (
+            f"SECURITY.md 'Current release line' says v{release_line.group(1)}, "
+            f"but the current version is {version}"
+        )
+        errors.append(msg)
+        discs.append(
+            _discrepancy(
+                check_id="security_release_line_stale",
+                category="version_ref",
+                severity="low",
+                source_file="SECURITY.md",
+                expected=f"v{version}",
+                actual=f"v{release_line.group(1)}",
+                description=msg,
+                fix_suggestion=f"Update the 'Current release line' line to **v{version}**",
+            )
+        )
     return errors, discs
 
 


### PR DESCRIPTION
`SECURITY.md:53` read **`Current release line: v2.49.0`** while the current version is **2.51.1** — two release lines out of date, in the document people consult before reporting a vulnerability.

## Why the existing check missed it

`scripts/check_model_consistency.py` already guards `SECURITY.md`, but only the supported-versions **table**:

```python
pattern = f"{major_minor}.x"
if pattern not in text:  # -> 'SECURITY.md does not list 2.51.x as supported'
```

The file carries the version **twice** — once in the table, once in the prose line below it. Only the first copy was pinned, so the second drifted silently. (The table itself was correct; it was fixed in #758.)

## What changed

1. Correct the line to `v2.51.1`.
2. Extend `_check_security_version()` to compare that line against `pyproject.toml` too, so the same drift fails the check rather than going unnoticed for two releases.

## Verified

Reintroducing the old value:

```
Model consistency check FAILED
FAIL: SECURITY.md 'Current release line' says v2.49.0, but the current version is 2.51.1
1 inconsistency(ies) found.
```

Restoring it:

```
OK: Signal model consistent: 19 scoring signals, version 2.51.1
```

`tests/test_model_consistency.py` passes, `ruff` clean, `markdownlint` reports 0 findings on `SECURITY.md`.

Fixing the class rather than the instance — the number would otherwise have gone stale again at the next release.