### PR TITLE
fix(guard): keep the index out of the repositories it analyses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Short version: Drift installs as a Claude Code plugin and works inside the agent
 - Hook output now reaches the model. The hooks printed findings to stdout and exited 0, which for `PreToolUse` and `PostToolUse` reaches the transcript only — the guard's findings would never have arrived. Output goes through `hookSpecificOutput.additionalContext`, with the session tally on `systemMessage`
 - `schema.connect()` no longer advertises `Connection | None` for writers that cannot fail; readers use `connect()`, writers use `create()`
 - make the two-line install actually produce a working guard
+- keep the index out of the repositories it analyses
 
 ## [2.51.1] - 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@
 
 Restart Claude Code, then run `/drift:doctor`. Those two lines are the whole
 install: the guard imports nothing but the standard library and runs from the
-plugin itself, so there is no `pip install`, no dependency to resolve, nothing
-to configure, and no file written into your project except a `.drift/` index
-you can delete at any time.
+plugin itself, so there is no `pip install`, no dependency to resolve and
+nothing to configure. It writes **nothing into your repositories** — the index
+lives in your cache (`~/.cache/drift`), keyed by repository path, because a
+plugin that fires in every project you open has no business leaving a directory
+in each of them. A project that wants the index alongside its source opts in by
+creating a `.drift/` directory.
 
 **Python files only.** The guard reads Python with `ast`; edits to other
 languages pass through untouched. The [CLI](#the-cli) below covers more.

--- a/docs-site/claude-code-plugin.md
+++ b/docs-site/claude-code-plugin.md
@@ -9,9 +9,13 @@
 
 Restart Claude Code, then run `/drift:doctor`. Those two lines are the whole
 install: the guard imports nothing but the standard library and runs from the
-plugin itself, so there is no `pip install`, no dependency to resolve, nothing
-to configure, and no file written into your project except a `.drift/` index
-you can delete at any time.
+plugin itself, so there is no `pip install`, no dependency to resolve and
+nothing to configure. It writes **nothing into your repositories** — the index
+lives in your cache (`~/.cache/drift`, or `$XDG_CACHE_HOME/drift`), keyed by
+repository path, because a plugin that fires in every project you open has no
+business leaving a directory in each of them. A project that wants the index
+alongside its source opts in by creating a `.drift/` directory; `DRIFT_CACHE_HOME`
+overrides both.
 
 !!! note "Python files only"
     The guard reads Python with `ast`. Edits to other languages pass through
@@ -81,12 +85,13 @@ but it can never block.
 
 | Piece | What it does |
 |---|---|
-| `.drift/index.db` | SQLite: module-level symbols, their normalised names and signature hashes, and every directory-to-directory import edge the repository contains |
+| `index.db` | SQLite: module-level symbols, their normalised names and signature hashes, and every directory-to-directory import edge the repository contains |
 | `drift-guard` | Lean entry point. Reads the index, parses at most the one file that changed |
 | Four hooks | `SessionStart` builds or refreshes the index in the background · `PreToolUse` briefs the agent before it creates a new file · `PostToolUse` reports what the edit introduced · `Stop` shows the session tally |
 
-The index is built once and updated per changed file. It is a cache: delete
-`.drift/` and the next session rebuilds it.
+The index is built once and updated per changed file. It is a cache and nothing
+more: delete the directory `/drift:doctor` prints and the next session rebuilds
+it. Nothing is written into the repository being analysed.
 
 ## Commands
 

--- a/src/drift/guard/report.py
+++ b/src/drift/guard/report.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import pathlib
 
-from drift.guard import lookup
+from drift.guard import lookup, schema
 
 MAX_MESSAGE_CHARS = 500
 _KINDS = ("duplicate", "boundary")
@@ -54,7 +54,9 @@ def hook_json(event: str, agent_text: str = "", user_text: str = "") -> str:
 
 
 def counter_path(repo_root) -> pathlib.Path:
-    return pathlib.Path(repo_root) / ".drift" / "session_counter.json"
+    # Same directory as the index, so the guard leaves exactly one place behind
+    # and `.drift/` never appears in a repository that did not ask for it.
+    return schema.state_dir(repo_root) / "session_counter.json"
 
 
 def read_counter(repo_root) -> dict:

--- a/src/drift/guard/schema.py
+++ b/src/drift/guard/schema.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import os
 import pathlib
 import sqlite3
 
@@ -37,9 +39,44 @@ CREATE INDEX IF NOT EXISTS idx_symbols_path ON symbols(path);
 """
 
 
+def state_dir(repo_root: pathlib.Path) -> pathlib.Path:
+    """Where the guard keeps its index and tally for one repository.
+
+    The guard is installed once and then fires in every repository the user
+    opens, including ones they do not own. Writing `.drift/` into each of them
+    would put an untracked directory in front of people who never asked for it
+    and never installed drift — a good way to get the plugin uninstalled. So
+    the default lives in the user's cache, keyed by the repository path.
+
+    A repository that *wants* the index alongside its source opts in simply by
+    having a `.drift/` directory; that path then wins. `DRIFT_CACHE_HOME`
+    overrides everything, which is what the tests use to stay off the real
+    cache.
+    """
+    repo_root = pathlib.Path(repo_root)
+    local = repo_root / ".drift"
+    if local.is_dir():
+        return local
+
+    override = os.environ.get("DRIFT_CACHE_HOME")
+    if override:
+        cache_root = pathlib.Path(override)
+    else:
+        xdg = os.environ.get("XDG_CACHE_HOME")
+        cache_root = pathlib.Path(xdg) if xdg else pathlib.Path.home() / ".cache"
+        cache_root = cache_root / "drift"
+
+    # The digest keys the directory; the name is only there to make the cache
+    # readable when someone goes looking. Both come from the resolved path, or
+    # `--repo .` would key on "" and produce a nameless directory.
+    resolved = repo_root.resolve()
+    digest = hashlib.sha256(str(resolved).encode("utf-8")).hexdigest()[:16]
+    return cache_root / f"{resolved.name or 'repo'}-{digest}"
+
+
 def index_path(repo_root: pathlib.Path) -> pathlib.Path:
     """Location of the guard index for a repository."""
-    return pathlib.Path(repo_root) / ".drift" / "index.db"
+    return state_dir(repo_root) / "index.db"
 
 
 def connect(repo_root: pathlib.Path) -> sqlite3.Connection | None:

--- a/tests/guard/conftest.py
+++ b/tests/guard/conftest.py
@@ -11,6 +11,19 @@ import pytest
 FIXTURE_ROOT = pathlib.Path(__file__).parent / "fixtures" / "sample_repo"
 
 
+@pytest.fixture(autouse=True)
+def guard_cache_home(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:
+    """Keep every test's index out of the real user cache.
+
+    The guard stores its index under the user's cache directory rather than in
+    the analysed repository, so without this the suite would write into
+    ~/.cache/drift and leak state between runs.
+    """
+    cache = tmp_path / "guard-cache"
+    monkeypatch.setenv("DRIFT_CACHE_HOME", str(cache))
+    return cache
+
+
 @pytest.fixture
 def sample_repo(tmp_path: pathlib.Path) -> pathlib.Path:
     """A writable copy of the ground-truth repo."""

--- a/tests/guard/test_schema.py
+++ b/tests/guard/test_schema.py
@@ -1,5 +1,6 @@
 """Index schema lifecycle."""
 
+import pathlib
 import sqlite3
 
 from drift.guard import schema
@@ -18,8 +19,40 @@ def test_initialize_creates_all_tables(tmp_path):
     assert schema.is_usable(conn) is True
 
 
-def test_index_lands_in_dot_drift(tmp_path):
+def test_index_stays_out_of_the_analysed_repository(tmp_path, guard_cache_home):
+    """The guard fires in every repository the user opens, including borrowed ones.
+
+    Dropping an untracked `.drift/` into each of them puts a directory in front
+    of people who never installed drift, so the default lives in the cache.
+    """
+    index = schema.index_path(tmp_path)
+
+    assert guard_cache_home in index.parents
+    assert ".drift" not in index.parts
+    assert not (tmp_path / ".drift").exists()
+
+
+def test_a_repository_can_opt_in_by_creating_dot_drift(tmp_path):
+    """An existing `.drift/` is a deliberate choice and wins over the cache."""
+    (tmp_path / ".drift").mkdir()
+
     assert schema.index_path(tmp_path).parts[-2:] == (".drift", "index.db")
+
+
+def test_two_repositories_do_not_share_a_cache_entry(tmp_path):
+    first = tmp_path / "alpha"
+    second = tmp_path / "beta"
+    first.mkdir()
+    second.mkdir()
+
+    assert schema.index_path(first) != schema.index_path(second)
+
+
+def test_the_counter_lives_beside_the_index(tmp_path):
+    """One directory for the guard's state, not two."""
+    from drift.guard import report
+
+    assert report.counter_path(tmp_path).parent == schema.index_path(tmp_path).parent
 
 
 def test_wrong_schema_version_is_not_usable(tmp_path):
@@ -34,3 +67,16 @@ def test_empty_database_is_not_usable(tmp_path):
     conn = sqlite3.connect(tmp_path / "bare.db")
 
     assert schema.is_usable(conn) is False
+
+
+def test_cache_directory_is_readable_even_for_a_relative_repo(tmp_path, monkeypatch):
+    """`--repo .` must not key on an empty name and produce a nameless directory."""
+    repo = tmp_path / "my-project"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    from_relative = schema.index_path(pathlib.Path("."))
+    from_absolute = schema.index_path(repo)
+
+    assert from_relative == from_absolute
+    assert from_relative.parent.name.startswith("my-project-")


### PR DESCRIPTION
The guard is installed once and then fires in **every** repository the user opens — including ones they neither own nor intend to change. It was writing `.drift/` into each of them.

That is the kind of detail that gets a plugin uninstalled rather than starred: an untracked directory appearing in someone else's checkout, from a tool that person never installed.

## What changed

The index and the session tally now live under the user's cache — `$XDG_CACHE_HOME/drift`, else `~/.cache/drift` — in one directory per repository, keyed by a digest of its resolved path:

```console
$ cd /tmp/clean && drift-guard --repo . build && drift-guard --repo . post --file src/api/schemas.py
drift:
  - `validate_token` already exists as `validate_token` in src/auth/tokens.py:4

$ ls -a /tmp/clean | grep -i drift        # nothing

$ find "$DRIFT_CACHE_HOME" -type f
<cache>/sample_repo-0ccf9c3e48c489ec/index.db
<cache>/sample_repo-0ccf9c3e48c489ec/session_counter.json
```

Both files sit together, so the guard leaves exactly one place behind and `/drift:doctor` prints where it is.

## Escape hatches

- A project that *wants* the index alongside its source opts in by creating a `.drift/` directory — that path then wins, which also keeps every existing checkout working without a migration.
- `DRIFT_CACHE_HOME` overrides both. The test suite sets it via an autouse fixture so the suite never touches the real cache.

## Detail worth naming

Name and digest both come from the *resolved* path. `--repo .` would otherwise key on an empty `.name` and produce a directory literally called `-<digest>` — readable cache defeated. There is a test for it.

## Verification

77 guard tests pass, all nine gates pass, `ruff` and `mypy` clean, markdownlint clean on both edited docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)