### PR TITLE
docs: publish the latency a session actually pays

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,15 +165,21 @@ The guard is a separate module that imports nothing but `sqlite3`, `ast` and
 `json` — no `click`, no `rich`, no ML stack, nothing from the analysis engine.
 That constraint is enforced by a test, not by intention.
 
-| Measured on this repository (344 Python files) | p50 | p95 |
+The whole hook, as Claude Code runs it — shell start, `git rev-parse`, the
+lookup — against an index of **2169 files**:
+
+| | p50 | p95 |
 |---|---|---|
-| Before an edit to a new file | 70 ms | 72 ms |
-| After an edit to an existing file | 86 ms | 87 ms |
+| Before an edit to a new file | 67 ms | 68 ms |
+| After an edit to an existing file | 82 ms | 85 ms |
 | *Python interpreter startup alone, for reference* | *24 ms* | *29 ms* |
 | *`import drift.cli`, the path the guard avoids* | *3229 ms* | *3959 ms* |
 
-20 runs each, cold, macOS/arm64, Python 3.12 → [guard_baseline.json](benchmark_results/guard_baseline.json).
-Clean checkout to a working guard: **5 s** (`bash scripts/gates/measure_install.sh`).
+Cold, macOS/arm64, Python 3.12. The reference rows come from
+[guard_baseline.json](benchmark_results/guard_baseline.json); the two hook rows
+are the round trip a session actually pays, which is a fairer number than the
+Python call on its own. Clean checkout to a working guard: **5 s**
+(`bash scripts/gates/measure_install.sh`).
 
 If the guard breaks, it stays silent and the session continues — it can report,
 but it can never block.


### PR DESCRIPTION
Every interactive test of this guard so far ran against a **six-file fixture**, and the published numbers timed the **Python call alone**. Neither is what a user experiences: the hook is a shell script that starts bash, runs `git rev-parse` and then calls the guard, and the repository it answers about is not six files.

Measured against an index of **2169 files**, 15 runs each, whole round trip:

| | p50 | p95 |
|---|---|---|
| Before an edit to a new file | 67 ms | 68 ms |
| After an edit to an existing file | 82 ms | 85 ms |

The shell and git overhead turns out to be small, so the honest number is barely worse than the flattering one. But it is the honest one, and the table now says which rows are the full hook and which are references.

## Verified live at the same time

A session in this repository, guard active, 2169-file index:

> One fact worth passing along from the guard: a `find_duplicates` already exists at `src/drift/guard/lookup.py:110`.

A first attempt used `dir_of` and the guard correctly said nothing — five characters after normalisation, below `MIN_DUPLICATE_NAME_LENGTH`. That is the rule working, not the guard failing, and it is worth writing down because a silent guard is exactly what a broken one looks like.

Docs only. 172 guard tests, all nine gates, markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)