### PR TITLE
fix(guard): the pre-edit briefing spoke on almost every new file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Short version: Drift installs as a Claude Code plugin and works inside the agent
 - let merges to main reach users who already installed
 - stop the guard speaking on half of every real repository
 - the boundary signal was blind to relative imports
+- the pre-edit briefing spoke on almost every new file
 
 ## [2.51.1] - 2026-05-04
 

--- a/src/drift/guard/lookup.py
+++ b/src/drift/guard/lookup.py
@@ -178,18 +178,45 @@ def find_novel_edges(conn: sqlite3.Connection, rel_path: str, imports: list[str]
 
 
 def neighbourhood(conn: sqlite3.Connection, rel_path: str, limit: int = 8) -> list[str]:
-    """Symbol names that already live in the same directory."""
+    """Everything already defined in this directory, or nothing at all.
+
+    Two rules, both learned from measuring this on real repositories, where the
+    briefing fired on 201 of fastapi's 203 directories and offered lists like
+    `Termynal, handleSponsorImages, main, openLinksInNewTab, shuffle`.
+
+    The names are filtered exactly as duplicate candidates are: a directory
+    containing `main` and `setup` tells an agent nothing it can act on.
+
+    And the list is returned only when it is *complete*. An alphabetical slice
+    of a fifty-symbol directory, printed as "already defined in src/api/",
+    reads as the contents of that directory and is not — the first eight names
+    alphabetically are the ones least likely to be the relevant ones. A partial
+    answer that looks whole is worse than silence.
+    """
+    if repeats_by_design(rel_path):
+        return []
+
     src_dir = build.dir_of(rel_path)
     like = "%" if src_dir == "." else f"{src_dir}/%"
     rows = conn.execute(
-        "SELECT DISTINCT name FROM symbols WHERE path LIKE ? AND path != ? ORDER BY name LIMIT ?",
-        (like, rel_path, limit),
+        "SELECT DISTINCT name FROM symbols WHERE path LIKE ? AND path != ? ORDER BY name",
+        (like, rel_path),
     )
-    return [row[0] for row in rows]
+    names = [
+        name
+        for (name,) in rows
+        if extract.normalize(name) not in extract.STOPWORDS
+        and len(extract.normalize(name)) >= MIN_DUPLICATE_NAME_LENGTH
+        and not (name.startswith("__") and name.endswith("__"))
+    ]
+    return names if 0 < len(names) <= limit else []
 
 
 def known_targets(conn: sqlite3.Connection, rel_path: str) -> list[str]:
     """Directories this file's directory already imports from."""
+    if repeats_by_design(rel_path):
+        return []
+
     src_dir = build.dir_of(rel_path)
     rows = conn.execute(
         "SELECT dst_dir FROM import_edges WHERE src_dir = ? ORDER BY dst_dir", (src_dir,)

--- a/tests/guard/test_lookup.py
+++ b/tests/guard/test_lookup.py
@@ -173,3 +173,44 @@ def test_tutorial_paths_do_not_announce_boundaries(tmp_path):
     )
 
     assert lookup.find_novel_edges(conn, "docs_src/tutorial001.py", ["src.lib"]) == []
+
+
+def test_the_briefing_lists_everything_or_nothing(tmp_path):
+    """An alphabetical slice printed as "already defined in src/api/" reads as
+    the contents of that directory and is not."""
+    many = {f"src/api/mod{i}.py": f"def distinct_helper_{i}(a):\n    pass\n" for i in range(12)}
+    conn = _index(tmp_path, many)
+
+    assert lookup.neighbourhood(conn, "src/api/new.py", limit=8) == []
+
+
+def test_the_briefing_speaks_when_the_list_is_complete(tmp_path):
+    conn = _index(
+        tmp_path,
+        {
+            "src/api/one.py": "def render_invoice(a):\n    pass\n",
+            "src/api/two.py": "def collect_totals(a):\n    pass\n",
+        },
+    )
+
+    assert lookup.neighbourhood(conn, "src/api/new.py", limit=8) == [
+        "collect_totals",
+        "render_invoice",
+    ]
+
+
+def test_the_briefing_drops_names_that_carry_no_evidence(tmp_path):
+    """A directory containing `main` and `setup` tells an agent nothing."""
+    conn = _index(
+        tmp_path,
+        {"src/api/one.py": "def main():\n    pass\n\n\ndef setup():\n    pass\n"},
+    )
+
+    assert lookup.neighbourhood(conn, "src/api/new.py") == []
+
+
+def test_the_briefing_stays_quiet_in_directories_that_repeat_by_design(tmp_path):
+    conn = _index(tmp_path, {"examples/one.py": "def render_invoice(a):\n    pass\n"})
+
+    assert lookup.neighbourhood(conn, "examples/new.py") == []
+    assert lookup.known_targets(conn, "examples/new.py") == []


### PR DESCRIPTION
Two of the guard's three surfaces had been measured against real repositories (#782, #783). The third had not.

It fired on **18 of Flask's 21 directories** and **201 of fastapi's 203** — for a signal whose stated design was to be "rare enough to be worth a sentence".

## What it offered

```
already defined in docs/en/docs/js/: Termynal, handleSponsorImages, main,
openLinksInNewTab, setupOpinionsTabs, setupTermynal, showRandomAnnouncement, shuffle
```

Two separate problems in one line.

**The names were never filtered.** `main`, `setup`, `add`, `index` are excluded from duplicate matching precisely because they carry no evidence. The briefing offered them anyway, from its own unfiltered query.

**The list was an alphabetical slice.** `LIMIT 8`, printed as "already defined in `src/api/`". That reads as *the contents of that directory* and is not — and the first eight names alphabetically are the ones least likely to be the relevant ones. A partial answer that looks whole is worse than silence.

## The fix

- Same name filters as duplicate candidates: stopwords, minimum length, dunders.
- **Everything or nothing.** If the filtered list does not fit the limit, the briefing says nothing rather than a misleading sample.
- Tutorial, test and example directories go quiet here too, as they already had for the other two signals.

## After

| | before | after |
|---|---|---|
| flask | 18/21 directories | **4/21** |
| fastapi | 201/203 directories | **7/203** |

And what survives is worth reading:

```
src/flask/sansio/  defined: Blueprint, BlueprintSetupState, Scaffold,
                            _endpoint_from_view_func, _find_package_path,
                            _make_timedelta, find_package, setupmethod
fastapi/           imports from: fastapi/_compat, fastapi/dependencies,
                                 fastapi/middleware, fastapi/openapi
```

The first is the complete set of symbols in that directory. The second is the complete set of directories it imports from. Both are true statements an agent can act on.

## The pattern

Three of three surfaces held up against a six-file fixture and failed against real code — silent (#773), 27–69 % noise (#782), blind to relative imports (#783), and now speaking on 99 % of directories. The fixture cannot answer this class of question; only a corpus can.

## Verification

118 guard tests (4 new), all nine gates, noise measurement still within budget, `ruff` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)