### PR TITLE
feat(guard): guard TypeScript and JavaScript, not only Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Short version: Drift installs as a Claude Code plugin and works inside the agent
 - Add `drift-guard`, a lean entry point that imports only `sqlite3`, `ast` and `json` and answers from a prebuilt SQLite index instead of running an analysis
 - Add seven hard gates (latency, import hygiene, ground-truth recall, surface size, install time, index build, counter honesty) and a `guard-gates` CI job that installs without extras
 - add amphetamin — hold the session open on machine-checked work
+- guard TypeScript and JavaScript, not only Python
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ plugin that fires in every project you open has no business leaving a directory
 in each of them. A project that wants the index alongside its source opts in by
 creating a `.drift/` directory.
 
-**Python files only.** The guard reads Python with `ast`; edits to other
-languages pass through untouched. The [CLI](#the-cli) below covers more.
+**Python, TypeScript and JavaScript** (`.py .ts .tsx .js .jsx .mjs .cjs`), in one
+index — a name defined in Python is found from TypeScript, because
+`validate_token` and `validateToken` normalise to the same thing. Other
+languages pass through untouched.
 
 <!-- Re-enable once GitHub Actions is unlocked (billing) — runs currently fail before starting, which renders a misleading red badge:
 [![CI](https://github.com/mick-gsk/drift/actions/workflows/ci.yml/badge.svg)](https://github.com/mick-gsk/drift/actions/workflows/ci.yml)

--- a/docs-site/claude-code-plugin.md
+++ b/docs-site/claude-code-plugin.md
@@ -17,9 +17,15 @@ business leaving a directory in each of them. A project that wants the index
 alongside its source opts in by creating a `.drift/` directory; `DRIFT_CACHE_HOME`
 overrides both.
 
-!!! note "Python files only"
-    The guard reads Python with `ast`. Edits to other languages pass through
-    untouched. For everything else, use the [CLI](getting-started/installation.md).
+!!! note "Python, TypeScript and JavaScript"
+    `.py .ts .tsx .js .jsx .mjs .cjs`, all in one index — a name defined in
+    Python is found from TypeScript, because `validate_token` and
+    `validateToken` normalise to the same thing. Python is parsed with `ast`;
+    TypeScript and JavaScript are matched against top-level declarations,
+    because the guard may not grow a parser dependency. That trade costs recall,
+    never precision: every pattern is anchored to column zero and to a
+    declaration keyword, so a miss is possible and an invented symbol is not.
+    Edits to other languages pass through untouched.
 
 ## What it says
 

--- a/src/drift/guard/__main__.py
+++ b/src/drift/guard/__main__.py
@@ -67,7 +67,7 @@ def _target_file(args, repo_root: pathlib.Path) -> str | None:
         raw = str((payload.get("tool_input") or {}).get("file_path") or "")
     except (ValueError, OSError, AttributeError):
         return None
-    if not raw.endswith(".py"):
+    if pathlib.PurePosixPath(raw).suffix not in extract.GUARDED_SUFFIXES:
         return None
 
     path = pathlib.Path(raw)
@@ -193,7 +193,7 @@ def _cmd_post(args) -> int:
         conn.close()
         return 0
 
-    symbols, imports = extract.extract(source)
+    symbols, imports = extract.extract(source, pathlib.PurePosixPath(target).suffix)
     hits = lookup.find_duplicates(conn, target, symbols)
     hits += lookup.find_novel_edges(conn, target, imports)
     conn.close()

--- a/src/drift/guard/build.py
+++ b/src/drift/guard/build.py
@@ -1,7 +1,7 @@
 """Build the guard index from a repository.
 
-Full builds walk every Python file once. Incremental updates touch exactly
-one file, which is what the PostToolUse hook does after each edit.
+Full builds walk every indexable source file once. Incremental updates touch
+exactly one file, which is what the PostToolUse hook does after each edit.
 """
 
 from __future__ import annotations
@@ -45,10 +45,53 @@ def module_to_dir(module: str, known_dirs: set[str]) -> str | None:
     return None
 
 
-def _iter_python_files(repo_root: pathlib.Path):
-    for path in sorted(repo_root.rglob("*.py")):
+def relative_to_dir(specifier: str, src_dir: str, known_dirs: set[str]) -> str | None:
+    """Resolve a `./x` or `../y/z` import onto a repository directory.
+
+    A specifier can name either a directory (`../db`) or a module inside one
+    (`../db/client`), and the guard cannot tell which without touching the
+    disk. So it tries the resolved path as a directory first and falls back to
+    its parent — exactly right for the file case, harmless otherwise.
+    """
+    base = "" if src_dir == "." else src_dir
+    parts: list[str] = []
+    for part in f"{base}/{specifier}".split("/"):
+        if part in ("", "."):
+            continue
+        if part == "..":
+            if parts:
+                parts.pop()
+            continue
+        parts.append(part)
+
+    candidate = "/".join(parts) if parts else "."
+    if candidate in known_dirs:
+        return candidate
+    parent = dir_of(candidate)
+    return parent if parent in known_dirs else None
+
+
+def import_to_dir(specifier: str, src_dir: str, known_dirs: set[str]) -> str | None:
+    """Map any import specifier onto a repository directory, if it is one.
+
+    Bare TypeScript specifiers (`react`, `@scope/pkg`) name packages rather
+    than places in this repository, so they resolve to nothing.
+    """
+    if specifier.startswith("."):
+        return relative_to_dir(specifier, src_dir, known_dirs)
+    if "/" in specifier:
+        return None
+    return module_to_dir(specifier, known_dirs)
+
+
+def _iter_source_files(repo_root: pathlib.Path):
+    for path in sorted(repo_root.rglob("*")):
+        if path.suffix not in extract.GUARDED_SUFFIXES:
+            continue
         rel = path.relative_to(repo_root)
         if any(part in SKIP_DIRS for part in rel.parts):
+            continue
+        if not path.is_file():
             continue
         yield rel.as_posix(), path
 
@@ -69,7 +112,7 @@ def build_full(repo_root: pathlib.Path) -> dict:
     conn = schema.create(repo_root)
     schema.initialize(conn)
 
-    collected = list(_iter_python_files(repo_root))
+    collected = list(_iter_source_files(repo_root))
     known_dirs = {dir_of(rel) for rel, _ in collected}
 
     edge_counts: dict[tuple[str, str], int] = {}
@@ -82,13 +125,13 @@ def build_full(repo_root: pathlib.Path) -> dict:
             source = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        symbols, imports = extract.extract(source)
+        symbols, imports = extract.extract(source, path.suffix)
         src_dir = dir_of(rel)
 
         file_rows.append((rel, _sha256(path), now))
         symbol_rows.extend((rel, s.name, s.norm_name, s.kind, s.sig_hash, s.line) for s in symbols)
         for module in imports:
-            dst_dir = module_to_dir(module, known_dirs)
+            dst_dir = import_to_dir(module, src_dir, known_dirs)
             if dst_dir is None or dst_dir == src_dir:
                 continue
             edge_counts[(src_dir, dst_dir)] = edge_counts.get((src_dir, dst_dir), 0) + 1
@@ -133,7 +176,7 @@ def update_file(repo_root: pathlib.Path, rel_path: str) -> None:
             conn.commit()
             conn.close()
             return
-        symbols, imports = extract.extract(source)
+        symbols, imports = extract.extract(source, path.suffix)
         conn.executemany(
             "INSERT INTO symbols (path, name, norm_name, kind, sig_hash, line)"
             " VALUES (?, ?, ?, ?, ?, ?)",
@@ -147,7 +190,7 @@ def update_file(repo_root: pathlib.Path, rel_path: str) -> None:
         known_dirs |= {dir_of(row[0]) for row in conn.execute("SELECT path FROM files")}
         src_dir = dir_of(rel_path)
         for module in imports:
-            dst_dir = module_to_dir(module, known_dirs)
+            dst_dir = import_to_dir(module, src_dir, known_dirs)
             if dst_dir is None or dst_dir == src_dir:
                 continue
             conn.execute(

--- a/src/drift/guard/extract.py
+++ b/src/drift/guard/extract.py
@@ -1,15 +1,30 @@
-"""Extract symbols and import targets from a single Python source file.
+"""Extract symbols and import targets from a single source file.
 
-Only module-level functions and classes count as symbols. Methods are
-excluded on purpose: ``run``, ``handle`` and friends repeat across every
-class in a codebase and would drown the duplicate signal in noise.
+Only top-level functions, classes and named bindings count as symbols. Methods
+and locals are excluded on purpose: ``run``, ``handle`` and friends repeat
+across every class in a codebase and would drown the duplicate signal in noise.
+
+Python is parsed with ``ast``. TypeScript and JavaScript are matched with
+regular expressions against top-level declarations, because the guard may not
+grow a dependency — a parser would be a better tool and an unavailable one. The
+trade is deliberate and one-sided: a regex misses declarations a parser would
+catch (false negatives), and silence is already the guard's normal state, so a
+miss costs nothing the user notices. What it must never do is invent a symbol
+that is not there, which is why every pattern is anchored to column zero and to
+a declaration keyword.
 """
 
 from __future__ import annotations
 
 import ast
 import hashlib
+import re
 from typing import NamedTuple
+
+#: File types the guard indexes. Everything else passes through untouched.
+PYTHON_SUFFIXES = frozenset({".py"})
+TS_JS_SUFFIXES = frozenset({".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"})
+GUARDED_SUFFIXES = PYTHON_SUFFIXES | TS_JS_SUFFIXES
 
 #: Normalized names too common to ever be a meaningful duplicate.
 STOPWORDS = frozenset(
@@ -31,7 +46,49 @@ STOPWORDS = frozenset(
         "update",
         "delete",
         "test",
+        # Structural rather than semantic: every TypeScript codebase has many,
+        # and two files both exporting `default` says nothing about duplication.
+        "index",
+        "default",
     }
+)
+
+#: Top-level declarations in TypeScript and JavaScript. Each is anchored to
+#: column zero, which is the regex stand-in for "module level" — the same rule
+#: the Python side gets from walking `tree.body` instead of the whole tree.
+_TS_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "function",
+        re.compile(
+            r"^(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s*\*?\s*([A-Za-z_$][\w$]*)\s*\(",
+            re.MULTILINE,
+        ),
+    ),
+    (
+        "class",
+        re.compile(r"^(?:export\s+)?(?:default\s+)?class\s+([A-Za-z_$][\w$]*)", re.MULTILINE),
+    ),
+    (
+        "type",
+        re.compile(
+            r"^(?:export\s+)?(?:declare\s+)?(?:interface|type|enum)\s+([A-Za-z_$][\w$]*)",
+            re.MULTILINE,
+        ),
+    ),
+    (
+        "binding",
+        re.compile(r"^(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*[:=]", re.MULTILINE),
+    ),
+)
+
+#: Import and re-export specifiers. `require` and dynamic `import()` are matched
+#: anywhere, not just at column zero, because both routinely appear inside a
+#: function body and still describe a real dependency between directories.
+_TS_IMPORTS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"""^\s*(?:import|export)\b[^;\n]*?\bfrom\s*['"]([^'"]+)['"]""", re.MULTILINE),
+    re.compile(r"""^\s*import\s*['"]([^'"]+)['"]""", re.MULTILINE),
+    re.compile(r"""\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)"""),
+    re.compile(r"""\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)"""),
 )
 
 
@@ -62,7 +119,58 @@ def _arg_names(node: ast.AST) -> list[str]:
     return [a for a in collected if a not in ("self", "cls")]
 
 
-def extract(source: str) -> tuple[list[Symbol], list[str]]:
+def extract(source: str, suffix: str = ".py") -> tuple[list[Symbol], list[str]]:
+    """Return (top-level symbols, import specifiers) for one file.
+
+    `suffix` picks the reader. Anything unrecognised yields nothing rather than
+    guessing, so a new file type stays silent until it is supported on purpose.
+    """
+    if suffix in TS_JS_SUFFIXES:
+        return extract_ts(source)
+    if suffix in PYTHON_SUFFIXES:
+        return extract_python(source)
+    return ([], [])
+
+
+def extract_ts(source: str) -> tuple[list[Symbol], list[str]]:
+    """TypeScript and JavaScript, matched rather than parsed.
+
+    Line numbers come from counting newlines before the match, which is exact
+    for the anchored patterns and cheap enough to stay inside the guard's
+    latency budget.
+    """
+    symbols: list[Symbol] = []
+    seen: set[str] = set()
+
+    for kind, pattern in _TS_PATTERNS:
+        for match in pattern.finditer(source):
+            name = match.group(1)
+            if name in seen:
+                continue
+            seen.add(name)
+            symbols.append(
+                Symbol(
+                    name=name,
+                    norm_name=normalize(name),
+                    kind=kind,
+                    # No argument list: extracting parameters from a regex match
+                    # would mean re-implementing the parser this deliberately
+                    # avoids, and duplicate lookup matches on the normalised
+                    # name alone.
+                    sig_hash=signature_hash(kind, []),
+                    line=source.count("\n", 0, match.start()) + 1,
+                )
+            )
+
+    imports: list[str] = []
+    for pattern in _TS_IMPORTS:
+        imports.extend(match.group(1) for match in pattern.finditer(source))
+
+    symbols.sort(key=lambda s: s.line)
+    return (symbols, imports)
+
+
+def extract_python(source: str) -> tuple[list[Symbol], list[str]]:
     """Return (module-level symbols, imported module paths) for one file."""
     try:
         tree = ast.parse(source)

--- a/src/drift/guard/lookup.py
+++ b/src/drift/guard/lookup.py
@@ -56,7 +56,7 @@ def find_novel_edges(conn: sqlite3.Connection, rel_path: str, imports: list[str]
     hits: list[Hit] = []
     reported: set[str] = set()
     for module in imports:
-        dst_dir = build.module_to_dir(module, known_dirs)
+        dst_dir = build.import_to_dir(module, src_dir, known_dirs)
         if dst_dir is None or dst_dir == src_dir:
             continue
         if dst_dir in existing or dst_dir in reported:

--- a/tests/guard/test_extract_ts.py
+++ b/tests/guard/test_extract_ts.py
@@ -1,0 +1,178 @@
+"""TypeScript and JavaScript: what the matcher finds, and what it refuses to invent."""
+
+from __future__ import annotations
+
+from drift.guard import build, extract, lookup, report, schema
+
+SAMPLE = """\
+import { pool } from '../db/client';
+import React from 'react';
+import type { User } from './types';
+
+export async function validateToken(token: string, audience: string) {
+  return true;
+}
+
+function localHelper() {}
+
+export class TokenStore {
+  validate() { return true; }
+  private helper() {}
+}
+
+export interface Session {
+  id: string;
+}
+
+export const DEFAULT_TTL = 3600;
+
+const lazy = () => import('./heavy');
+const legacy = require('../legacy/shim');
+"""
+
+
+def _names(source: str, suffix: str = ".ts") -> list[str]:
+    symbols, _ = extract.extract(source, suffix)
+    return [s.name for s in symbols]
+
+
+def test_it_finds_top_level_declarations():
+    names = _names(SAMPLE)
+
+    assert "validateToken" in names
+    assert "localHelper" in names
+    assert "TokenStore" in names
+    assert "Session" in names
+    assert "DEFAULT_TTL" in names
+
+
+def test_it_ignores_class_members():
+    """Same rule as Python: methods repeat everywhere and would drown the signal."""
+    names = _names(SAMPLE)
+
+    assert "validate" not in names
+    assert "helper" not in names
+
+
+def test_it_collects_every_import_shape():
+    _, imports = extract.extract(SAMPLE, ".ts")
+
+    assert "../db/client" in imports
+    assert "./types" in imports
+    assert "react" in imports
+    assert "./heavy" in imports, "dynamic import() is a real dependency"
+    assert "../legacy/shim" in imports, "require() is a real dependency"
+
+
+def test_camel_case_and_snake_case_collide():
+    """`validateToken` in TypeScript must match `validate_token` in Python."""
+    ts_symbols, _ = extract.extract("export function validateToken(a) {}\n", ".ts")
+    py_symbols, _ = extract.extract("def validate_token(a):\n    pass\n", ".py")
+
+    assert ts_symbols[0].norm_name == py_symbols[0].norm_name
+
+
+def test_an_unsupported_suffix_yields_nothing():
+    """A new file type stays silent until it is supported on purpose."""
+    assert extract.extract("func main() {}\n", ".go") == ([], [])
+
+
+def test_line_numbers_point_at_the_declaration():
+    symbols, _ = extract.extract(SAMPLE, ".ts")
+    by_name = {s.name: s.line for s in symbols}
+
+    assert SAMPLE.split("\n")[by_name["validateToken"] - 1].startswith("export async function")
+    assert SAMPLE.split("\n")[by_name["TokenStore"] - 1].startswith("export class")
+
+
+def test_a_word_inside_a_string_is_not_a_declaration():
+    """Anchoring to column zero and a keyword is what keeps this honest."""
+    source = 'const message = "export function notARealFunction() {}";\n'
+
+    assert _names(source) == ["message"]
+
+
+def test_indented_declarations_are_not_top_level():
+    source = "function outer() {\n  function inner() {}\n  class Inner {}\n}\n"
+
+    assert _names(source) == ["outer"]
+
+
+def test_relative_imports_resolve_onto_directories():
+    known = {"src/api", "src/db", "src/auth", "."}
+
+    assert build.import_to_dir("../db/client", "src/api", known) == "src/db"
+    assert build.import_to_dir("../db", "src/api", known) == "src/db"
+    assert build.import_to_dir("./helpers", "src/api", known) == "src/api"
+
+
+def test_package_specifiers_are_not_repository_directories():
+    known = {"src/api", "react", "."}
+
+    assert build.import_to_dir("@scope/pkg", "src/api", known) is None
+    assert build.import_to_dir("lodash/fp", "src/api", known) is None
+
+
+def _write_ts_repo(root):
+    (root / "src" / "auth").mkdir(parents=True)
+    (root / "src" / "api").mkdir(parents=True)
+    (root / "src" / "db").mkdir(parents=True)
+    (root / "src" / "auth" / "tokens.ts").write_text(
+        "export function validateToken(token: string) {\n  return true;\n}\n", encoding="utf-8"
+    )
+    (root / "src" / "api" / "routes.ts").write_text(
+        "import { validateToken } from '../auth/tokens';\nexport function register() {}\n",
+        encoding="utf-8",
+    )
+    (root / "src" / "db" / "client.ts").write_text("export const pool = 1;\n", encoding="utf-8")
+
+
+def test_a_typescript_repository_reports_a_duplicate(tmp_path):
+    _write_ts_repo(tmp_path)
+    build.build_full(tmp_path)
+    conn = schema.connect(tmp_path)
+
+    symbols, _ = extract.extract(
+        "export function validateToken(t: string) {\n  return false;\n}\n", ".ts"
+    )
+    hits = lookup.find_duplicates(conn, "src/api/schemas.ts", symbols)
+
+    assert hits, "a duplicated TypeScript export must be reported"
+    assert "src/auth/tokens.ts:1" in hits[0].message
+
+
+def test_a_typescript_repository_reports_a_first_ever_boundary(tmp_path):
+    _write_ts_repo(tmp_path)
+    build.build_full(tmp_path)
+    conn = schema.connect(tmp_path)
+
+    hits = lookup.find_novel_edges(conn, "src/api/routes.ts", ["../db/client"])
+
+    assert hits, "src/api has never imported from src/db"
+    assert "src/api" in hits[0].message and "src/db" in hits[0].message
+
+
+def test_an_established_typescript_edge_is_not_reported(tmp_path):
+    """src/api already imports from src/auth, so that crossing is not news."""
+    _write_ts_repo(tmp_path)
+    build.build_full(tmp_path)
+    conn = schema.connect(tmp_path)
+
+    assert lookup.find_novel_edges(conn, "src/api/routes.ts", ["../auth/tokens"]) == []
+
+
+def test_python_and_typescript_share_one_index(tmp_path):
+    """A symbol defined in Python must be found from a TypeScript file."""
+    _write_ts_repo(tmp_path)
+    (tmp_path / "src" / "auth" / "session.py").write_text(
+        "def rotate_secret(a):\n    return a\n", encoding="utf-8"
+    )
+    build.build_full(tmp_path)
+    conn = schema.connect(tmp_path)
+
+    symbols, _ = extract.extract("export function rotateSecret(a) {}\n", ".ts")
+    hits = lookup.find_duplicates(conn, "src/api/new.ts", symbols)
+
+    assert hits, "the index is one index, not one per language"
+    assert "session.py" in hits[0].message
+    assert report.format_hits(hits)


### PR DESCRIPTION
"Python files only" excluded most of the people this plugin is for. That line was on the first screen of the README as an honest limitation; this removes the limitation instead.

## What works now

`.py .ts .tsx .js .jsx .mjs .cjs`, in **one** index rather than one per language. A name defined in Python is found from TypeScript, because `validate_token` and `validateToken` already normalise to the same string.

Verified through the real hook on a TypeScript repository — both signals, one edit:

```json
{"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext":
 "drift:\n  - `validateToken` already exists as `validateToken` in src/auth/tokens.ts:1\n  - first import from src/api/ into src/db/ anywhere in this repository"}}
```

Index build on a 62-file TypeScript repository: 9.4 ms.

## Regex, and why that is the right call here

Python keeps `ast`. TypeScript and JavaScript are matched, not parsed, because the guard may not grow a dependency — that constraint is what makes `/plugin install` sufficient with no `pip install`, and it is enforced by G2 and by a test.

The trade is one-sided and stated in the module docstring:

- **Recall**: a regex misses declarations a parser would catch. Silence is already the guard's normal state, so a miss costs nothing the user notices.
- **Precision**: inventing a symbol would cost trust, so every pattern is anchored to column zero *and* to a declaration keyword. Two tests exist for exactly this — `const message = "export function notARealFunction() {}"` must yield only `message`, and declarations nested inside a function must not be treated as top level.

Class members are excluded, same rule as Python: `validate()` and `helper()` repeat across every class and would drown the signal.

## Import resolution

The dotted-module mapper never had the source directory, and `./x` or `../db/client` mean nothing without knowing where they were written. `import_to_dir`:

- resolves relative specifiers against the file's own directory,
- tries the result as a directory and falls back to its parent, which is exactly right when the specifier names a file (`../db/client` → `src/db`),
- drops bare specifiers, because `react` and `@scope/pkg` are packages rather than places in the repository.

`index` and `default` join the stopword list — structural names in TypeScript, and two files exporting `default` says nothing about duplication.

## Verification

101 guard tests (14 new), all nine gates including G1 latency and G6 index build, `ruff` and `mypy` clean, markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)