### PR TITLE
fix(guard): make the two-line install actually produce a working guard

### DIFF
--- a/.github/repo-root-allowlist
+++ b/.github/repo-root-allowlist
@@ -8,8 +8,11 @@
 # and slash commands are only discovered in `commands/` at the plugin root.
 # The plugin root is the repository root because the marketplace entry points
 # at "./", which is what makes `/plugin marketplace add mick-gsk/drift` work.
+# `bin/` is the third: Claude Code puts it on PATH so the slash commands can
+# call `drift-guard` without the user having installed the PyPI package.
 .claude-plugin
 commands
+bin
 
 .githooks
 .github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Short version: Drift installs as a Claude Code plugin and works inside the agent
 
 - Hook output now reaches the model. The hooks printed findings to stdout and exited 0, which for `PreToolUse` and `PostToolUse` reaches the transcript only — the guard's findings would never have arrived. Output goes through `hookSpecificOutput.additionalContext`, with the session tally on `systemMessage`
 - `schema.connect()` no longer advertises `Connection | None` for writers that cannot fail; readers use `connect()`, writers use `create()`
+- make the two-line install actually produce a working guard
 
 ## [2.51.1] - 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@
 /plugin install drift@drift
 ```
 
-Restart Claude Code, then run `/drift:doctor`. Nothing to configure, no profile
-to pick, no file written into your project except a `.drift/` index you can
-delete at any time.
+Restart Claude Code, then run `/drift:doctor`. Those two lines are the whole
+install: the guard imports nothing but the standard library and runs from the
+plugin itself, so there is no `pip install`, no dependency to resolve, nothing
+to configure, and no file written into your project except a `.drift/` index
+you can delete at any time.
 
 **Python files only.** The guard reads Python with `ast`; edits to other
 languages pass through untouched. The [CLI](#the-cli) below covers more.

--- a/bin/drift-guard
+++ b/bin/drift-guard
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# `drift-guard` for the Bash tool inside Claude Code.
+#
+# Claude Code puts a plugin's bin/ on PATH, so `/drift:doctor` and `/drift:stats`
+# can call `drift-guard` as a bare command whether or not the user ever ran
+# `pip install drift-analyzer`. An installed package still wins: it is the same
+# code, already importable, and skipping the PYTHONPATH detour keeps it fast.
+set -uo pipefail
+
+self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+plugin_root="${CLAUDE_PLUGIN_ROOT:-$(dirname "$self_dir")}"
+
+# An installed console script, but never this wrapper again.
+while IFS= read -r candidate; do
+  [ "$candidate" = "${BASH_SOURCE[0]}" ] && continue
+  [ "$candidate" = "$self_dir/drift-guard" ] && continue
+  exec "$candidate" "$@"
+done < <(command -v -a drift-guard 2>/dev/null || true)
+
+if python3 -c "import drift.guard" >/dev/null 2>&1; then
+  exec python3 -m drift.guard "$@"
+fi
+
+if [ -d "$plugin_root/src/drift/guard" ]; then
+  exec env PYTHONPATH="$plugin_root/src${PYTHONPATH:+:$PYTHONPATH}" python3 -m drift.guard "$@"
+fi
+
+echo "drift-guard: cannot locate the guard (looked for an installed package and $plugin_root/src)" >&2
+exit 1

--- a/docs-site/claude-code-plugin.md
+++ b/docs-site/claude-code-plugin.md
@@ -7,9 +7,11 @@
 /plugin install drift@drift
 ```
 
-Restart Claude Code, then run `/drift:doctor`. There is nothing to configure,
-no profile to pick, and no file written into your project except a `.drift/`
-index you can delete at any time.
+Restart Claude Code, then run `/drift:doctor`. Those two lines are the whole
+install: the guard imports nothing but the standard library and runs from the
+plugin itself, so there is no `pip install`, no dependency to resolve, nothing
+to configure, and no file written into your project except a `.drift/` index
+you can delete at any time.
 
 !!! note "Python files only"
     The guard reads Python with `ast`. Edits to other languages pass through

--- a/hooks/_guard_lib.sh
+++ b/hooks/_guard_lib.sh
@@ -1,17 +1,38 @@
 #!/usr/bin/env bash
 # Shared helpers for the drift guard hooks. Sourced, never executed directly.
 
-# Resolve the guard entry point: prefer the console script, fall back to the
-# module. Prints nothing and returns 1 when neither is available.
-guard_cmd() {
+# Resolve how to run the guard and put it in GUARD_CMD. Returns 1 when there is
+# no way to run it, in which case the hooks stay silent.
+#
+# The last branch is what makes `/plugin install drift@drift` enough on its own.
+# The marketplace clones this repository, so the guard's source ships inside the
+# installed plugin, and the guard imports nothing but the standard library — it
+# runs from that copy under any system Python 3.11+, with no `pip install` and
+# no dependency to resolve. Without this branch a fresh install is completely
+# inert: every hook exits 0 with no output, forever, and looks like a guard that
+# simply never finds anything.
+#
+# This sets a variable rather than echoing a command, because a `PYTHONPATH`
+# exported inside `$(...)` would be lost with the subshell.
+guard_resolve() {
   if command -v drift-guard >/dev/null 2>&1; then
-    echo "drift-guard"
+    GUARD_CMD="drift-guard"
     return 0
   fi
-  if python3 -c "import drift.guard" >/dev/null 2>&1; then
-    echo "python3 -m drift.guard"
+
+  if command -v python3 >/dev/null 2>&1 && python3 -c "import drift.guard" >/dev/null 2>&1; then
+    GUARD_CMD="python3 -m drift.guard"
     return 0
   fi
+
+  local bundled="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}/src"
+  if [ -d "$bundled/drift/guard" ] && command -v python3 >/dev/null 2>&1 &&
+    PYTHONPATH="$bundled" python3 -c "import drift.guard" >/dev/null 2>&1; then
+    export PYTHONPATH="$bundled${PYTHONPATH:+:$PYTHONPATH}"
+    GUARD_CMD="python3 -m drift.guard"
+    return 0
+  fi
+
   return 1
 }
 

--- a/hooks/guard-post-edit.sh
+++ b/hooks/guard-post-edit.sh
@@ -9,6 +9,6 @@ set -uo pipefail
 # shellcheck source=/dev/null
 . "$(dirname "$0")/_guard_lib.sh"
 
-cmd="$(guard_cmd)" || exit 0
-$cmd --hook PostToolUse --repo "$(guard_repo_root)" post --payload-stdin 2>/dev/null || true
+guard_resolve || exit 0
+$GUARD_CMD --hook PostToolUse --repo "$(guard_repo_root)" post --payload-stdin 2>/dev/null || true
 exit 0

--- a/hooks/guard-pre-edit.sh
+++ b/hooks/guard-pre-edit.sh
@@ -5,6 +5,6 @@ set -uo pipefail
 # shellcheck source=/dev/null
 . "$(dirname "$0")/_guard_lib.sh"
 
-cmd="$(guard_cmd)" || exit 0
-$cmd --hook PreToolUse --repo "$(guard_repo_root)" pre --payload-stdin 2>/dev/null || true
+guard_resolve || exit 0
+$GUARD_CMD --hook PreToolUse --repo "$(guard_repo_root)" pre --payload-stdin 2>/dev/null || true
 exit 0

--- a/hooks/guard-session-start.sh
+++ b/hooks/guard-session-start.sh
@@ -5,6 +5,6 @@ set -uo pipefail
 # shellcheck source=/dev/null
 . "$(dirname "$0")/_guard_lib.sh"
 
-cmd="$(guard_cmd)" || exit 0
-$cmd --hook SessionStart --repo "$(guard_repo_root)" session-start 2>/dev/null || true
+guard_resolve || exit 0
+$GUARD_CMD --hook SessionStart --repo "$(guard_repo_root)" session-start 2>/dev/null || true
 exit 0

--- a/hooks/guard-stop.sh
+++ b/hooks/guard-stop.sh
@@ -4,6 +4,6 @@ set -uo pipefail
 # shellcheck source=/dev/null
 . "$(dirname "$0")/_guard_lib.sh"
 
-cmd="$(guard_cmd)" || exit 0
-$cmd --hook Stop --repo "$(guard_repo_root)" stats 2>/dev/null || true
+guard_resolve || exit 0
+$GUARD_CMD --hook Stop --repo "$(guard_repo_root)" stats 2>/dev/null || true
 exit 0

--- a/tests/guard/test_hooks.py
+++ b/tests/guard/test_hooks.py
@@ -165,3 +165,88 @@ def test_hook_config_points_at_scripts_that_exist():
     for command in referenced:
         relative = command.strip('"').replace("${CLAUDE_PLUGIN_ROOT}/", "")
         assert (root / relative).exists(), f"{relative} is referenced but missing"
+
+
+def _bare_env():
+    """An environment where nothing drift-related is installed or importable.
+
+    This is what a user has after `/plugin install drift@drift` and nothing
+    else: no `drift-guard` on PATH, no `drift` package, no PYTHONPATH.
+    """
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("PYTHONPATH", "VIRTUAL_ENV", "CLAUDE_PLUGIN_ROOT")
+    }
+    env["PATH"] = "/usr/bin:/bin:/usr/sbin:/sbin"
+    return env
+
+
+def test_the_plugin_alone_is_enough(sample_repo):
+    """A bare `/plugin install` must produce a working guard, with no pip step.
+
+    The marketplace clones the repository, so the guard's source ships inside
+    the installed plugin and runs from there under any system Python. Without
+    that fallback a fresh install is silently inert: every hook exits 0 with no
+    output, which is indistinguishable from a guard that never finds anything.
+    """
+    build.build_full(sample_repo)
+    (sample_repo / "src" / "api" / "schemas.py").write_text(
+        "def validate_token(token, audience):\n    return True\n", encoding="utf-8"
+    )
+    payload = {"tool_input": {"file_path": str(sample_repo / "src" / "api" / "schemas.py")}}
+
+    result = subprocess.run(
+        ["bash", str(HOOKS / "guard-post-edit.sh")],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        cwd=sample_repo,
+        env=_bare_env(),
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip(), "the hook stayed silent with only the plugin installed"
+    assert "validate_token" in json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+
+
+def test_the_guard_imports_only_the_standard_library():
+    """The bundled fallback works only as long as no third-party import creeps in."""
+    env = _bare_env()
+    env["PYTHONPATH"] = str(HOOKS.parent / "src")
+
+    result = subprocess.run(
+        [
+            "python3",
+            "-c",
+            "import drift.guard.build, drift.guard.lookup, drift.guard.report; print('ok')",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_bin_wrapper_works_without_an_installed_package():
+    """`/drift:doctor` calls `drift-guard` as a bare command; bin/ makes that real.
+
+    Claude Code puts a plugin's bin/ on PATH. Without this wrapper the two slash
+    commands only work for users who separately ran `pip install drift-analyzer`.
+    """
+    wrapper = HOOKS.parent / "bin" / "drift-guard"
+
+    assert wrapper.exists()
+    assert os.access(wrapper, os.X_OK), "bin/drift-guard must be executable"
+
+    result = subprocess.run(
+        [str(wrapper), "--repo", str(HOOKS.parent), "doctor"],
+        capture_output=True,
+        text=True,
+        env=_bare_env(),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "index" in result.stdout


### PR DESCRIPTION
Found by installing the plugin on this machine and following the README exactly.

## The bug

`drift-guard` is a console script from the PyPI package `drift-analyzer`. The plugin does not install that package. So after

```bash
/plugin marketplace add mick-gsk/drift
/plugin install drift@drift
```

on any machine without a separate `pip install drift-analyzer`, the guard was **completely inert**. Reproduced against the real installation with a scrubbed PATH:

```console
$ which drift-guard
drift-guard not found
$ python3 -c "import drift.guard"
ModuleNotFoundError: No module named 'drift'
$ echo '{"tool_input":{"file_path":".../lookup.py"}}' | bash "$PLUGIN/hooks/guard-post-edit.sh"
$ echo $?
0
```

Every hook exited 0 with no output. `/drift:doctor` called a command that did not exist.

## Why this one mattered more than most

Silence is also what a *working* guard does most of the time — that is the design. So a new user has no way to tell "nothing to report" from "never ran". They would install it, see nothing, conclude it does not work, and leave. The README promised "nothing to configure" while quietly requiring a step it never mentioned.

## The fix

The guard imports nothing but `sqlite3`, `ast` and `json`, and the marketplace clones this repository — so its source already ships inside the installed plugin. It runs from there under any system Python 3.11+.

- The hooks fall back to `PYTHONPATH=${CLAUDE_PLUGIN_ROOT}/src python3 -m drift.guard`, still preferring an installed package when one exists.
- `bin/drift-guard` wraps the same resolution for the Bash tool. Claude Code puts a plugin's `bin/` on PATH, which is what makes the two slash commands work without the package.

`guard_cmd` became `guard_resolve` and sets a variable instead of echoing a command: a `PYTHONPATH` exported inside `$(...)` dies with the subshell.

The two-line install is now literally the whole install, and the README says so.

## Tests

Three, all with `PATH`, `PYTHONPATH` and `VIRTUAL_ENV` stripped so they fail if the fallback regresses:

- `test_the_plugin_alone_is_enough` — bare environment, real hook script, real payload, asserts the finding arrives in `additionalContext`
- `test_bin_wrapper_works_without_an_installed_package` — `bin/drift-guard doctor` from a bare environment
- `test_the_guard_imports_only_the_standard_library` — the property the whole fallback rests on

All nine gates pass, `ruff` and `mypy` clean, `claude plugin validate --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)