### PR TITLE
fix(plugin): let merges to main reach users who already installed

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "_comment_version": "There is deliberately no `version` field. Claude Code pins a plugin to that string and only offers an update when it changes; without it, the plugin tracks the git commit SHA and every merge to main reaches installed users. `claude plugin validate --strict` warns about the absence - that warning is the intended trade-off, not an oversight. See tests/guard/test_hooks.py::test_plugin_manifest_is_not_version_pinned.",
   "name": "drift",
   "displayName": "Drift",
-  "version": "2.51.1",
   "description": "Tells your coding agent when it is about to build something that already exists.",
   "author": {
     "name": "mick-gsk",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Short version: Drift installs as a Claude Code plugin and works inside the agent
 - `schema.connect()` no longer advertises `Connection | None` for writers that cannot fail; readers use `connect()`, writers use `create()`
 - make the two-line install actually produce a working guard
 - keep the index out of the repositories it analyses
+- let merges to main reach users who already installed
 
 ## [2.51.1] - 2026-05-04
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,10 +247,12 @@ check_untyped_defs = true
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
-# The Claude Code plugin ships from this same repository, so its manifest
-# version is bumped by the same release rather than maintained by hand — one
-# number, no drift between the PyPI package and the plugin.
-version_variables = [".claude-plugin/plugin.json:version"]
+# The Claude Code plugin manifest deliberately carries no version. A pinned
+# version means users only receive updates when that string changes, and the
+# release channel that would change it is not always available — so a fix could
+# sit on main for weeks without reaching anyone who installed. Without the
+# field, Claude Code falls back to the git commit SHA and every merge to main
+# propagates. See tests/guard/test_hooks.py::test_plugin_manifest_is_not_version_pinned.
 commit_message = "chore: Release {version}"
 tag_format = "v{version}"
 build_command = ""

--- a/tests/guard/test_hooks.py
+++ b/tests/guard/test_hooks.py
@@ -250,3 +250,25 @@ def test_bin_wrapper_works_without_an_installed_package():
 
     assert result.returncode == 0, result.stderr
     assert "index" in result.stdout
+
+
+def test_plugin_manifest_is_not_version_pinned():
+    """No `version` field, so every merge to main reaches installed users.
+
+    Claude Code pins a plugin to the manifest's `version` string when one is
+    present and only offers an update when that string changes. This repository
+    releases through a channel that is not always available, so a pinned
+    version means a fix can sit on main indefinitely while `plugin update`
+    reports "already at latest". Without the field, Claude Code falls back to
+    the git commit SHA.
+    """
+    root = pathlib.Path(__file__).resolve().parents[2]
+    manifest = json.loads((root / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))
+
+    assert "version" not in manifest, (
+        "a pinned plugin version stops fixes from reaching users who already installed"
+    )
+
+    entry = json.loads((root / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8"))
+    for plugin in entry["plugins"]:
+        assert "version" not in plugin, f"{plugin['name']} is pinned in marketplace.json"


### PR DESCRIPTION
## The problem

The manifest pinned `version` to the package version. From the plugin docs:

> `version` — Plugin version. **If set, the plugin is pinned to this string and users only receive updates when it changes.** Omit to fall back to the git commit SHA.

So `plugin update` only offers anything on a release, and releases go through a workflow that is currently blocked. A fix could sit on main indefinitely while every installed user is told they are current.

Not hypothetical — it happened within the hour:

```console
$ claude plugin marketplace update drift
✔ Successfully updated marketplace: drift
$ claude plugin update drift@drift
✔ drift is already at the latest version (2.51.1).
```

That was after #773 merged. The fix that made a bare install work *at all* could not reach anyone who had installed before it. I had to uninstall, purge the cache and re-add the marketplace to test my own fix.

## The change

Remove the field. Claude Code then tracks the git commit SHA, and every merge to main propagates on the next `plugin update`.

I introduced the pin myself, to keep the plugin and package versions from drifting apart. That reasoning was sound and the conclusion was wrong: tying the plugin to a release channel that may be unavailable trades a cosmetic risk for a functional one.

## The trade-off, stated

`claude plugin validate --strict` now warns:

```
⚠ version: No version specified. Consider adding a version following semver
✔ Validation passed with warnings
```

Advisory only — the plugin loads normally. Since the obvious "cleanup" is to add the version back, the reasoning is recorded in three places: the manifest itself, `pyproject.toml` where the release config used to bump it, and `test_plugin_manifest_is_not_version_pinned`, which fails if either manifest grows a `version` again.

## Verification

78 guard tests, all nine gates, `ruff` and `mypy` clean. Rebased onto #775.

🤖 Generated with [Claude Code](https://claude.com/claude-code)