### PR TITLE
fix(guard): sample the full index for staleness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Short version: Drift installs as a Claude Code plugin and works inside the agent
 
 ### Fixed
 
+- Spread stale-index samples across the full indexed path range
 - Hook output now reaches the model. The hooks printed findings to stdout and exited 0, which for `PreToolUse` and `PostToolUse` reaches the transcript only — the guard's findings would never have arrived. Output goes through `hookSpecificOutput.additionalContext`, with the session tally on `systemMessage`
 - `schema.connect()` no longer advertises `Connection | None` for writers that cannot fail; readers use `connect()`, writers use `create()`
 - make the two-line install actually produce a working guard

--- a/src/drift/guard/build.py
+++ b/src/drift/guard/build.py
@@ -216,8 +216,15 @@ def is_stale(repo_root: pathlib.Path, conn) -> bool:
     if not rows:
         return True
 
-    step = max(1, len(rows) // STALENESS_SAMPLE)
-    sample = rows[::step][:STALENESS_SAMPLE]
+    sample_count = min(STALENESS_SAMPLE, len(rows))
+    if sample_count == 1:
+        sample = rows
+    else:
+        last_index = len(rows) - 1
+        sample = [
+            rows[round(position * last_index / (sample_count - 1))]
+            for position in range(sample_count)
+        ]
 
     moved = 0
     for rel, digest in sample:

--- a/tests/guard/test_build.py
+++ b/tests/guard/test_build.py
@@ -120,3 +120,18 @@ def test_a_repository_without_markers_is_one_package(tmp_path):
     (tmp_path / "src").mkdir()
 
     assert build.package_root_of(tmp_path, "src/thing.py", {}) == "."
+
+
+def test_staleness_sample_spans_a_medium_sized_index(tmp_path):
+    files = []
+    for index in range(39):
+        path = tmp_path / f"file_{index:02d}.py"
+        path.write_text(f"def value_{index}():\n    return {index}\n", encoding="utf-8")
+        files.append(path)
+    build.build_full(tmp_path)
+
+    for path in files[20:]:
+        path.write_text("def branch_version():\n    return False\n", encoding="utf-8")
+    conn = schema.connect(tmp_path)
+
+    assert build.is_stale(tmp_path, conn) is True


### PR DESCRIPTION
Follow-up to #785.

## Problem

The merged staleness check says its sample is spread across the indexed path order, but indexes with 21-39 files use a step of one and then truncate to the first 20 rows. A branch can rewrite the entire unsampled tail without triggering staleness.

A 39-file regression demonstrates it: after indexing all files, rewriting sorted paths 20-38 left `is_stale()` false before this patch.

## Change

Select up to 20 deterministic positions distributed from the first indexed path through the last. This preserves the existing sample size, 25% threshold, hashing behavior, and SessionStart flow.

## Verification

- RED: the new 39-file tail-change regression failed on merged main
- `pytest tests/guard/test_build.py -q` — 13 passed
- `pytest tests/guard -q --deselect tests/guard/test_hooks.py::test_bin_wrapper_works_without_an_installed_package` — 171 passed, 1 deselected
- `python scripts/gates/run_all_gates.py` — all nine guard gates passed
- focused Ruff, Ruff format, and MyPy — passed
- 50-run SessionStart latency: p95 65.79 ms against the 150 ms budget, 0 failures

## Known baseline limitation

The full guard suite has one unrelated current-main fixture failure in `test_bin_wrapper_works_without_an_installed_package`: its isolated cache contains a zero-file index. The failure reproduces unchanged on untouched current main; this patch does not modify that path.

AI assisted implementation and review. I reproduced the false negative before the fix, ran the listed tests and gates, measured latency, and inspected the complete diff.

Assisted-by: OpenAI Codex
Human verification: VrtxOmega