### PR TITLE
fix(guard): stop build scripts counting as source, and measure the boundary signal honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Short version: Drift installs as a Claude Code plugin and works inside the agent
 - stop the guard speaking on half of every real repository
 - the boundary signal was blind to relative imports
 - the pre-edit briefing spoke on almost every new file
+- stop build scripts counting as source, and measure the boundary
 
 ## [2.51.1] - 2026-05-04
 

--- a/scripts/gates/measure_noise.py
+++ b/scripts/gates/measure_noise.py
@@ -53,6 +53,13 @@ def measure_boundary_reach(repo: pathlib.Path, conn) -> dict:
     per_file: dict[str, set[tuple[str, str]]] = {}
 
     for rel in files:
+        # The guard's own filters have to apply here too. Without them this
+        # number counted `docs_src/` tutorials and test files the guard never
+        # speaks about, and overstated the boundary signal by an order of
+        # magnitude — the second time this tool has flattered or maligned a
+        # signal that was behaving correctly.
+        if lookup.repeats_by_design(rel):
+            continue
         try:
             source = (repo / rel).read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):

--- a/src/drift/guard/lookup.py
+++ b/src/drift/guard/lookup.py
@@ -97,7 +97,14 @@ def repeats_by_design(rel_path: str) -> bool:
         return True
     # Generated code restates whatever it was generated from, and no one edits
     # it: `Model.designer.cs`, `Api.g.cs`, `Schema.generated.ts`.
-    return stem.lower().endswith((".designer", ".g", ".generated", "_pb2", "_pb"))
+    if stem.lower().endswith((".designer", ".g", ".generated", "_pb2", "_pb")):
+        return True
+    # Build scripts are configuration that happens to be written in a
+    # programming language. `okhttp.jvm-conventions.gradle.kts` and its
+    # siblings all declare `library`, and a Gradle file reaching into
+    # build-logic is not an architectural event.
+    name = parts[-1].lower()
+    return name.endswith((".gradle.kts", ".gradle")) or name in ("build.sbt", "conftest.py")
 
 
 def find_duplicates(

--- a/tests/guard/test_lookup.py
+++ b/tests/guard/test_lookup.py
@@ -273,3 +273,11 @@ def test_generated_files_repeat_whatever_generated_them():
     assert lookup.repeats_by_design("src/Api.g.cs")
     assert lookup.repeats_by_design("src/schema_pb2.py")
     assert not lookup.repeats_by_design("src/designer.py")
+
+
+def test_build_scripts_are_configuration_not_source():
+    """Gradle convention files all declare `library`; that is not duplication."""
+    assert lookup.repeats_by_design("build-logic/src/main/kotlin/okhttp.jvm-conventions.gradle.kts")
+    assert lookup.repeats_by_design("android-test/build.gradle.kts")
+    assert lookup.repeats_by_design("project/build.gradle")
+    assert not lookup.repeats_by_design("src/main/kotlin/okhttp3/Request.kt")


### PR DESCRIPTION
The boundary signal's *usefulness* had never been examined — only its reach. That number said **15.9 %** of okhttp's files would announce a first-ever crossing if written fresh. Roughly one new file in six, which would make it an interruption rather than a report.

So I read what it would actually say.

## Most of it was not the guard's doing

`measure_boundary_reach` did not apply the guard's own filters. It counted fastapi's `docs_src/` tutorials and okhttp's test paths — both of which `find_novel_edges` already skips.

| | before | after |
|---|---|---|
| fastapi | 7.2 % | **0.4 %** |
| okhttp | 15.9 % | **9.4 %** |

That is the second time this tool has misrepresented a signal that was behaving correctly (the first was [#786](https://github.com/mick-gsk/drift/pull/786), where a missing suffix hid 21 Go edges). A measurement tool that does not share the code path it measures will keep doing this, so the filter call now sits in the loop itself with the reason next to it.

## What was left was real

Gradle build scripts. `okhttp.jvm-conventions.gradle.kts` and its siblings all declare `library`, and a build file reaching into `build-logic` is configuration referring to configuration — not an architectural event.

`*.gradle.kts`, `*.gradle`, `build.sbt` and `conftest.py` now repeat by design. okhttp's duplicate rate goes from 0.4 % to **0.0 %** with them out.

## No regression

Nine repositories, eight file types:

| requests | gson | serilog | gin | flask | axios | ripgrep |
|---|---|---|---|---|---|---|
| 0.0 % | 0.0 % | 0.9 % | 2.0 % | 4.8 % | 5.6 % | 7.3 % |

## Verification

171 guard tests (1 new), all nine gates, `ruff` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)