### PR TITLE
fix(guard): stop the guard speaking on half of every real repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Short version: Drift installs as a Claude Code plugin and works inside the agent
 - make the two-line install actually produce a working guard
 - keep the index out of the repositories it analyses
 - let merges to main reach users who already installed
+- stop the guard speaking on half of every real repository
 
 ## [2.51.1] - 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,37 @@ repository, answered before the agent writes its next line:
    repository actually contains, so a first-ever crossing stands out without you
    writing a single rule.
 
-`/drift:stats` shows what it caught this session. Silence is the normal case,
-not a failure.
+`/drift:stats` shows what it caught this session.
+
+### Silence is the normal case — measured, not asserted
+
+Replaying every file of five real repositories through the same lookups the
+hook runs, as if each had just been written:
+
+| Repository | Files | Speaks on |
+|---|---|---|
+| requests | 37 | **0.0 %** |
+| fastapi | 1140 | **1.0 %** |
+| date-fns | 1619 | **2.0 %** |
+| flask | 83 | **4.8 %** |
+| axios | 232 | **5.6 %** |
+
+Reproduce it with `python scripts/gates/measure_noise.py <dir-of-checkouts>`.
+
+The first run of that measurement said 27–69 %, and what it reported was junk:
+`config`, `argv`, `add`, plus fastapi's `docs_src/` tutorials, which define
+`Item` in over a hundred files on purpose. Nothing in the test suite could have
+caught it — the fixture is six files written to demonstrate the two signals.
+Five rules came out of that measurement, each one a defect it exposed: a
+function does not duplicate a class, a name repeated across the codebase is a
+convention rather than an accident, short and dunder names carry no evidence,
+test and example directories restate names by design, and a TypeScript `const`
+counts only when it holds a function — Python never indexed plain assignments,
+and the asymmetry was the single largest source of noise.
+
+What survives is worth reading: `_make_timedelta` really is defined twice in
+Flask, and `Blueprint` really does exist in both `blueprints.py` and
+`sansio/blueprints.py`.
 
 ### What that looks like in a real session
 

--- a/scripts/gates/measure_noise.py
+++ b/scripts/gates/measure_noise.py
@@ -1,0 +1,115 @@
+"""How often would the guard speak on code that is already in the repository?
+
+Every file in a checked-out repository is existing, reviewed, working code. A
+report on one of those files is not automatically wrong — real duplication
+exists, and this measurement finds some — but a high rate means the guard is
+noise in practice, whatever it scores on a fixture.
+
+This exists because the fixture said 100 % recall and 0 false positives while
+the guard, measured against five real repositories, would have spoken on
+27–69 % of their files. Nothing in the test suite could have caught that: the
+fixture is six files written to demonstrate the two signals.
+
+Usage:
+
+    git clone --depth 1 https://github.com/pallets/flask /tmp/corpus/flask
+    python scripts/gates/measure_noise.py /tmp/corpus
+
+Point it at a directory of checkouts. It builds an index per repository and
+replays every file through the same lookups the PostToolUse hook runs.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "src"))
+
+from drift.guard import build, extract, lookup, schema  # noqa: E402
+
+#: Above this, the guard is interrupting rather than reporting. Chosen from the
+#: measured spread (0.0-5.6 % across five repositories), not from taste.
+NOISE_BUDGET_PERCENT = 10.0
+
+
+def measure(repo: pathlib.Path) -> dict:
+    started = time.perf_counter()
+    stats = build.build_full(repo)
+    build_seconds = time.perf_counter() - started
+
+    conn = schema.connect(repo)
+    if conn is None:
+        return {"repo": repo.name, "files": 0, "rate": 0.0, "examples": []}
+
+    files = [row[0] for row in conn.execute("SELECT path FROM files ORDER BY path")]
+    spoke = 0
+    duplicates = 0
+    boundaries = 0
+    examples: list[str] = []
+
+    for rel in files:
+        try:
+            source = (repo / rel).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        symbols, imports = extract.extract(source, pathlib.PurePosixPath(rel).suffix)
+        hits = lookup.find_duplicates(conn, rel, symbols)
+        duplicate_count = len(hits)
+        hits += lookup.find_novel_edges(conn, rel, imports)
+        if not hits:
+            continue
+        spoke += 1
+        duplicates += duplicate_count
+        boundaries += len(hits) - duplicate_count
+        if len(examples) < 3:
+            examples.append(f"{rel}: {hits[0].message}")
+
+    conn.close()
+    return {
+        "repo": repo.name,
+        "files": len(files),
+        "symbols": stats["symbols"],
+        "build_seconds": round(build_seconds, 2),
+        "spoke_on": spoke,
+        "rate": round(100.0 * spoke / max(1, len(files)), 1),
+        "duplicates": duplicates,
+        "boundaries": boundaries,
+        "examples": examples,
+    }
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 2
+
+    corpus = pathlib.Path(sys.argv[1])
+    over_budget: list[str] = []
+
+    for repo in sorted(p for p in corpus.iterdir() if p.is_dir()):
+        result = measure(repo)
+        print(
+            f"\n{result['repo']:14} {result['files']:>5} files  "
+            f"{result['symbols']:>6} symbols  build {result['build_seconds']:>5.2f}s"
+        )
+        print(
+            f"{'':14} speaks on {result['spoke_on']:>4}/{result['files']} files "
+            f"= {result['rate']}%  ({result['duplicates']} duplicate, "
+            f"{result['boundaries']} boundary)"
+        )
+        for example in result["examples"]:
+            print(f"{'':16}· {example}")
+        if result["rate"] > NOISE_BUDGET_PERCENT:
+            over_budget.append(f"{result['repo']} at {result['rate']}%")
+
+    if over_budget:
+        print(f"\nover the {NOISE_BUDGET_PERCENT}% noise budget: {', '.join(over_budget)}")
+        return 1
+    print(f"\nevery repository within the {NOISE_BUDGET_PERCENT}% noise budget")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/drift/guard/extract.py
+++ b/src/drift/guard/extract.py
@@ -75,9 +75,19 @@ _TS_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
             re.MULTILINE,
         ),
     ),
+    # Only bindings that hold a function. Python indexes `def` and `class` and
+    # ignores module-level assignments; indexing every TypeScript `const` broke
+    # that symmetry and was the largest single source of noise measured against
+    # real repositories — `config`, `version`, `ignorePattern` and every other
+    # top-level constant collided across unrelated files. An arrow function or
+    # a function expression is a definition in the same sense `def` is.
     (
         "binding",
-        re.compile(r"^(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*[:=]", re.MULTILINE),
+        re.compile(
+            r"^(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::[^=\n]+)?=\s*"
+            r"(?:async\s+)?(?:function\b|\([^)]*\)\s*(?::[^=>\n]+)?=>|[A-Za-z_$][\w$]*\s*=>)",
+            re.MULTILINE,
+        ),
     ),
 )
 

--- a/src/drift/guard/lookup.py
+++ b/src/drift/guard/lookup.py
@@ -17,19 +17,93 @@ class Hit(NamedTuple):
     message: str
 
 
+#: Path segments whose contents repeat names on purpose. Measured against five
+#: real repositories: fastapi's `docs_src/` defines `Item` in over a hundred
+#: tutorial files, date-fns ships the same example under `cjs/`, `cts/`, `esm/`,
+#: and every test suite reuses helper and fixture names. Reporting those as
+#: duplicates is not merely useless, it is the difference between a guard that
+#: speaks on 2 % of edits and one that speaks on half of them.
+_REPEATING_DIRS = frozenset(
+    {
+        "test",
+        "tests",
+        "__tests__",
+        "spec",
+        "specs",
+        "example",
+        "examples",
+        "docs_src",
+        "fixtures",
+        "__fixtures__",
+        "testdata",
+        "benchmarks",
+        "migrations",
+    }
+)
+
+#: A name shorter than this carries no evidence on its own. `add`, `date` and
+#: `argv` all collide across unrelated files in real repositories.
+MIN_DUPLICATE_NAME_LENGTH = 6
+
+#: Above this many other definitions, a repeated name is a convention rather
+#: than an accident, and saying so is worse than saying nothing. date-fns
+#: implements the same `formatLong` and `localize` in 93 locale directories:
+#: the author of the 94th knows. A name that exists once elsewhere is the
+#: signal this guard was built for; a name that exists ninety times is the
+#: shape of the codebase.
+MAX_DUPLICATE_OCCURRENCES = 3
+
+#: Kinds that can meaningfully duplicate each other. A function named `request`
+#: and a class named `Request` are not the same thing, and reporting them as
+#: duplicates was the single most convincing-looking false positive in the
+#: measurement — plausible enough that a reader might believe it.
+_KIND_GROUP = {
+    "function": "callable",
+    "binding": "callable",
+    "class": "type",
+    "type": "type",
+}
+
+
+def repeats_by_design(rel_path: str) -> bool:
+    """True for paths whose whole purpose is to restate the same names.
+
+    Directory *and* filename, because the two conventions coexist: pytest puts
+    `test_x.py` under `tests/`, date-fns puts `test.ts` beside the source it
+    covers, and both reuse helper names across files by design.
+    """
+    parts = rel_path.split("/")
+    if any(part in _REPEATING_DIRS for part in parts):
+        return True
+
+    stem = parts[-1].rsplit(".", 1)[0]
+    return (
+        stem in ("test", "spec")
+        or stem.startswith(("test_", "test-"))
+        or stem.endswith(("_test", "-test", ".test", ".spec", "_spec"))
+    )
+
+
 def find_duplicates(
     conn: sqlite3.Connection, rel_path: str, symbols: list[extract.Symbol]
 ) -> list[Hit]:
     """Symbols that already exist elsewhere in the repository."""
+    if repeats_by_design(rel_path):
+        return []
+
     hits: list[Hit] = []
     for symbol in symbols:
         if symbol.norm_name in extract.STOPWORDS:
             continue
-        row = conn.execute(
-            "SELECT path, name, line FROM symbols"
-            " WHERE norm_name = ? AND path != ? ORDER BY path LIMIT 1",
-            (symbol.norm_name, rel_path),
-        ).fetchone()
+        if len(symbol.norm_name) < MIN_DUPLICATE_NAME_LENGTH:
+            continue
+        # `__getattr__` and friends are language protocol, not names anyone chose.
+        if symbol.name.startswith("__") and symbol.name.endswith("__"):
+            continue
+        group = _KIND_GROUP.get(symbol.kind)
+        if group is None:
+            continue
+        row = _first_real_match(conn, symbol, rel_path, group)
         if row is None:
             continue
         other_path, other_name, other_line = row
@@ -42,6 +116,30 @@ def find_duplicates(
             )
         )
     return hits
+
+
+def _first_real_match(
+    conn: sqlite3.Connection, symbol: extract.Symbol, rel_path: str, group: str
+) -> tuple | None:
+    """The first definition elsewhere that is the same sort of thing.
+
+    Filtering happens in Python rather than SQL because the two conditions —
+    kind group and path shape — do not fit a column each, and the candidate
+    list for one normalised name is short by construction.
+    """
+    rows = conn.execute(
+        "SELECT path, name, line, kind FROM symbols"
+        " WHERE norm_name = ? AND path != ? ORDER BY path",
+        (symbol.norm_name, rel_path),
+    )
+    candidates = [
+        (path, name, line)
+        for path, name, line, kind in rows
+        if _KIND_GROUP.get(kind) == group and not repeats_by_design(path)
+    ]
+    if not candidates or len(candidates) > MAX_DUPLICATE_OCCURRENCES:
+        return None
+    return candidates[0]
 
 
 def find_novel_edges(conn: sqlite3.Connection, rel_path: str, imports: list[str]) -> list[Hit]:

--- a/tests/guard/test_extract_ts.py
+++ b/tests/guard/test_extract_ts.py
@@ -43,7 +43,20 @@ def test_it_finds_top_level_declarations():
     assert "localHelper" in names
     assert "TokenStore" in names
     assert "Session" in names
-    assert "DEFAULT_TTL" in names
+    assert "lazy" in names, "an arrow function is a definition"
+
+
+def test_plain_constants_are_not_definitions():
+    """Python indexes `def` and `class`, not module-level assignments.
+
+    Indexing every TypeScript `const` broke that symmetry and was the largest
+    single source of noise measured against real repositories: `config`,
+    `version` and `ignorePattern` collide across unrelated files and say
+    nothing. A binding counts only when it holds a function.
+    """
+    names = _names(SAMPLE)
+
+    assert "DEFAULT_TTL" not in names
 
 
 def test_it_ignores_class_members():
@@ -89,7 +102,7 @@ def test_a_word_inside_a_string_is_not_a_declaration():
     """Anchoring to column zero and a keyword is what keeps this honest."""
     source = 'const message = "export function notARealFunction() {}";\n'
 
-    assert _names(source) == ["message"]
+    assert _names(source) == []
 
 
 def test_indented_declarations_are_not_top_level():

--- a/tests/guard/test_lookup.py
+++ b/tests/guard/test_lookup.py
@@ -78,3 +78,72 @@ def test_known_targets_lists_existing_edges(sample_repo):
     conn = _conn(sample_repo)
 
     assert lookup.known_targets(conn, "src/api/routes.py") == ["src/services"]
+
+
+def _index(tmp_path, files: dict[str, str]):
+    for rel, source in files.items():
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source, encoding="utf-8")
+    build.build_full(tmp_path)
+    return schema.connect(tmp_path)
+
+
+def _hit_names(conn, rel_path, source, suffix=".py"):
+    symbols, _ = extract.extract(source, suffix)
+    return [h.message for h in lookup.find_duplicates(conn, rel_path, symbols)]
+
+
+def test_a_function_does_not_duplicate_a_class(tmp_path):
+    """`request` and `Request` are different things; saying otherwise looks convincing."""
+    conn = _index(tmp_path, {"src/models.py": "class Requestor:\n    pass\n"})
+
+    assert _hit_names(conn, "src/api.py", "def requestor(url):\n    pass\n") == []
+
+
+def test_a_name_repeated_across_the_codebase_is_a_convention(tmp_path):
+    """date-fns implements `formatLong` in 93 locales. The author of the 94th knows."""
+    files = {
+        f"src/locale/l{i}/format.py": "def format_long(a):\n    pass\n"
+        for i in range(lookup.MAX_DUPLICATE_OCCURRENCES + 2)
+    }
+    conn = _index(tmp_path, files)
+
+    assert _hit_names(conn, "src/locale/new/format.py", "def format_long(a):\n    pass\n") == []
+
+
+def test_a_name_that_exists_once_elsewhere_is_still_reported(tmp_path):
+    """The rare case is the whole point; the cap must not swallow it."""
+    conn = _index(tmp_path, {"src/auth/tokens.py": "def validate_token(a):\n    pass\n"})
+
+    assert _hit_names(conn, "src/api/schemas.py", "def validate_token(a):\n    pass\n")
+
+
+def test_short_names_carry_no_evidence(tmp_path):
+    conn = _index(tmp_path, {"src/a.py": "def add(a, b):\n    return a\n"})
+
+    assert _hit_names(conn, "src/b.py", "def add(a, b):\n    return b\n") == []
+
+
+def test_dunder_names_are_language_protocol(tmp_path):
+    conn = _index(tmp_path, {"src/a.py": "def __getattr__(name):\n    pass\n"})
+
+    assert _hit_names(conn, "src/b.py", "def __getattr__(name):\n    pass\n") == []
+
+
+def test_directories_that_repeat_by_design_are_neither_source_nor_target(tmp_path):
+    conn = _index(tmp_path, {"examples/one.py": "def build_widget(a):\n    pass\n"})
+
+    assert _hit_names(conn, "src/real.py", "def build_widget(a):\n    pass\n") == []
+    assert _hit_names(conn, "tests/thing.py", "def build_widget(a):\n    pass\n") == []
+
+
+def test_test_files_are_detected_by_name_as_well_as_directory():
+    """pytest puts `test_x.py` under tests/; date-fns puts `test.ts` beside the source."""
+    assert lookup.repeats_by_design("src/foo/test.ts")
+    assert lookup.repeats_by_design("src/foo/thing.test.ts")
+    assert lookup.repeats_by_design("src/foo/thing.spec.ts")
+    assert lookup.repeats_by_design("pkg/test_thing.py")
+    assert lookup.repeats_by_design("pkg/thing_test.go")
+    assert not lookup.repeats_by_design("src/foo/latest.ts")
+    assert not lookup.repeats_by_design("src/contest/thing.py")


### PR DESCRIPTION
The README promised **"silence is the normal case"**. Measured against five real repositories for the first time, the guard would have spoken on **27–69 %** of their files.

| Repository | Before | After |
|---|---|---|
| requests | 10.8 % | **0.0 %** |
| fastapi | 68.8 % | **1.0 %** |
| date-fns | 44.1 % | **2.0 %** |
| flask | 26.5 % | **4.8 %** |
| axios | 44.8 % | **5.6 %** |

## Why no test caught it

The fixture is six files written to demonstrate the two signals. Against it, recall is 100 % and false positives are zero — gate G3 has been green the whole time. Precision only exists relative to a corpus, and there was no corpus.

What it actually reported: `config`, `argv`, `add`, `date`. fastapi's `docs_src/` defines `Item` in over a hundred tutorial files on purpose. date-fns implements the same `formatLong` in 93 locale directories. And a function named `request` was reported as a duplicate of a class named `Request` — the most convincing-looking of the false positives, plausible enough that a reader might have believed it.

## Five defects the measurement exposed

1. **Kinds were never compared.** A function is not a duplicate of a class.
2. **A repeated name is a convention, not an accident.** Above three other definitions the guard says nothing. The author of date-fns' 94th locale knows that `formatLong` exists.
3. **Short names and dunders carry no evidence.** `add`, `date`, `argv`, `__getattr__`.
4. **Test, example, fixture and tutorial paths restate names by design.** Detected by directory *and* filename — pytest writes `tests/test_x.py`, date-fns writes `test.ts` beside the source it covers.
5. **A TypeScript `const` counted as a definition even when it held a plain value.** Python never indexed module-level assignments; that asymmetry was the largest single source of noise. A binding now counts only when it holds a function.

## What survives is worth reading

```
src/flask/app.py: `_make_timedelta` already exists in src/flask/sansio/app.py:52
src/flask/blueprints.py: `Blueprint` already exists in src/flask/sansio/blueprints.py:119
lib/adapters/fetch.js: `encodeUTF8` already exists in lib/helpers/resolveConfig.js:20
```

All three are real.

## Reproducible from now on

```bash
git clone --depth 1 https://github.com/pallets/flask /tmp/corpus/flask
python scripts/gates/measure_noise.py /tmp/corpus
```

Exits non-zero above a 10 % budget, so the next person changing these rules finds out what it costs. Seven unit tests pin each rule individually — including `test_a_name_that_exists_once_elsewhere_is_still_reported`, because the occurrence cap must not swallow the rare case the guard exists for.

Two existing tests changed. Both encoded the old behaviour (`DEFAULT_TTL` treated as a definition), and both now state the new rule with the reason.

## Verification

109 guard tests, all nine gates, `ruff` and `mypy` clean on `src/` and `tests/`, markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)