### PR TITLE
docs: note that CI is paused so the red badge is not read as broken code

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ drift status         # traffic-light health check — your daily entry point
 [![License](https://img.shields.io/github/license/mick-gsk/drift)](LICENSE)
 [![Discussions](https://img.shields.io/github/discussions/mick-gsk/drift)](https://github.com/mick-gsk/drift/discussions)
 
+> **CI runs are paused right now**, so the badge above is stale rather than a
+> verdict on the code. The suite is green locally — `make check` runs lint,
+> types, tests and self-analysis. Contributions are welcome as usual.
+
 [Docs](https://mick-gsk.github.io/drift/) · [Quick Start](https://mick-gsk.github.io/drift/getting-started/quickstart/) · [Playground](https://mick-gsk.github.io/drift/playground/) · [Benchmarking](https://mick-gsk.github.io/drift/benchmarking/) · [Trust & Limitations](https://mick-gsk.github.io/drift/trust-evidence/) · [Community](https://github.com/mick-gsk/drift/discussions)
 
 **Using AI coding tools?** [Start here](examples/vibe-coding/README.md) · **CI & team rollout?** [Team rollout guide](https://mick-gsk.github.io/drift/getting-started/team-rollout/) · **Benchmarks & evidence?** [Study](docs/STUDY.md)


### PR DESCRIPTION
The CI badge sits at the top of the README and currently reports failure. It is **accurate about the workflow but misleading about the code**: jobs are not failing, they never start. Meanwhile the suite is green locally:

```
pytest   6788 passed, 6 skipped, 0 failed
ruff     All checks passed
mypy     Success: no issues found in 344 source files
mkdocs   build --strict -> exit 0
```

A prospective contributor who sees `CI: failing` and nothing else concludes the project is broken and moves on. That is the single largest gap left between how this repo *is* and how it *reads*.

## What this adds

Three lines directly under the badge row:

> **CI runs are paused right now**, so the badge above is stale rather than a verdict on the code. The suite is green locally — `make check` runs lint, types, tests and self-analysis. Contributions are welcome as usual.

## What it deliberately does not do

- **Does not hide the badge.** It stays exactly where it is, still red. Nothing is faked or removed.
- **Does not say why runs are paused.** That is not a contributor's concern and not the README's job.

## Verified

- `make check` exists — `Makefile:63`, *"Run all checks: lint + typecheck + tests (incl. slow) + self-analysis"*
- `markdownlint` on `README.md`: **0 findings before, 0 after**
- Diff is one added hunk, nothing else touched

**Revert this single hunk once CI is running again** — it is written to be removed in one step.