### PR TITLE
feat(guard): guard Java and Kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Short version: Drift installs as a Claude Code plugin and works inside the agent
 - notice when the index describes a tree that has moved
 - guard Go
 - guard Rust, and stop conflating packages in a workspace
+- guard Java and Kotlin
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ plugin that fires in every project you open has no business leaving a directory
 in each of them. A project that wants the index alongside its source opts in by
 creating a `.drift/` directory.
 
-**Python, TypeScript, JavaScript, Go and Rust** (`.py .ts .tsx .js .jsx .mjs
-.cjs .go .rs`),
+**Seven file types in one index** — Python, TypeScript, JavaScript, Go, Rust,
+Java and Kotlin (`.py .ts .tsx .js .jsx .mjs .cjs .go .rs .java .kt .kts`),
 in one index — a name defined in Python is found from TypeScript, because
 `validate_token`, `validateToken` and `ValidateToken` all normalise to the same
 thing. Other languages pass through untouched.

--- a/docs-site/claude-code-plugin.md
+++ b/docs-site/claude-code-plugin.md
@@ -17,8 +17,8 @@ business leaving a directory in each of them. A project that wants the index
 alongside its source opts in by creating a `.drift/` directory; `DRIFT_CACHE_HOME`
 overrides both.
 
-!!! note "Python, TypeScript, JavaScript, Go and Rust"
-    `.py .ts .tsx .js .jsx .mjs .cjs .go .rs`, all in one index — a name defined in
+!!! note "Python, TypeScript, JavaScript, Go, Rust, Java and Kotlin"
+    `.py .ts .tsx .js .jsx .mjs .cjs .go .rs .java .kt .kts`, all in one index — a name defined in
     Python is found from Go, because `validate_token`, `validateToken` and
     `ValidateToken` all normalise to the same thing. Python is parsed with `ast`;
     the others are matched against top-level declarations,

--- a/src/drift/guard/build.py
+++ b/src/drift/guard/build.py
@@ -114,7 +114,7 @@ def import_to_dir(
     """
     if specifier.startswith("."):
         return relative_to_dir(specifier, src_dir, known_dirs)
-    if suffix in extract.GO_SUFFIXES or suffix in extract.RUST_SUFFIXES:
+    if suffix in extract.GO_SUFFIXES | extract.RUST_SUFFIXES | extract.JVM_SUFFIXES:
         return suffix_to_dir(specifier, known_dirs)
     if "/" in specifier:
         return None
@@ -139,7 +139,16 @@ def _sha256(path: pathlib.Path) -> str:
 
 #: A directory holding one of these is the root of its own package. Observed
 #: rather than configured, like everything else the index records.
-PACKAGE_MARKERS = ("Cargo.toml", "package.json", "go.mod", "pyproject.toml", "setup.py")
+PACKAGE_MARKERS = (
+    "Cargo.toml",
+    "package.json",
+    "go.mod",
+    "pyproject.toml",
+    "setup.py",
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+)
 
 
 def package_root_of(repo_root: pathlib.Path, rel_path: str, cache: dict[str, str]) -> str:

--- a/src/drift/guard/extract.py
+++ b/src/drift/guard/extract.py
@@ -26,7 +26,8 @@ PYTHON_SUFFIXES = frozenset({".py"})
 TS_JS_SUFFIXES = frozenset({".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"})
 GO_SUFFIXES = frozenset({".go"})
 RUST_SUFFIXES = frozenset({".rs"})
-GUARDED_SUFFIXES = PYTHON_SUFFIXES | TS_JS_SUFFIXES | GO_SUFFIXES | RUST_SUFFIXES
+JVM_SUFFIXES = frozenset({".java", ".kt", ".kts"})
+GUARDED_SUFFIXES = PYTHON_SUFFIXES | TS_JS_SUFFIXES | GO_SUFFIXES | RUST_SUFFIXES | JVM_SUFFIXES
 
 #: Normalized names too common to ever be a meaningful duplicate.
 STOPWORDS = frozenset(
@@ -167,6 +168,34 @@ _RUST_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
 _RUST_USE = re.compile(r"^\s*(?:pub\s+)?use\s+([^;]+);", re.MULTILINE)
 
 
+#: Java and Kotlin declarations. Members are indented, so the column-zero
+#: anchor excludes them exactly as it does in Go and Rust. Kotlin's top-level
+#: `fun` is included because it genuinely is a file-level definition.
+_JVM_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "type",
+        re.compile(
+            r"^(?:@\w+\s+)*(?:public\s+|internal\s+|private\s+|protected\s+|final\s+|abstract\s+"
+            r"|sealed\s+|open\s+|data\s+|value\s+|static\s+)*"
+            r"(?:class|interface|enum|record|object|@interface)\s+([A-Za-z_$][\w$]*)",
+            re.MULTILINE,
+        ),
+    ),
+    (
+        "function",
+        re.compile(
+            r"^(?:public\s+|internal\s+|private\s+|suspend\s+|inline\s+)*fun\s+"
+            r"(?:<[^>]+>\s+)?([A-Za-z_$][\w$]*)\s*\(",
+            re.MULTILINE,
+        ),
+    ),
+)
+
+#: `import a.b.C;` in Java, `import a.b.C` in Kotlin. The trailing segment is
+#: the type, so the resolver gets the package and matches it as a directory.
+_JVM_IMPORT = re.compile(r"^import\s+(?:static\s+)?([\w.]+(?:\*)?)", re.MULTILINE)
+
+
 class Symbol(NamedTuple):
     name: str
     norm_name: str
@@ -208,7 +237,53 @@ def extract(source: str, suffix: str = ".py") -> tuple[list[Symbol], list[str]]:
         return extract_go(source)
     if suffix in RUST_SUFFIXES:
         return extract_rust(source)
+    if suffix in JVM_SUFFIXES:
+        return extract_jvm(source)
     return ([], [])
+
+
+def extract_jvm(source: str) -> tuple[list[Symbol], list[str]]:
+    """Java and Kotlin, matched rather than parsed.
+
+    Import specifiers become slash paths so the same trailing-segment resolver
+    that serves Go and Rust can find them: `com.example.db.Client` carries the
+    package `com/example/db`, and a Java tree holds exactly that under
+    `src/main/java/`.
+    """
+    symbols: list[Symbol] = []
+    seen: set[str] = set()
+
+    for kind, pattern in _JVM_PATTERNS:
+        for match in pattern.finditer(source):
+            name = match.group(1)
+            if name in seen:
+                continue
+            seen.add(name)
+            symbols.append(
+                Symbol(
+                    name=name,
+                    norm_name=normalize(name),
+                    kind=kind,
+                    sig_hash=signature_hash(kind, []),
+                    line=source.count("\n", 0, match.start()) + 1,
+                )
+            )
+
+    # The last segment of a plain import is the type rather than part of the
+    # package, so it is dropped. A wildcard names the package outright, and
+    # dropping its last segment would point one directory too high.
+    imports = []
+    for match in _JVM_IMPORT.finditer(source):
+        raw = match.group(1)
+        parts = [p for p in raw.split(".") if p and p != "*"]
+        if raw.endswith("*"):
+            if parts:
+                imports.append("/".join(parts))
+        elif len(parts) > 1:
+            imports.append("/".join(parts[:-1]))
+
+    symbols.sort(key=lambda s: s.line)
+    return (symbols, imports)
 
 
 def extract_rust(source: str) -> tuple[list[Symbol], list[str]]:

--- a/src/drift/guard/lookup.py
+++ b/src/drift/guard/lookup.py
@@ -31,16 +31,23 @@ _REPEATING_DIRS = frozenset(
         "__tests__",
         "spec",
         "specs",
-        "example",
-        "examples",
-        "docs_src",
+        "testdata",
         "fixtures",
         "__fixtures__",
-        "testdata",
         "benchmarks",
         "migrations",
+        "examples",
+        "docs_src",
+        "samples",
+        "demos",
     }
 )
+
+#: Only when they are the first path segment. `com/example` is the package name
+#: every Java scaffold generates, and reading it as a demonstration directory
+#: switched the guard off for most of Java. The plural forms above are safe
+#: anywhere; the singular ones are a word that appears inside real namespaces.
+_REPEATING_ROOT_DIRS = frozenset({"example", "demo", "sample"})
 
 #: A name shorter than this carries no evidence on its own. `add`, `date` and
 #: `argv` all collide across unrelated files in real repositories.
@@ -75,6 +82,8 @@ def repeats_by_design(rel_path: str) -> bool:
     """
     parts = rel_path.split("/")
     if any(part in _REPEATING_DIRS for part in parts):
+        return True
+    if parts and parts[0] in _REPEATING_ROOT_DIRS:
         return True
 
     stem = parts[-1].rsplit(".", 1)[0]

--- a/tests/guard/test_extract_jvm.py
+++ b/tests/guard/test_extract_jvm.py
@@ -1,0 +1,170 @@
+"""Java and Kotlin: what the matcher finds, and what it refuses to invent."""
+
+from __future__ import annotations
+
+from drift.guard import build, extract, lookup, schema
+
+JAVA = """\
+package com.example.auth;
+
+import java.util.Map;
+import com.example.db.Client;
+import static com.example.util.Helpers.escape;
+import com.example.api.*;
+
+@Service
+public final class TokenStore implements Validator {
+
+    private Map<String, String> entries;
+
+    public boolean validate(String token) {
+        return true;
+    }
+
+    private void internalDetail() {}
+}
+
+interface Validator {
+    boolean validate(String token);
+}
+
+enum Outcome {
+    ACCEPTED
+}
+
+record Pair(String left, String right) {}
+"""
+
+KOTLIN = """\
+package com.example.auth
+
+import com.example.db.Client
+
+fun validateToken(token: String, audience: String): Boolean = true
+
+private fun unexportedHelper() {}
+
+suspend fun fetchRecords() {}
+
+data class TokenStore(val entries: Map<String, String>) {
+    fun validate(token: String): Boolean = true
+}
+
+object Registry {
+    fun register() {}
+}
+"""
+
+
+def _names(source: str, suffix: str) -> list[str]:
+    symbols, _ = extract.extract(source, suffix)
+    return [s.name for s in symbols]
+
+
+def test_java_finds_top_level_types():
+    names = _names(JAVA, ".java")
+
+    assert "TokenStore" in names
+    assert "Validator" in names
+    assert "Outcome" in names
+    assert "Pair" in names
+
+
+def test_java_members_are_not_indexed():
+    """Members are indented; the column-zero anchor excludes them."""
+    names = _names(JAVA, ".java")
+
+    assert "validate" not in names
+    assert "internalDetail" not in names
+
+
+def test_kotlin_top_level_functions_are_definitions():
+    names = _names(KOTLIN, ".kt")
+
+    assert "validateToken" in names
+    assert "unexportedHelper" in names
+    assert "fetchRecords" in names
+    assert "TokenStore" in names
+    assert "Registry" in names
+
+
+def test_kotlin_members_are_not_indexed():
+    names = _names(KOTLIN, ".kt")
+
+    assert "validate" not in names
+    assert "register" not in names
+
+
+def test_imports_carry_the_package_not_the_type():
+    """`com.example.db.Client` names the type; `com/example/db` is the place."""
+    _, imports = extract.extract(JAVA, ".java")
+
+    assert "com/example/db" in imports
+    assert "java/util" in imports
+    assert "com/example/util/Helpers" in imports, "a static import ends at the class"
+    assert "com/example/api" in imports, "a wildcard import still names its package"
+
+
+def test_a_word_inside_a_string_is_not_a_declaration():
+    source = 'package a;\n\nclass Real { String s = "public class NotReal {}"; }\n'
+
+    assert _names(source, ".java") == ["Real"]
+
+
+def _write_java_repo(root):
+    base = root / "src" / "main" / "java" / "com" / "example"
+    (base / "auth").mkdir(parents=True)
+    (base / "db").mkdir(parents=True)
+    (base / "api").mkdir(parents=True)
+    (root / "pom.xml").write_text("<project/>\n", encoding="utf-8")
+    (base / "auth" / "TokenStore.java").write_text(
+        "package com.example.auth;\n\npublic class TokenStore {}\n", encoding="utf-8"
+    )
+    (base / "db" / "Client.java").write_text(
+        "package com.example.db;\n\npublic class Client {}\n", encoding="utf-8"
+    )
+    (base / "api" / "Routes.java").write_text(
+        "package com.example.api;\n\nimport com.example.auth.TokenStore;\n\n"
+        "public class Routes {}\n",
+        encoding="utf-8",
+    )
+
+
+def test_a_java_repository_reports_a_duplicate(tmp_path):
+    _write_java_repo(tmp_path)
+    build.build_full(tmp_path)
+    conn = schema.connect(tmp_path)
+
+    symbols, _ = extract.extract(
+        "package com.example.api;\n\npublic class TokenStore {}\n", ".java"
+    )
+    hits = lookup.find_duplicates(conn, "src/main/java/com/example/api/TokenStore.java", symbols)
+
+    assert hits
+    assert "auth/TokenStore.java" in hits[0].message
+
+
+def test_a_java_repository_reports_a_first_ever_boundary(tmp_path):
+    _write_java_repo(tmp_path)
+    build.build_full(tmp_path)
+    conn = schema.connect(tmp_path)
+
+    hits = lookup.find_novel_edges(
+        conn, "src/main/java/com/example/api/Routes.java", ["com/example/db"]
+    )
+
+    assert hits, "the api package has never imported from db"
+    assert "api" in hits[0].message and "db" in hits[0].message
+
+
+def test_an_established_java_edge_is_not_reported(tmp_path):
+    _write_java_repo(tmp_path)
+    build.build_full(tmp_path)
+    conn = schema.connect(tmp_path)
+
+    assert (
+        lookup.find_novel_edges(
+            conn, "src/main/java/com/example/api/Routes.java", ["com/example/auth"]
+        )
+        == []
+    )

--- a/tests/guard/test_lookup.py
+++ b/tests/guard/test_lookup.py
@@ -247,3 +247,15 @@ def test_one_package_still_reports_its_own_duplicates(tmp_path):
     symbols, _ = extract.extract("pub fn validate_token(t: &str) {}\n", ".rs")
 
     assert lookup.find_duplicates(conn, "src/api/schemas.rs", symbols)
+
+
+def test_a_java_package_named_example_is_not_a_demo_directory():
+    """`com/example` is what every Java scaffold generates."""
+    assert not lookup.repeats_by_design("src/main/java/com/example/api/Routes.java")
+    assert not lookup.repeats_by_design("src/main/java/com/example/Application.java")
+
+
+def test_a_top_level_example_directory_still_repeats_by_design():
+    assert lookup.repeats_by_design("example/main.go")
+    assert lookup.repeats_by_design("examples/celery/app.py")
+    assert lookup.repeats_by_design("pkgs/core/examples/cjs/test.cjs")


### PR DESCRIPTION
Seven file types in one index. Measured on real repositories: **gson 0.0 %** of 264 files, **okhttp 0.4 %** of 668.

Members are indented in both languages, so the column-zero anchor excludes them without a special case — the same property that made Go and Rust cheap. Kotlin's top-level `fun` is included, because there it genuinely is a file-level definition. Imports become slash paths so the trailing-segment resolver written for Go and Rust serves them unchanged: `com.example.db.Client` carries the package `com/example/db`, which a Java tree holds verbatim under `src/main/java/`.

## Two bugs found by writing the tests, not by trusting the patterns

**A wildcard import lost a directory.** `import com.example.api.*` names the package outright, so dropping its last segment — correct for `import com.example.db.Client`, where the tail is a type — pointed one level too high.

**`com/example` is the package name every Java scaffold generates.** The rule that treats `examples/` as a directory which repeats names by design matched it *anywhere* in a path — so it switched the duplicate signal off for most Java code in existence. The Java end-to-end test failed with an empty result and the reason was three rules away from where I was looking.

The fix splits the set: plural forms and `docs_src` still match at any depth, because `pkgs/core/examples/` is real. The singular `example`, `demo` and `sample` now match only as the **first path segment**, which is where a demonstration directory actually lives.

`pom.xml`, `build.gradle` and `build.gradle.kts` join the package markers, so a Gradle multi-project gets the same treatment as the Cargo workspace fix in #787.

## No regression

| | |
|---|---|
| axios | 5.6 % |
| fastapi | 1.0 % |
| flask | 4.8 % |
| gin | 2.0 % |
| ripgrep | 7.3 % |
| gson | **0.0 %** |
| okhttp | **0.4 %** |

## Verification

159 guard tests (11 new), all nine gates, seven repositories across seven file types within the noise budget, `ruff` and `mypy` clean, markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)