### PR TITLE
feat(guard): add amphetamin — hold the session open on machine-checked work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Short version: Drift installs as a Claude Code plugin and works inside the agent
 - Ship drift as a Claude Code plugin: manifest, four hooks (SessionStart, PreToolUse, PostToolUse, Stop) and two slash commands (`/drift:doctor`, `/drift:stats`)
 - Add `drift-guard`, a lean entry point that imports only `sqlite3`, `ast` and `json` and answers from a prebuilt SQLite index instead of running an analysis
 - Add seven hard gates (latency, import hygiene, ground-truth recall, surface size, install time, index build, counter honesty) and a `guard-gates` CI job that installs without extras
+- add amphetamin — hold the session open on machine-checked work
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,43 @@ installed and no other instruction, Claude came back with this on its own:
 Nobody asked it to check for duplicates. The guard put the fact in front of it,
 and it did the rest. One run, unedited.
 
+## Amphetamin — keep the session running on open work
+
+Off by default. `/drift:amphetamin on` turns it on for a repository.
+
+Agents stop early far more often than they work slowly, and most early stops
+leave something on the table. While the mode is on, the `Stop` hook refuses
+**one** stop per session — and only when drift's index recorded a symbol
+introduced during that session which already existed elsewhere. It hands back a
+specific, finishable instruction and never asks twice:
+
+```json
+{"decision": "block",
+ "reason": "drift recorded 1 symbol(s) introduced in this session that already
+            existed elsewhere in this repository. Before finishing, for each
+            one: reuse the existing definition, or state in one line why a
+            second definition belongs here."}
+```
+
+That criterion is a recorded fact, not a judgement about whether an answer felt
+finished, so it cannot fire on a session that left nothing behind.
+
+**What is a mechanism and what is not.** The held stop is a mechanism: it fires
+or it does not, and there are tests for both. The mode also injects four
+throughput instructions at session start — batch independent tool calls, do not
+re-read unchanged files, prefer ranged reads, keep going while the next step is
+determined. Those are *instructions*. Nothing enforces them, and no speedup has
+been measured; calling them a guarantee would be the same mistake as citing a
+benchmark nobody ran.
+
+**What it will not do.** It does not skip permission prompts, truncate reads,
+shorten plans, skip verification or lower any threshold. An earlier draft
+auto-approved read-only tools at the permission prompt; that was cut. The prompt
+on `Read` is your only view of what an agent reaches for, and repository content
+is an established prompt-injection surface — an agent steered by a file it just
+read can ask for `~/.ssh/id_rsa`. A public plugin that removes that prompt trades
+a real control for convenience. A test fails if the mechanism ever grows back.
+
 ## Why it can run inside the loop
 
 The guard is a separate module that imports nothing but `sqlite3`, `ast` and

--- a/commands/drift-amphetamin.md
+++ b/commands/drift-amphetamin.md
@@ -1,0 +1,26 @@
+---
+description: Turn amphetamin on or off — keep sessions running on machine-checked open work.
+---
+
+Run `drift-guard amph $ARGUMENTS` in the repository root and show the output.
+
+With no argument it reports the current state. `on` and `off` switch the mode
+and reset this session's counters.
+
+If the user asks what the mode does, tell them exactly this and nothing more:
+
+- **What it does:** while on, the `Stop` hook refuses **one** stop per session
+  when drift's index recorded a symbol introduced during that session which
+  already existed elsewhere. It hands back a specific, finishable instruction
+  and never asks twice. It also injects a short set of throughput instructions
+  at session start: batch independent tool calls, do not re-read unchanged
+  files, prefer ranged reads, keep going while the next step is determined.
+- **What it does not do:** it does not skip permission prompts, truncate reads,
+  shorten plans, skip verification or lower any threshold. The prompt on `Read`
+  is the user's only view of what an agent reaches for, and repository content
+  is a prompt-injection surface — removing it would buy convenience with a real
+  control.
+- **What is guaranteed and what is not:** the single held stop is a mechanism —
+  it either fires or it does not, and there is a test for it. The throughput
+  instructions are instructions; nothing enforces them, and no speedup has been
+  measured. Say so if asked.

--- a/src/drift/guard/__main__.py
+++ b/src/drift/guard/__main__.py
@@ -12,7 +12,7 @@ import json
 import pathlib
 import sys
 
-from drift.guard import build, extract, lookup, report, schema
+from drift.guard import amphetamin, build, extract, lookup, report, schema
 
 ROUTING_TEXT = (
     "drift guard is active. After each edit it reports symbols that already "
@@ -22,6 +22,23 @@ ROUTING_TEXT = (
 )
 BUILDING_TEXT = (
     "drift: building the structural index in the background; the guard becomes active shortly."
+)
+# Injected only while amphetamin is on. These are instructions to the model,
+# not mechanisms: they change how it spends turns and nothing enforces them.
+# Kept separate from anything the guard actually guarantees so the difference
+# stays visible to whoever reads this next.
+AMPHETAMIN_TEXT = (
+    "amphetamin is on for this session. Spend turns, not care:\n"
+    "- Issue independent tool calls in one batch rather than one per turn. Most "
+    "reads, greps and globs in a plan do not depend on each other.\n"
+    "- Do not re-read a file you already read this session unless something "
+    "changed it. You still have the contents.\n"
+    "- Read the part you need. A ranged read of a known region beats a whole "
+    "file you will skim.\n"
+    "- Keep going while the next step is determined. Stop to ask only when the "
+    "answer would change what you do, not to report progress.\n"
+    "None of this trades correctness for speed: verify what you changed, and "
+    "say plainly when something failed."
 )
 
 
@@ -134,7 +151,12 @@ def _cmd_session_start(args) -> int:
         return 0
 
     report.reset_counter(repo_root)
-    _emit(args, ROUTING_TEXT)
+    amphetamin.reset_run(repo_root)
+
+    text = ROUTING_TEXT
+    if amphetamin.read_state(repo_root)["enabled"]:
+        text = f"{text}\n\n{AMPHETAMIN_TEXT}"
+    _emit(args, text)
     return 0
 
 
@@ -188,7 +210,32 @@ def _cmd_post(args) -> int:
 def _cmd_stats(args) -> int:
     # The tally is the user's proof that the guard earned its place, so it goes
     # to the human channel rather than into the agent's context.
-    _emit(args, user_text=report.summary_line(report.read_counter(pathlib.Path(args.repo))))
+    repo_root = pathlib.Path(args.repo)
+    counts = report.read_counter(repo_root)
+    tally = report.summary_line(counts)
+
+    # Under the Stop hook, amphetamin may hold the session open for work the
+    # index says is unfinished. That verdict rides along with the tally in one
+    # object: Claude Code reads a single JSON document from a hook.
+    if getattr(args, "hook", None) == "Stop":
+        block = amphetamin.decide_stop(repo_root, counts)
+        if block is not None:
+            payload = dict(block)
+            payload["systemMessage"] = f"{tally} · amphetamin held the session open"
+            print(json.dumps(payload))
+            return 0
+
+    _emit(args, user_text=tally)
+    return 0
+
+
+def _cmd_amph(args) -> int:
+    repo_root = pathlib.Path(args.repo)
+    if args.action in ("on", "off"):
+        state = amphetamin.set_enabled(repo_root, args.action == "on")
+    else:
+        state = amphetamin.read_state(repo_root)
+    print(amphetamin.status_line(state))
     return 0
 
 
@@ -248,6 +295,8 @@ def main(argv: list[str] | None = None) -> int:
     _add("reset", "Reset the session tally.")
     _add("doctor", "Check the guard installation.")
     _add("session-start", "Ensure an index exists and brief the agent.")
+    amph = _add("amph", "Turn amphetamin on or off, or show its state.")
+    amph.add_argument("action", nargs="?", default="status", choices=["on", "off", "status"])
 
     args = parser.parse_args(argv)
     args.repo = args.repo_local or args.repo_global
@@ -259,6 +308,7 @@ def main(argv: list[str] | None = None) -> int:
         "reset": _cmd_reset,
         "doctor": _cmd_doctor,
         "session-start": _cmd_session_start,
+        "amph": _cmd_amph,
     }
     try:
         return handlers[args.command](args)

--- a/src/drift/guard/amphetamin.py
+++ b/src/drift/guard/amphetamin.py
@@ -1,0 +1,127 @@
+"""Amphetamin — keep the agent working, without making it careless.
+
+The name promises speed. How that speed is bought matters more than the
+promise, so this module is explicit about what it will not do:
+
+* It does not skip permission prompts. An earlier draft auto-approved
+  "non-mutating" tools at the `PermissionRequest` hook. That was wrong. The
+  prompt on `Read` is the user's only view of what an agent reaches for, and
+  repository content is an established prompt-injection surface — an agent
+  steered by a file it just read can ask for `~/.ssh/id_rsa` or `.env`. A
+  public plugin that removes that prompt weakens a real control in exchange
+  for convenience.
+* It does not truncate reads, shorten plans, skip verification or lower any
+  threshold. Those buy a measurable win with an unmeasurable loss, and the
+  loss lands on the user long after the win was noticed.
+
+What is left is the honest version of "works longer": the agent stops early
+far more often than it works slowly, and most early stops happen with work
+still on the table. So this mode refuses exactly one stop per session, and
+only when the guard's own index says something concrete was left behind.
+
+That criterion is a fact, not a judgement about whether an answer "felt"
+finished. A mode that argues with the model about intent burns turns; a mode
+that points at a recorded duplicate gets a specific, finishable instruction.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+from drift.guard import schema
+
+#: One continuation per session. A Stop hook that blocks repeatedly is a loop,
+#: not a mode, and the user cannot easily get out of one.
+MAX_CONTINUATIONS = 1
+
+_DEFAULT_STATE: dict = {"enabled": False, "continuations": 0, "blocked_for": 0}
+
+
+def _state_file(repo_root) -> pathlib.Path:
+    return schema.state_dir(repo_root) / "amphetamin.json"
+
+
+def read_state(repo_root) -> dict:
+    path = _state_file(repo_root)
+    if not path.exists():
+        return dict(_DEFAULT_STATE)
+    try:
+        with open(path, encoding="utf-8") as handle:
+            stored = json.load(handle)
+    except (OSError, ValueError):
+        return dict(_DEFAULT_STATE)
+    return {
+        "enabled": bool(stored.get("enabled", False)),
+        "continuations": int(stored.get("continuations", 0)),
+        "blocked_for": int(stored.get("blocked_for", 0)),
+    }
+
+
+def write_state(repo_root, state: dict) -> None:
+    path = _state_file(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(state, handle)
+
+
+def set_enabled(repo_root, enabled: bool) -> dict:
+    """Turn the mode on or off, and start the new run from zero."""
+    state = read_state(repo_root)
+    state["enabled"] = enabled
+    state["continuations"] = 0
+    state["blocked_for"] = 0
+    write_state(repo_root, state)
+    return state
+
+
+def reset_run(repo_root) -> None:
+    """Clear the per-session counters without changing the on/off choice."""
+    state = read_state(repo_root)
+    state["continuations"] = 0
+    state["blocked_for"] = 0
+    write_state(repo_root, state)
+
+
+def decide_stop(repo_root, counts: dict) -> dict | None:
+    """Block one stop when the session left machine-checked work behind.
+
+    Returns None — meaning "let it stop" — whenever the mode is off, the
+    session already used its one continuation, or the tally is clean. Silence
+    is the default here exactly as it is everywhere else in the guard.
+    """
+    state = read_state(repo_root)
+    if not state["enabled"]:
+        return None
+    if state["continuations"] >= MAX_CONTINUATIONS:
+        return None
+
+    duplicates = int(counts.get("duplicate", 0))
+    if duplicates <= 0:
+        return None
+
+    state["continuations"] += 1
+    state["blocked_for"] = duplicates
+    write_state(repo_root, state)
+
+    return {
+        "decision": "block",
+        "reason": (
+            f"drift recorded {duplicates} symbol(s) introduced in this session that already "
+            "existed elsewhere in this repository. Before finishing, for each one: reuse the "
+            "existing definition, or state in one line why a second definition belongs here. "
+            "If you have already done that, say so in one line and stop — this check fires "
+            "once per session and will not ask again."
+        ),
+    }
+
+
+def status_line(state: dict) -> str:
+    if not state["enabled"]:
+        return "amphetamin: off — `drift-guard amph on` to keep sessions running on open work"
+    if state["continuations"]:
+        return (
+            f"amphetamin: on · held the session open once for "
+            f"{state['blocked_for']} unresolved duplicate(s)"
+        )
+    return "amphetamin: on · nothing left open this session"

--- a/tests/guard/test_amphetamin.py
+++ b/tests/guard/test_amphetamin.py
@@ -1,0 +1,163 @@
+"""Amphetamin: what it holds open, and what it refuses to touch."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+
+from drift.guard import amphetamin
+
+GUARD_SRC = pathlib.Path(__file__).resolve().parents[2] / "src" / "drift" / "guard"
+
+
+def _executable_source(path: pathlib.Path) -> str:
+    """The module without its docstrings.
+
+    Checked with `ast` rather than by filtering lines: the docstrings in this
+    module explain at length why it does not touch the permission system, and a
+    line filter would read that explanation as the thing it forbids.
+    """
+    import ast
+
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        body = node.body
+        leads_with_a_string = (
+            bool(body)
+            and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)
+        )
+        if leads_with_a_string:
+            node.body = body[1:] or [ast.Pass()]
+    return ast.unparse(tree)
+
+
+def test_off_by_default(tmp_path):
+    """Nobody opts into a behaviour change by installing a plugin."""
+    assert amphetamin.read_state(tmp_path)["enabled"] is False
+    assert amphetamin.decide_stop(tmp_path, {"duplicate": 3}) is None
+
+
+def test_holds_the_session_open_on_a_recorded_duplicate(tmp_path):
+    amphetamin.set_enabled(tmp_path, True)
+
+    verdict = amphetamin.decide_stop(tmp_path, {"duplicate": 2})
+
+    assert verdict is not None
+    assert verdict["decision"] == "block"
+    assert "2 symbol(s)" in verdict["reason"]
+
+
+def test_a_clean_tally_never_holds_the_session(tmp_path):
+    """Silence is the default here too — no duplicates, no interference."""
+    amphetamin.set_enabled(tmp_path, True)
+
+    assert amphetamin.decide_stop(tmp_path, {"duplicate": 0, "boundary": 5}) is None
+
+
+def test_it_blocks_once_and_then_lets_go(tmp_path):
+    """A Stop hook that blocks repeatedly is a loop the user cannot escape."""
+    amphetamin.set_enabled(tmp_path, True)
+
+    first = amphetamin.decide_stop(tmp_path, {"duplicate": 1})
+    second = amphetamin.decide_stop(tmp_path, {"duplicate": 1})
+    third = amphetamin.decide_stop(tmp_path, {"duplicate": 9})
+
+    assert first is not None
+    assert second is None
+    assert third is None
+
+
+def test_switching_on_starts_the_run_from_zero(tmp_path):
+    amphetamin.set_enabled(tmp_path, True)
+    amphetamin.decide_stop(tmp_path, {"duplicate": 1})
+    assert amphetamin.read_state(tmp_path)["continuations"] == 1
+
+    amphetamin.set_enabled(tmp_path, True)
+
+    assert amphetamin.read_state(tmp_path)["continuations"] == 0
+
+
+def test_a_corrupt_state_file_does_not_break_the_session(tmp_path):
+    amphetamin.set_enabled(tmp_path, True)
+    amphetamin._state_file(tmp_path).write_text("{not json", encoding="utf-8")
+
+    assert amphetamin.read_state(tmp_path)["enabled"] is False
+    assert amphetamin.decide_stop(tmp_path, {"duplicate": 4}) is None
+
+
+def test_it_never_touches_the_permission_system():
+    """The prompt on `Read` is the user's only view of what an agent reaches for.
+
+    Repository content is an established prompt-injection surface, so a plugin
+    that auto-approves reads trades a real control for convenience. This test
+    exists because the first draft of this module did exactly that.
+    """
+    code = _executable_source(GUARD_SRC / "amphetamin.py")
+
+    for forbidden in ("permissionDecision", "PermissionRequest", "behavior"):
+        assert forbidden not in code, (
+            f"{forbidden} appears in amphetamin's executable code — this mode must never "
+            "answer a permission prompt on the user's behalf"
+        )
+
+
+def test_the_stop_hook_emits_a_single_json_object(tmp_path, sample_repo):
+    """Claude Code parses one JSON document from a hook, not two."""
+    from drift.guard import build, report
+
+    build.build_full(sample_repo)
+    amphetamin.set_enabled(sample_repo, True)
+    report.bump(sample_repo, "duplicate")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "drift.guard",
+            "--hook",
+            "Stop",
+            "--repo",
+            str(sample_repo),
+            "stats",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["decision"] == "block"
+    assert "reason" in payload
+    assert "drift:" in payload["systemMessage"]
+
+
+def test_a_quiet_session_still_reports_the_tally(tmp_path, sample_repo):
+    from drift.guard import build
+
+    build.build_full(sample_repo)
+    amphetamin.set_enabled(sample_repo, True)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "drift.guard",
+            "--hook",
+            "Stop",
+            "--repo",
+            str(sample_repo),
+            "stats",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert "decision" not in payload
+    assert "drift:" in payload["systemMessage"]

--- a/tests/guard/test_gates.py
+++ b/tests/guard/test_gates.py
@@ -120,8 +120,15 @@ def test_gate_g3_no_false_positives_on_clean_files(sample_repo):
         assert hits == [], f"{rel_path} produced unexpected findings: {hits}"
 
 
+#: Raised from 2 to 3 on 2026-07-30 for `/drift:amphetamin`. The limit exists to
+#: keep the plugin to one promise, and this is the one command that serves a
+#: second one — so the increase is recorded here rather than absorbed silently.
+#: A fourth needs the same argument made again, in writing.
+MAX_SLASH_COMMANDS = 3
+
+
 def test_gate_g4_surface_stays_small():
-    """G4: the plugin surface must stay at or below two tools and two commands."""
+    """G4: the plugin surface must stay at or below one server and three commands."""
     root = pathlib.Path(__file__).resolve().parents[2]
     with open(root / ".claude-plugin" / "plugin.json", encoding="utf-8") as handle:
         manifest = json.load(handle)
@@ -130,7 +137,9 @@ def test_gate_g4_surface_stays_small():
     commands = list((root / "commands").glob("drift-*.md"))
 
     assert len(tools) <= 1, "at most one MCP server"
-    assert len(commands) <= 2, f"at most two slash commands, found {len(commands)}"
+    assert len(commands) <= MAX_SLASH_COMMANDS, (
+        f"at most {MAX_SLASH_COMMANDS} slash commands, found {len(commands)}"
+    )
 
     # Zero mandatory config files. The repository's own drift.yaml configures
     # the analysis engine and predates the guard, so the property is checked


### PR DESCRIPTION
Requested feature. Off by default; `/drift:amphetamin on` enables it per repository.

## The mechanism

Agents stop early far more often than they work slowly, and most early stops leave something on the table. While the mode is on, the `Stop` hook refuses **one** stop per session — and only when the index recorded a symbol introduced during that session that already existed elsewhere.

Verified live, not asserted:

```json
{"decision": "block",
 "reason": "drift recorded 1 symbol(s) introduced in this session that already existed elsewhere in this repository. Before finishing, for each one: reuse the existing definition, or state in one line why a second definition belongs here. If you have already done that, say so in one line and stop — this check fires once per session and will not ask again.",
 "systemMessage": "drift: 1 duplicate(s) flagged, 0 new boundary crossing(s) this session · amphetamin held the session open"}
```

Claude Code parsed it, the session continued, and the second turn addressed the duplicate. State afterwards: `amphetamin: on · held the session open once for 1 unresolved duplicate(s)`.

The criterion is a recorded fact, not a judgement about whether an answer felt finished — so it cannot fire on a clean session. The one-shot cap means a `Stop` hook can never become a loop the user cannot escape.

## What I cut, and why

The first draft also auto-approved read-only tools at the `PermissionRequest` hook, to remove the other thing that ends autonomous runs: waiting for a human. That would have been the larger speed win. It is not in this PR.

The prompt on `Read` is the user's only view of what an agent reaches for, and repository content is an established prompt-injection surface — an agent steered by a file it just read can ask for `~/.ssh/id_rsa` or `.env`. Shipping that in a **public** plugin trades a real control for convenience, and drift's whole pitch is that it reads your repository and feeds it to your agent. `test_it_never_touches_the_permission_system` parses this module's AST (not its text — the docstrings explain the ban at length) and fails if `permissionDecision`, `PermissionRequest` or `behavior` ever appear in executable code.

## Mechanism vs. instruction

Four throughput instructions ride along at session start: batch independent tool calls, do not re-read unchanged files, prefer ranged reads, keep going while the next step is determined.

Those are **instructions**. Nothing enforces them and no speedup has been measured. The README, the command doc and a code comment all say so, because a feature that blurs "we guarantee this" into "we suggest this" is exactly the kind of unfounded claim the rest of this repository has been cleaning up.

## Surface

G4 raised from two slash commands to three. That gate exists to keep the plugin to one promise, and this command serves a second one — so the increase is recorded in the gate with the argument for it, and a fourth needs the argument made again in writing.

**Worth saying plainly:** the analysis this whole effort rests on attributes context-mode's outcome to one promise per codebase. A second, unrelated promise in the same plugin is the change most likely to weaken that. Shipped because it was asked for; the positioning cost is real.

## Verification

87 guard tests (9 new), all nine gates, `ruff` and `mypy` clean, markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)