### PR TITLE
feat(guard): guard Rust, and stop conflating packages in a workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Short version: Drift installs as a Claude Code plugin and works inside the agent
 - guard TypeScript and JavaScript, not only Python
 - notice when the index describes a tree that has moved
 - guard Go
+- guard Rust, and stop conflating packages in a workspace
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ plugin that fires in every project you open has no business leaving a directory
 in each of them. A project that wants the index alongside its source opts in by
 creating a `.drift/` directory.
 
-**Python, TypeScript, JavaScript and Go** (`.py .ts .tsx .js .jsx .mjs .cjs .go`),
+**Python, TypeScript, JavaScript, Go and Rust** (`.py .ts .tsx .js .jsx .mjs
+.cjs .go .rs`),
 in one index — a name defined in Python is found from TypeScript, because
 `validate_token`, `validateToken` and `ValidateToken` all normalise to the same
 thing. Other languages pass through untouched.

--- a/docs-site/claude-code-plugin.md
+++ b/docs-site/claude-code-plugin.md
@@ -17,8 +17,8 @@ business leaving a directory in each of them. A project that wants the index
 alongside its source opts in by creating a `.drift/` directory; `DRIFT_CACHE_HOME`
 overrides both.
 
-!!! note "Python, TypeScript, JavaScript and Go"
-    `.py .ts .tsx .js .jsx .mjs .cjs .go`, all in one index — a name defined in
+!!! note "Python, TypeScript, JavaScript, Go and Rust"
+    `.py .ts .tsx .js .jsx .mjs .cjs .go .rs`, all in one index — a name defined in
     Python is found from Go, because `validate_token`, `validateToken` and
     `ValidateToken` all normalise to the same thing. Python is parsed with `ast`;
     the others are matched against top-level declarations,

--- a/src/drift/guard/__main__.py
+++ b/src/drift/guard/__main__.py
@@ -163,8 +163,10 @@ def _cmd_session_start(args) -> int:
     stale = False
     conn = schema.connect(repo_root)
     if conn is not None:
-        if schema.is_usable(conn):
-            stale = build.is_stale(repo_root, conn)
+        # An index written by an older schema is unusable, and nothing else
+        # would ever replace it: the file exists, so the missing-index path
+        # never runs. Treating it as stale is what makes an upgrade recover.
+        stale = build.is_stale(repo_root, conn) if schema.is_usable(conn) else True
         conn.close()
     if stale:
         _spawn_background_build(repo_root)

--- a/src/drift/guard/build.py
+++ b/src/drift/guard/build.py
@@ -72,20 +72,35 @@ def relative_to_dir(specifier: str, src_dir: str, known_dirs: set[str]) -> str |
 
 
 def suffix_to_dir(specifier: str, known_dirs: set[str]) -> str | None:
-    """Match the trailing segments of a full module path onto a directory.
+    """Match a module path onto a directory from its trailing segments.
 
-    Go imports carry the whole module path — `github.com/org/repo/internal/db`
-    — and the repository knows itself as `internal/db`. Dropping leading
-    segments until something matches finds it without reading `go.mod`.
+    Two shapes, one rule. Go carries the whole module path and the repository
+    holds the tail verbatim: `github.com/org/repo/internal/db` against
+    `internal/db`. Rust drops the head instead — `crate::db::client` says
+    nothing about `src/`, because `crate` *is* `src/` — so the repository holds
+    the tail of the *specifier* rather than the other way round.
 
-    This is reserved for Go. Applying it to TypeScript would resolve
+    Longest slice first, and a slice matching more than one directory is
+    discarded rather than guessed: two directories ending in `db` make the
+    answer ambiguous, and an ambiguous boundary claim is the confident-wrong
+    kind this guard keeps having to remove.
+
+    Reserved for Go and Rust. Applying it to TypeScript would resolve
     `lodash/fp` onto a directory named `fp`, and date-fns has one.
     """
-    parts = specifier.split("/")
-    for start in range(len(parts)):
-        candidate = "/".join(parts[start:])
-        if candidate in known_dirs:
-            return candidate
+    parts = [p for p in specifier.split("/") if p]
+    # The last segment may be a module inside the directory rather than the
+    # directory itself, exactly as in `relative_to_dir`.
+    for candidate_parts in (parts, parts[:-1]):
+        for start in range(len(candidate_parts)):
+            slice_ = "/".join(candidate_parts[start:])
+            if not slice_:
+                continue
+            if slice_ in known_dirs:
+                return slice_
+            matches = [d for d in known_dirs if d.endswith(f"/{slice_}")]
+            if len(matches) == 1:
+                return matches[0]
     return None
 
 
@@ -99,7 +114,7 @@ def import_to_dir(
     """
     if specifier.startswith("."):
         return relative_to_dir(specifier, src_dir, known_dirs)
-    if suffix in extract.GO_SUFFIXES:
+    if suffix in extract.GO_SUFFIXES or suffix in extract.RUST_SUFFIXES:
         return suffix_to_dir(specifier, known_dirs)
     if "/" in specifier:
         return None
@@ -120,6 +135,39 @@ def _iter_source_files(repo_root: pathlib.Path):
 
 def _sha256(path: pathlib.Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+#: A directory holding one of these is the root of its own package. Observed
+#: rather than configured, like everything else the index records.
+PACKAGE_MARKERS = ("Cargo.toml", "package.json", "go.mod", "pyproject.toml", "setup.py")
+
+
+def package_root_of(repo_root: pathlib.Path, rel_path: str, cache: dict[str, str]) -> str:
+    """The package a file belongs to, as a repo-relative directory.
+
+    ripgrep is a Cargo workspace: `crates/cli` and `crates/globset` are separate
+    published crates, and a function named `escape` in each is not duplication —
+    it is two libraries with their own namespaces. Measured, that single
+    conflation put ripgrep at 23.6 % while every other repository sat under 6 %.
+
+    Node monorepos, Go modules and Python source trees split the same way, so
+    the marker files are the language-agnostic version of the same question.
+    """
+    directory = dir_of(rel_path)
+    if directory in cache:
+        return cache[directory]
+
+    parts = [] if directory == "." else directory.split("/")
+    found = "."
+    for depth in range(len(parts), -1, -1):
+        candidate = "/".join(parts[:depth]) if depth else "."
+        base = repo_root if candidate == "." else repo_root / candidate
+        if any((base / marker).exists() for marker in PACKAGE_MARKERS):
+            found = candidate
+            break
+
+    cache[directory] = found
+    return found
 
 
 #: How many indexed files to check, and how much of that sample has to have
@@ -177,6 +225,7 @@ def build_full(repo_root: pathlib.Path) -> dict:
     collected = list(_iter_source_files(repo_root))
     known_dirs = {dir_of(rel) for rel, _ in collected}
 
+    package_cache: dict[str, str] = {}
     edge_counts: dict[tuple[str, str], int] = {}
     symbol_rows: list[tuple] = []
     file_rows: list[tuple] = []
@@ -190,7 +239,7 @@ def build_full(repo_root: pathlib.Path) -> dict:
         symbols, imports = extract.extract(source, path.suffix)
         src_dir = dir_of(rel)
 
-        file_rows.append((rel, _sha256(path), now))
+        file_rows.append((rel, _sha256(path), now, package_root_of(repo_root, rel, package_cache)))
         symbol_rows.extend((rel, s.name, s.norm_name, s.kind, s.sig_hash, s.line) for s in symbols)
         for module in imports:
             dst_dir = import_to_dir(module, src_dir, known_dirs, path.suffix)
@@ -198,7 +247,10 @@ def build_full(repo_root: pathlib.Path) -> dict:
                 continue
             edge_counts[(src_dir, dst_dir)] = edge_counts.get((src_dir, dst_dir), 0) + 1
 
-    conn.executemany("INSERT INTO files (path, sha256, indexed_at) VALUES (?, ?, ?)", file_rows)
+    conn.executemany(
+        "INSERT INTO files (path, sha256, indexed_at, package_root) VALUES (?, ?, ?, ?)",
+        file_rows,
+    )
     conn.executemany(
         "INSERT INTO symbols (path, name, norm_name, kind, sig_hash, line)"
         " VALUES (?, ?, ?, ?, ?, ?)",
@@ -245,8 +297,8 @@ def update_file(repo_root: pathlib.Path, rel_path: str) -> None:
             [(rel_path, s.name, s.norm_name, s.kind, s.sig_hash, s.line) for s in symbols],
         )
         conn.execute(
-            "INSERT INTO files (path, sha256, indexed_at) VALUES (?, ?, ?)",
-            (rel_path, _sha256(path), time.time()),
+            "INSERT INTO files (path, sha256, indexed_at, package_root) VALUES (?, ?, ?, ?)",
+            (rel_path, _sha256(path), time.time(), package_root_of(repo_root, rel_path, {})),
         )
         known_dirs = {row[0] for row in conn.execute("SELECT DISTINCT src_dir FROM import_edges")}
         known_dirs |= {dir_of(row[0]) for row in conn.execute("SELECT path FROM files")}

--- a/src/drift/guard/extract.py
+++ b/src/drift/guard/extract.py
@@ -25,7 +25,8 @@ from typing import NamedTuple
 PYTHON_SUFFIXES = frozenset({".py"})
 TS_JS_SUFFIXES = frozenset({".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"})
 GO_SUFFIXES = frozenset({".go"})
-GUARDED_SUFFIXES = PYTHON_SUFFIXES | TS_JS_SUFFIXES | GO_SUFFIXES
+RUST_SUFFIXES = frozenset({".rs"})
+GUARDED_SUFFIXES = PYTHON_SUFFIXES | TS_JS_SUFFIXES | GO_SUFFIXES | RUST_SUFFIXES
 
 #: Normalized names too common to ever be a meaningful duplicate.
 STOPWORDS = frozenset(
@@ -51,6 +52,12 @@ STOPWORDS = frozenset(
         # and two files both exporting `default` says nothing about duplication.
         "index",
         "default",
+        # Measured in two unrelated languages before being added here: `config`
+        # was the loudest false positive in axios and again in ripgrep, where
+        # nearly every Rust module keeps its own private `Config`. `options`
+        # follows the same idiom.
+        "config",
+        "options",
     }
 )
 
@@ -133,6 +140,33 @@ _GO_IMPORTS: tuple[re.Pattern[str], ...] = (
 _GO_IMPORT_LINE = re.compile(r'^\s*(?:[A-Za-z_.]\w*\s+)?"([^"]+)"', re.MULTILINE)
 
 
+#: Rust declarations. Methods live inside `impl` blocks and are indented, so
+#: the column-zero anchor excludes them the way it does in Go — `new`, `fmt`
+#: and `from` are on half the types in any crate.
+_RUST_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "function",
+        re.compile(
+            r"^(?:pub(?:\([^)]*\))?\s+)?(?:const\s+|async\s+|unsafe\s+|extern\s+\"[^\"]*\"\s+)*"
+            r"fn\s+([A-Za-z_][\w]*)",
+            re.MULTILINE,
+        ),
+    ),
+    (
+        "type",
+        re.compile(
+            r"^(?:pub(?:\([^)]*\))?\s+)?(?:struct|enum|trait|union|type)\s+([A-Za-z_][\w]*)",
+            re.MULTILINE,
+        ),
+    ),
+)
+
+#: `use` paths, including the braced form. `mod x;` is deliberately absent: it
+#: declares a child module in the same directory rather than reaching into
+#: another one, so it is not a boundary crossing.
+_RUST_USE = re.compile(r"^\s*(?:pub\s+)?use\s+([^;]+);", re.MULTILINE)
+
+
 class Symbol(NamedTuple):
     name: str
     norm_name: str
@@ -172,7 +206,68 @@ def extract(source: str, suffix: str = ".py") -> tuple[list[Symbol], list[str]]:
         return extract_python(source)
     if suffix in GO_SUFFIXES:
         return extract_go(source)
+    if suffix in RUST_SUFFIXES:
+        return extract_rust(source)
     return ([], [])
+
+
+def extract_rust(source: str) -> tuple[list[Symbol], list[str]]:
+    """Rust, matched rather than parsed, on the same terms as Go.
+
+    `use` paths become the specifiers the resolver already understands:
+    `crate::db::client` is emitted as `db/client` for trailing-segment
+    matching, while `super::` and `self::` become the relative forms that
+    Python and TypeScript already produce.
+    """
+    symbols: list[Symbol] = []
+    seen: set[str] = set()
+
+    for kind, pattern in _RUST_PATTERNS:
+        for match in pattern.finditer(source):
+            name = match.group(1)
+            if name in seen:
+                continue
+            seen.add(name)
+            symbols.append(
+                Symbol(
+                    name=name,
+                    norm_name=normalize(name),
+                    kind=kind,
+                    sig_hash=signature_hash(kind, []),
+                    line=source.count("\n", 0, match.start()) + 1,
+                )
+            )
+
+    imports: list[str] = []
+    for match in _RUST_USE.finditer(source):
+        imports.extend(_rust_use_targets(match.group(1)))
+
+    symbols.sort(key=lambda s: s.line)
+    return (symbols, imports)
+
+
+def _rust_use_targets(clause: str) -> list[str]:
+    """Turn one `use` clause into specifiers the resolver understands.
+
+    A braced clause names several children of one prefix — `use crate::db::{a,
+    b}` — and the prefix is the part that identifies a directory, so the braces
+    are dropped rather than expanded.
+    """
+    head = clause.split("{", 1)[0].strip().rstrip(":")
+    parts = [p for p in head.split("::") if p]
+    if not parts:
+        return []
+
+    root = parts[0]
+    rest = parts[1:]
+    if root == "crate":
+        return ["/".join(rest)] if rest else []
+    if root == "super":
+        return [f"../{'/'.join(rest)}"] if rest else ["../"]
+    if root == "self":
+        return [f"./{'/'.join(rest)}"] if rest else ["./"]
+    # An external crate, or a re-export of one. Not a place in this repository.
+    return []
 
 
 def extract_go(source: str) -> tuple[list[Symbol], list[str]]:

--- a/src/drift/guard/lookup.py
+++ b/src/drift/guard/lookup.py
@@ -128,19 +128,44 @@ def _first_real_match(
     kind group and path shape — do not fit a column each, and the candidate
     list for one normalised name is short by construction.
     """
+    own_package = _package_of(conn, rel_path)
     rows = conn.execute(
-        "SELECT path, name, line, kind FROM symbols"
-        " WHERE norm_name = ? AND path != ? ORDER BY path",
+        "SELECT s.path, s.name, s.line, s.kind, COALESCE(f.package_root, '.')"
+        " FROM symbols s LEFT JOIN files f ON f.path = s.path"
+        " WHERE s.norm_name = ? AND s.path != ? ORDER BY s.path",
         (symbol.norm_name, rel_path),
     )
     candidates = [
         (path, name, line)
-        for path, name, line, kind in rows
-        if _KIND_GROUP.get(kind) == group and not repeats_by_design(path)
+        for path, name, line, kind, package in rows
+        if _KIND_GROUP.get(kind) == group
+        and not repeats_by_design(path)
+        # Two packages in a workspace have their own namespaces. ripgrep's
+        # `crates/cli` and `crates/globset` both define `escape`, and neither
+        # author would call that duplication.
+        and package == own_package
     ]
     if not candidates or len(candidates) > MAX_DUPLICATE_OCCURRENCES:
         return None
     return candidates[0]
+
+
+def _package_of(conn: sqlite3.Connection, rel_path: str) -> str:
+    """The package an edited file belongs to.
+
+    The file may be brand new and absent from the index, so the answer falls
+    back to any indexed file sharing its directory.
+    """
+    row = conn.execute("SELECT package_root FROM files WHERE path = ?", (rel_path,)).fetchone()
+    if row is not None:
+        return str(row[0])
+
+    directory = build.dir_of(rel_path)
+    like = "%" if directory == "." else f"{directory}/%"
+    row = conn.execute(
+        "SELECT package_root FROM files WHERE path LIKE ? LIMIT 1", (like,)
+    ).fetchone()
+    return str(row[0]) if row is not None else "."
 
 
 def find_novel_edges(conn: sqlite3.Connection, rel_path: str, imports: list[str]) -> list[Hit]:

--- a/src/drift/guard/schema.py
+++ b/src/drift/guard/schema.py
@@ -7,7 +7,9 @@ import os
 import pathlib
 import sqlite3
 
-SCHEMA_VERSION = 1
+#: 2 added `files.package_root`. A symbol in one package of a workspace does
+#: not duplicate a symbol in another, and the guard could not tell before.
+SCHEMA_VERSION = 2
 
 _TABLES = """
 CREATE TABLE IF NOT EXISTS meta (
@@ -15,9 +17,10 @@ CREATE TABLE IF NOT EXISTS meta (
     value TEXT NOT NULL
 );
 CREATE TABLE IF NOT EXISTS files (
-    path       TEXT PRIMARY KEY,
-    sha256     TEXT NOT NULL,
-    indexed_at REAL NOT NULL
+    path         TEXT PRIMARY KEY,
+    sha256       TEXT NOT NULL,
+    indexed_at   REAL NOT NULL,
+    package_root TEXT NOT NULL DEFAULT '.'
 );
 CREATE TABLE IF NOT EXISTS symbols (
     path      TEXT NOT NULL,

--- a/tests/guard/test_build.py
+++ b/tests/guard/test_build.py
@@ -105,3 +105,18 @@ def test_an_empty_index_is_stale(tmp_path):
     schema.initialize(conn)
 
     assert build.is_stale(tmp_path, conn) is True
+
+
+def test_package_root_finds_the_nearest_marker(tmp_path):
+    (tmp_path / "crates" / "cli" / "src").mkdir(parents=True)
+    (tmp_path / "Cargo.toml").write_text("[workspace]\n", encoding="utf-8")
+    (tmp_path / "crates" / "cli" / "Cargo.toml").write_text("[package]\n", encoding="utf-8")
+
+    assert build.package_root_of(tmp_path, "crates/cli/src/main.rs", {}) == "crates/cli"
+    assert build.package_root_of(tmp_path, "build.rs", {}) == "."
+
+
+def test_a_repository_without_markers_is_one_package(tmp_path):
+    (tmp_path / "src").mkdir()
+
+    assert build.package_root_of(tmp_path, "src/thing.py", {}) == "."

--- a/tests/guard/test_extract_rust.py
+++ b/tests/guard/test_extract_rust.py
@@ -1,0 +1,147 @@
+"""Rust: what the matcher finds, and what it refuses to invent."""
+
+from __future__ import annotations
+
+from drift.guard import build, extract, lookup, schema
+
+SAMPLE = """\
+use std::collections::HashMap;
+use crate::db::client::Pool;
+use super::shared::helper;
+use crate::api::{routes, schemas};
+use self::inner::Thing;
+
+mod inner;
+
+pub fn validate_token(token: &str, audience: &str) -> bool {
+    true
+}
+
+fn unexported_helper() {}
+
+pub async fn fetch_records() {}
+
+pub struct TokenStore {
+    entries: HashMap<String, String>,
+}
+
+pub enum Outcome {
+    Accepted,
+}
+
+pub trait Validator {
+    fn validate(&self, token: &str) -> bool;
+}
+
+impl TokenStore {
+    pub fn new() -> Self {
+        Self { entries: HashMap::new() }
+    }
+
+    fn internal_detail(&self) {}
+}
+"""
+
+
+def _names(source: str) -> list[str]:
+    symbols, _ = extract.extract(source, ".rs")
+    return [s.name for s in symbols]
+
+
+def test_it_finds_top_level_declarations():
+    names = _names(SAMPLE)
+
+    assert "validate_token" in names
+    assert "unexported_helper" in names
+    assert "fetch_records" in names
+    assert "TokenStore" in names
+    assert "Outcome" in names
+    assert "Validator" in names
+
+
+def test_methods_inside_impl_blocks_are_not_indexed():
+    """`new`, `fmt` and `from` sit on half the types in any crate."""
+    names = _names(SAMPLE)
+
+    assert "new" not in names
+    assert "internal_detail" not in names
+
+
+def test_crate_paths_become_directory_specifiers():
+    _, imports = extract.extract(SAMPLE, ".rs")
+
+    assert "db/client/Pool" in imports
+    assert "../shared/helper" in imports
+    assert "./inner/Thing" in imports
+
+
+def test_a_braced_use_keeps_its_prefix():
+    """`use crate::api::{routes, schemas}` identifies one directory, not two."""
+    _, imports = extract.extract("use crate::api::{routes, schemas};\n", ".rs")
+
+    assert imports == ["api"]
+
+
+def test_external_crates_are_not_places_in_this_repository():
+    _, imports = extract.extract("use std::collections::HashMap;\nuse serde::Serialize;\n", ".rs")
+
+    assert imports == []
+
+
+def test_mod_declarations_are_not_boundary_crossings():
+    """`mod inner;` declares a child in the same directory."""
+    _, imports = extract.extract("mod inner;\nmod other;\n", ".rs")
+
+    assert imports == []
+
+
+def test_a_word_inside_a_string_is_not_a_declaration():
+    source = 'const MSG: &str = "pub fn not_a_real_function() {}";\n'
+
+    assert _names(source) == []
+
+
+def _write_rust_repo(root):
+    (root / "src" / "auth").mkdir(parents=True)
+    (root / "src" / "db").mkdir(parents=True)
+    (root / "src" / "api").mkdir(parents=True)
+    (root / "src" / "auth" / "tokens.rs").write_text(
+        "pub fn validate_token(token: &str) -> bool {\n    true\n}\n", encoding="utf-8"
+    )
+    (root / "src" / "db" / "client.rs").write_text(
+        "pub fn open_connection() {}\n", encoding="utf-8"
+    )
+    (root / "src" / "api" / "routes.rs").write_text(
+        "use crate::auth::tokens;\n\npub fn register_routes() {}\n", encoding="utf-8"
+    )
+
+
+def test_a_rust_repository_reports_a_duplicate(tmp_path):
+    _write_rust_repo(tmp_path)
+    build.build_full(tmp_path)
+    conn = schema.connect(tmp_path)
+
+    symbols, _ = extract.extract("pub fn validate_token(t: &str) -> bool {\n    false\n}\n", ".rs")
+    hits = lookup.find_duplicates(conn, "src/api/schemas.rs", symbols)
+
+    assert hits
+    assert "src/auth/tokens.rs:1" in hits[0].message
+
+
+def test_a_rust_repository_reports_a_first_ever_boundary(tmp_path):
+    _write_rust_repo(tmp_path)
+    build.build_full(tmp_path)
+    conn = schema.connect(tmp_path)
+
+    hits = lookup.find_novel_edges(conn, "src/api/routes.rs", ["db/client"])
+
+    assert hits, "src/api has never imported from src/db"
+    assert "src/api" in hits[0].message and "src/db" in hits[0].message
+
+
+def test_an_established_rust_edge_is_not_reported(tmp_path):
+    _write_rust_repo(tmp_path)
+    build.build_full(tmp_path)
+    conn = schema.connect(tmp_path)
+
+    assert lookup.find_novel_edges(conn, "src/api/routes.rs", ["auth/tokens"]) == []

--- a/tests/guard/test_extract_ts.py
+++ b/tests/guard/test_extract_ts.py
@@ -86,8 +86,13 @@ def test_camel_case_and_snake_case_collide():
 
 
 def test_an_unsupported_suffix_yields_nothing():
-    """A new file type stays silent until it is supported on purpose."""
-    assert extract.extract("fn main() {}\n", ".rs") == ([], [])
+    """A file type stays silent until it is supported on purpose.
+
+    The suffix is deliberately fictional. Naming a real unsupported language
+    here made this test fail twice, once when Go arrived and once for Rust —
+    which is the correct behaviour reported as a failure.
+    """
+    assert extract.extract("func main() {}\n", ".madeuplang") == ([], [])
 
 
 def test_line_numbers_point_at_the_declaration():

--- a/tests/guard/test_lookup.py
+++ b/tests/guard/test_lookup.py
@@ -214,3 +214,36 @@ def test_the_briefing_stays_quiet_in_directories_that_repeat_by_design(tmp_path)
 
     assert lookup.neighbourhood(conn, "examples/new.py") == []
     assert lookup.known_targets(conn, "examples/new.py") == []
+
+
+def test_two_packages_in_a_workspace_do_not_duplicate_each_other(tmp_path):
+    """ripgrep's `crates/cli` and `crates/globset` both define `escape`."""
+    (tmp_path / "crates" / "cli").mkdir(parents=True)
+    (tmp_path / "crates" / "globset").mkdir(parents=True)
+    (tmp_path / "crates" / "cli" / "Cargo.toml").write_text("[package]\n", encoding="utf-8")
+    (tmp_path / "crates" / "globset" / "Cargo.toml").write_text("[package]\n", encoding="utf-8")
+    (tmp_path / "crates" / "globset" / "lib.rs").write_text(
+        "pub fn escape_pattern(s: &str) {}\n", encoding="utf-8"
+    )
+    build.build_full(tmp_path)
+    conn = schema.connect(tmp_path)
+
+    symbols, _ = extract.extract("pub fn escape_pattern(s: &str) {}\n", ".rs")
+
+    assert lookup.find_duplicates(conn, "crates/cli/escape.rs", symbols) == []
+
+
+def test_one_package_still_reports_its_own_duplicates(tmp_path):
+    """The workspace rule must not switch the signal off inside a package."""
+    (tmp_path / "src" / "auth").mkdir(parents=True)
+    (tmp_path / "src" / "api").mkdir(parents=True)
+    (tmp_path / "Cargo.toml").write_text("[package]\n", encoding="utf-8")
+    (tmp_path / "src" / "auth" / "tokens.rs").write_text(
+        "pub fn validate_token(t: &str) {}\n", encoding="utf-8"
+    )
+    build.build_full(tmp_path)
+    conn = schema.connect(tmp_path)
+
+    symbols, _ = extract.extract("pub fn validate_token(t: &str) {}\n", ".rs")
+
+    assert lookup.find_duplicates(conn, "src/api/schemas.rs", symbols)


### PR DESCRIPTION
Five languages in one index. Rust follows Go's shape — but the interesting part is what the noise gate rejected on the way.

## The gate did its job

The first version measured **23.6 % on ripgrep**, over the 10 % budget, and `measure_noise.py` exited non-zero.

The cause was not Rust. ripgrep is a Cargo workspace: `crates/cli` and `crates/globset` both define `escape`. Those are two published libraries with their own namespaces, and no author would call that duplication.

**The index had no idea packages existed** — so every monorepo had been getting this wrong, in every language, since the beginning. Node workspaces, Go modules and Python source trees split exactly the same way.

`files.package_root` now records the nearest ancestor holding a `Cargo.toml`, `package.json`, `go.mod`, `pyproject.toml` or `setup.py`, and duplicates are reported only within one package. Observed rather than configured, like every other fact this index keeps.

| | before | after |
|---|---|---|
| ripgrep | 23.6 % | **7.3 %** |
| serde | 4.8 % | **2.9 %** |

No regression elsewhere: requests 0.0 %, gin 2.0 %, flask 4.8 %, axios 5.6 %.

## A schema bump that had to fix itself

Schema goes to 2. That exposed a second problem: an index written by an older schema is unusable, and **nothing would ever replace it** — the file exists, so the missing-index path never runs, and the guard would sit silent forever behind an index it cannot read. SessionStart now treats an unusable schema as stale.

## Rust specifics

- `pub fn`, `struct`, `enum`, `trait`, `union`, `type` at column zero.
- Methods inside `impl` blocks are excluded: `new`, `fmt` and `from` sit on half the types in any crate — the same rule as Go and for the same measured reason.
- `use crate::db::client` becomes `db/client`; `super::` and `self::` become the relative forms Python and TypeScript already emit. `use crate::api::{routes, schemas}` keeps its prefix, because the braces name children of one directory.
- `mod x;` is not an import — it declares a child module in the same directory.
- `suffix_to_dir` had to learn a second shape: Go carries the full module path and the repository holds its tail, while Rust drops the head (`crate` *is* `src/`), so the repository holds the tail of the specifier. Ambiguous matches are discarded rather than guessed.

## `config` and `options` join the stopwords

Not corpus fitting. `config` was the loudest false positive in axios, in JavaScript, before Rust existed here — and it came back as the dominant one in ripgrep, where nearly every module keeps a private `Config`.

## Verification

148 guard tests (14 new), all nine gates, six repositories across five languages within the noise budget, `ruff` and `mypy` clean, markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)