### PR TITLE
fix(guard): the boundary signal was blind to relative imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Short version: Drift installs as a Claude Code plugin and works inside the agent
 - keep the index out of the repositories it analyses
 - let merges to main reach users who already installed
 - stop the guard speaking on half of every real repository
+- the boundary signal was blind to relative imports
 
 ## [2.51.1] - 2026-05-04
 

--- a/scripts/gates/measure_noise.py
+++ b/scripts/gates/measure_noise.py
@@ -34,6 +34,50 @@ from drift.guard import build, extract, lookup, schema  # noqa: E402
 NOISE_BUDGET_PERCENT = 10.0
 
 
+def measure_boundary_reach(repo: pathlib.Path, conn) -> dict:
+    """How much of the repository the boundary signal can even see.
+
+    Replaying an existing file can never produce a boundary hit — its edges are
+    already indexed — so the noise pass reports zero for this signal by
+    construction. That zero once hid a real defect: relative imports were
+    dropped entirely, and Flask appeared to have no cross-directory imports at
+    all, 0 of 83 files. This asks the question the other pass cannot: how many
+    files import across a directory, and for how many is that crossing theirs
+    alone, so that writing the file fresh would announce it?
+    """
+    import collections
+
+    files = [row[0] for row in conn.execute("SELECT path FROM files ORDER BY path")]
+    known_dirs = {build.dir_of(f) for f in files}
+    edge_owners: dict[tuple[str, str], set[str]] = collections.defaultdict(set)
+    per_file: dict[str, set[tuple[str, str]]] = {}
+
+    for rel in files:
+        try:
+            source = (repo / rel).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        _, imports = extract.extract(source, pathlib.PurePosixPath(rel).suffix)
+        src_dir = build.dir_of(rel)
+        edges = set()
+        for specifier in imports:
+            destination = build.import_to_dir(specifier, src_dir, known_dirs)
+            if destination and destination != src_dir:
+                edges.add((src_dir, destination))
+        per_file[rel] = edges
+        for edge in edges:
+            edge_owners[edge].add(rel)
+
+    crossing = [f for f, edges in per_file.items() if edges]
+    sole = [f for f, edges in per_file.items() if any(edge_owners[e] == {f} for e in edges)]
+    return {
+        "crossing": len(crossing),
+        "edges": len(edge_owners),
+        "sole": len(sole),
+        "sole_rate": round(100.0 * len(sole) / max(1, len(files)), 1),
+    }
+
+
 def measure(repo: pathlib.Path) -> dict:
     started = time.perf_counter()
     stats = build.build_full(repo)
@@ -66,9 +110,11 @@ def measure(repo: pathlib.Path) -> dict:
         if len(examples) < 3:
             examples.append(f"{rel}: {hits[0].message}")
 
+    reach = measure_boundary_reach(repo, conn)
     conn.close()
     return {
         "repo": repo.name,
+        "reach": reach,
         "files": len(files),
         "symbols": stats["symbols"],
         "build_seconds": round(build_seconds, 2),
@@ -99,6 +145,14 @@ def main() -> int:
             f"= {result['rate']}%  ({result['duplicates']} duplicate, "
             f"{result['boundaries']} boundary)"
         )
+        reach = result.get("reach")
+        if reach:
+            print(
+                f"{'':14} boundary reach: {reach['crossing']} files import across a "
+                f"directory over {reach['edges']} distinct edges; writing "
+                f"{reach['sole']} of them fresh ({reach['sole_rate']}%) would "
+                f"announce a first-ever crossing"
+            )
         for example in result["examples"]:
             print(f"{'':16}· {example}")
         if result["rate"] > NOISE_BUDGET_PERCENT:

--- a/src/drift/guard/extract.py
+++ b/src/drift/guard/extract.py
@@ -218,8 +218,26 @@ def extract_python(source: str) -> tuple[list[Symbol], list[str]]:
     for imported in ast.walk(tree):
         if isinstance(imported, ast.Import):
             imports.extend(alias.name for alias in imported.names)
-        elif isinstance(imported, ast.ImportFrom) and imported.module and imported.level == 0:
-            imports.append(imported.module)
-            imports.extend(f"{imported.module}.{alias.name}" for alias in imported.names)
+        elif isinstance(imported, ast.ImportFrom):
+            if imported.level == 0:
+                if imported.module:
+                    imports.append(imported.module)
+                    imports.extend(f"{imported.module}.{alias.name}" for alias in imported.names)
+            else:
+                imports.append(_relative_specifier(imported.level, imported.module))
 
     return (symbols, imports)
+
+
+def _relative_specifier(level: int, module: str | None) -> str:
+    """Turn `from ..db.client import x` into `../db/client`.
+
+    Relative imports were dropped entirely, which left the boundary signal
+    blind to the dominant way Python packages import from themselves: measured
+    on Flask, 0 of 83 files appeared to import across a directory. Emitting the
+    path form lets one resolver serve both languages, since `../db/client`
+    means the same thing in either.
+    """
+    prefix = "./" if level == 1 else "../" * (level - 1)
+    tail = module.replace(".", "/") if module else ""
+    return f"{prefix}{tail}" if tail else prefix

--- a/src/drift/guard/lookup.py
+++ b/src/drift/guard/lookup.py
@@ -144,6 +144,12 @@ def _first_real_match(
 
 def find_novel_edges(conn: sqlite3.Connection, rel_path: str, imports: list[str]) -> list[Hit]:
     """Imports that introduce a directory-to-directory edge seen nowhere yet."""
+    # A tutorial reaching into the library it teaches is not an architectural
+    # event. Measured on fastapi, `docs_src/` supplied most of what this signal
+    # would have announced.
+    if repeats_by_design(rel_path):
+        return []
+
     known_dirs = {build.dir_of(row[0]) for row in conn.execute("SELECT path FROM files")}
     src_dir = build.dir_of(rel_path)
     existing = {

--- a/tests/guard/test_extract.py
+++ b/tests/guard/test_extract.py
@@ -59,3 +59,32 @@ def test_common_names_are_stopwords():
     assert "main" in extract.STOPWORDS
     assert "run" in extract.STOPWORDS
     assert "validatetoken" not in extract.STOPWORDS
+
+
+def test_relative_imports_are_not_dropped():
+    """`from .sansio.app import App` is how a Python package imports itself.
+
+    Dropping relative imports left the boundary signal blind to the dominant
+    intra-package style: measured on Flask, 0 of 83 files appeared to import
+    across a directory at all.
+    """
+    _, imports = extract.extract("from .sansio.app import App\n")
+
+    assert "./sansio/app" in imports
+
+
+def test_relative_import_levels_become_path_prefixes():
+    _, one = extract.extract("from .db import client\n")
+    _, two = extract.extract("from ..shared.util import helper\n")
+    _, bare = extract.extract("from . import sibling\n")
+
+    assert "./db" in one
+    assert "../shared/util" in two
+    assert "./" in bare
+
+
+def test_absolute_imports_still_look_like_modules():
+    _, imports = extract.extract("from drift.guard import lookup\nimport os.path\n")
+
+    assert "drift.guard" in imports
+    assert "os.path" in imports

--- a/tests/guard/test_lookup.py
+++ b/tests/guard/test_lookup.py
@@ -147,3 +147,29 @@ def test_test_files_are_detected_by_name_as_well_as_directory():
     assert lookup.repeats_by_design("pkg/thing_test.go")
     assert not lookup.repeats_by_design("src/foo/latest.ts")
     assert not lookup.repeats_by_design("src/contest/thing.py")
+
+
+def test_a_relative_import_crossing_a_directory_is_reported(tmp_path):
+    """Flask's `from .sansio.app import App` shape, end to end."""
+    conn = _index(
+        tmp_path,
+        {
+            "src/pkg/app.py": "x = 1\n",
+            "src/pkg/sansio/app.py": "def make_app(a):\n    pass\n",
+        },
+    )
+
+    hits = lookup.find_novel_edges(conn, "src/pkg/app.py", ["./sansio/app"])
+
+    assert hits, "a relative import across a directory must be visible"
+    assert "src/pkg" in hits[0].message and "src/pkg/sansio" in hits[0].message
+
+
+def test_tutorial_paths_do_not_announce_boundaries(tmp_path):
+    """A tutorial reaching into the library it teaches is not an architectural event."""
+    conn = _index(
+        tmp_path,
+        {"src/lib/core.py": "def run_engine(a):\n    pass\n", "src/other.py": "y = 2\n"},
+    )
+
+    assert lookup.find_novel_edges(conn, "docs_src/tutorial001.py", ["src.lib"]) == []


### PR DESCRIPTION
All five repositories in #782's noise measurement reported **zero boundary hits**. I read that as "no false positives" and moved on.

It was the method. Replaying an existing file cannot produce a boundary hit — its edges are already in the index. The zero was an artefact of how the measurement worked, and it hid a defect.

## What the zero was hiding

Asking the question the noise pass cannot — *how many files import across a directory at all* — gave the answer:

```
flask     83 files ·  0 import across dirs ·  0 distinct edges
requests  37 files ·  2 import across dirs ·  1 distinct edges
```

Flask plainly imports across its own directories. `src/flask/app.py` does it on the first screen.

`extract_python` matched `ImportFrom` only at `level == 0`:

```python
elif isinstance(imported, ast.ImportFrom) and imported.module and imported.level == 0:
```

Every relative import was dropped. `from .sansio.app import App` is how a Python package imports itself — so for most Python packages, **half of this product did nothing at all**, and nothing in the test suite or the gates said so.

## The fix

Relative imports become path specifiers: `from ..db.client import x` → `../db/client`. One resolver then serves both languages, because that string already means the same thing on the TypeScript side.

| | before | after |
|---|---|---|
| flask, files crossing a directory | 0 | **13** (6 distinct edges) |
| requests | 2 | **3** |
| fastapi | 859 | **866** |

## Second fix from the same measurement

Tutorial and example paths no longer announce boundaries. fastapi's `docs_src/` supplied most of what this signal would have said, and a tutorial importing the library it teaches is not an architectural event. Duplicates already ignored those paths (#782); boundaries now do too.

## Method change

The boundary measurement joins `measure_noise.py` instead of living beside it. The lesson is that the two questions have to be asked together — one of them structurally cannot see what the other measures, and I only found this because the zero looked too clean.

```
flask   speaks on 4/83 files = 4.8%  (4 duplicate, 0 boundary)
        boundary reach: 13 files import across a directory over 6 distinct edges;
        writing 3 of them fresh (3.6%) would announce a first-ever crossing
```

## Verification

114 guard tests (5 new: three on relative-import levels, one end-to-end on Flask's shape, one on tutorial paths), all nine gates, noise still within budget, `ruff` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)