### PR TITLE
fix(guard): the session tally lost 97 % of its increments under concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Short version: Drift installs as a Claude Code plugin and works inside the agent
 - the pre-edit briefing spoke on almost every new file
 - stop build scripts counting as source, and measure the boundary
 - make the slash commands answer to the names the docs promise
+- the session tally lost 97 % of its increments under concurrency
 
 ## [2.51.1] - 2026-05-04
 

--- a/src/drift/guard/report.py
+++ b/src/drift/guard/report.py
@@ -7,7 +7,7 @@ Nothing here fabricates or estimates a number.
 from __future__ import annotations
 
 import json
-import pathlib
+import sqlite3
 
 from drift.guard import lookup, schema
 
@@ -53,40 +53,82 @@ def hook_json(event: str, agent_text: str = "", user_text: str = "") -> str:
     return json.dumps(payload) if payload else ""
 
 
-def counter_path(repo_root) -> pathlib.Path:
-    # Same directory as the index, so the guard leaves exactly one place behind
-    # and `.drift/` never appears in a repository that did not ask for it.
-    return schema.state_dir(repo_root) / "session_counter.json"
+# The tally lives in the index database, not in a JSON file beside it.
+#
+# Claude Code fires PostToolUse once per tool call and therefore concurrently
+# whenever the model batches independent calls — which amphetamin explicitly
+# asks it to do. Read-modify-write on a JSON file loses those updates: measured
+# with 200 increments across 8 threads, the file-backed counter ended at 6.
+#
+# SQLite makes the increment a single atomic statement, and the database is
+# already open in this code path anyway. No index means no counting, which is
+# correct: without one the guard has nothing to report either.
+_COUNTER_KEY = "count_{kind}"
+
+
+def _counter_connection(repo_root):
+    conn = schema.connect(repo_root)
+    if conn is None or not schema.is_usable(conn):
+        if conn is not None:
+            conn.close()
+        return None
+    return conn
 
 
 def read_counter(repo_root) -> dict:
-    path = counter_path(repo_root)
-    if not path.exists():
+    conn = _counter_connection(repo_root)
+    if conn is None:
         return {kind: 0 for kind in _KINDS}
     try:
-        with open(path, encoding="utf-8") as handle:
-            stored = json.load(handle)
-    except (OSError, ValueError):
+        rows = dict(conn.execute("SELECT key, value FROM meta").fetchall())
+    except sqlite3.DatabaseError:
         return {kind: 0 for kind in _KINDS}
-    return {kind: int(stored.get(kind, 0)) for kind in _KINDS}
+    finally:
+        conn.close()
+
+    counts = {}
+    for kind in _KINDS:
+        try:
+            counts[kind] = int(rows.get(_COUNTER_KEY.format(kind=kind), 0))
+        except (TypeError, ValueError):
+            counts[kind] = 0
+    return counts
 
 
 def bump(repo_root, kind: str, amount: int = 1) -> None:
     if kind not in _KINDS:
         return
-    counts = read_counter(repo_root)
-    counts[kind] += amount
-    path = counter_path(repo_root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w", encoding="utf-8") as handle:
-        json.dump(counts, handle)
+    conn = _counter_connection(repo_root)
+    if conn is None:
+        return
+    try:
+        conn.execute(
+            "INSERT INTO meta (key, value) VALUES (?, ?)"
+            " ON CONFLICT(key) DO UPDATE SET value ="
+            " CAST(CAST(value AS INTEGER) + ? AS TEXT)",
+            (_COUNTER_KEY.format(kind=kind), str(amount), amount),
+        )
+        conn.commit()
+    except sqlite3.DatabaseError:
+        pass  # a guard that cannot count still must not break the session
+    finally:
+        conn.close()
 
 
 def reset_counter(repo_root) -> None:
-    path = counter_path(repo_root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w", encoding="utf-8") as handle:
-        json.dump({kind: 0 for kind in _KINDS}, handle)
+    conn = _counter_connection(repo_root)
+    if conn is None:
+        return
+    try:
+        conn.executemany(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES (?, '0')",
+            [(_COUNTER_KEY.format(kind=kind),) for kind in _KINDS],
+        )
+        conn.commit()
+    except sqlite3.DatabaseError:
+        pass
+    finally:
+        conn.close()
 
 
 def summary_line(counts: dict) -> str:

--- a/tests/guard/test_report.py
+++ b/tests/guard/test_report.py
@@ -2,7 +2,9 @@
 
 import json
 
-from drift.guard import lookup, report
+import pytest
+
+from drift.guard import lookup, report, schema
 
 
 def test_no_hits_produces_no_output():
@@ -29,23 +31,53 @@ def test_long_hit_lists_are_truncated():
     assert len(report.format_hits(hits)) <= report.MAX_MESSAGE_CHARS
 
 
-def test_counter_starts_at_zero(tmp_path):
+@pytest.fixture
+def indexed(tmp_path):
+    """A repository with an index, which is where the tally now lives."""
+    conn = schema.create(tmp_path)
+    schema.initialize(conn)
+    conn.close()
+    return tmp_path
+
+
+def test_counter_starts_at_zero(indexed):
+    assert report.read_counter(indexed) == {"duplicate": 0, "boundary": 0}
+
+
+def test_bump_accumulates_per_kind(indexed):
+    report.bump(indexed, "duplicate")
+    report.bump(indexed, "duplicate")
+    report.bump(indexed, "boundary")
+
+    assert report.read_counter(indexed) == {"duplicate": 2, "boundary": 1}
+
+
+def test_reset_clears_the_counter(indexed):
+    report.bump(indexed, "duplicate")
+    report.reset_counter(indexed)
+
+    assert report.read_counter(indexed) == {"duplicate": 0, "boundary": 0}
+
+
+def test_without_an_index_there_is_nothing_to_count(tmp_path):
+    """No index means the guard reported nothing, so a tally would be a lie."""
+    report.bump(tmp_path, "duplicate")
+
     assert report.read_counter(tmp_path) == {"duplicate": 0, "boundary": 0}
 
 
-def test_bump_accumulates_per_kind(tmp_path):
-    report.bump(tmp_path, "duplicate")
-    report.bump(tmp_path, "duplicate")
-    report.bump(tmp_path, "boundary")
+def test_the_counter_survives_concurrent_hooks(indexed):
+    """Claude Code fires PostToolUse concurrently for batched tool calls.
 
-    assert report.read_counter(tmp_path) == {"duplicate": 2, "boundary": 1}
+    Read-modify-write on a JSON file lost 194 of 200 increments across eight
+    threads. The tally is the one number the user sees, so it has to hold.
+    """
+    import concurrent.futures
 
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(lambda _: report.bump(indexed, "duplicate"), range(200)))
 
-def test_reset_clears_the_counter(tmp_path):
-    report.bump(tmp_path, "duplicate")
-    report.reset_counter(tmp_path)
-
-    assert report.read_counter(tmp_path) == {"duplicate": 0, "boundary": 0}
+    assert report.read_counter(indexed)["duplicate"] == 200
 
 
 def test_summary_line_states_zero_honestly():

--- a/tests/guard/test_schema.py
+++ b/tests/guard/test_schema.py
@@ -48,11 +48,19 @@ def test_two_repositories_do_not_share_a_cache_entry(tmp_path):
     assert schema.index_path(first) != schema.index_path(second)
 
 
-def test_the_counter_lives_beside_the_index(tmp_path):
-    """One directory for the guard's state, not two."""
+def test_the_counter_lives_inside_the_index(tmp_path):
+    """Not beside it. A JSON file next to the database lost 194 of 200
+    concurrent increments; the tally is now a row the database updates
+    atomically."""
     from drift.guard import report
 
-    assert report.counter_path(tmp_path).parent == schema.index_path(tmp_path).parent
+    conn = schema.create(tmp_path)
+    schema.initialize(conn)
+    conn.close()
+    report.bump(tmp_path, "duplicate")
+
+    assert not (schema.state_dir(tmp_path) / "session_counter.json").exists()
+    assert report.read_counter(tmp_path)["duplicate"] == 1
 
 
 def test_wrong_schema_version_is_not_usable(tmp_path):


### PR DESCRIPTION
The hooks reference says PostToolUse *"fires concurrently when Claude makes parallel tool calls"*. The tally was a JSON file updated by read-modify-write, so those calls overwrote each other.

Measured — 200 increments across eight threads:

```
counter ended at 6 — 194 lost
```

**This is the one number the user sees**, and G7 is named *counter honesty*. The gate only ever checked that an increment needs a real hit behind it. It never ran two at once.

Worse: amphetamin ([#777](https://github.com/mick-gsk/drift/pull/777)) tells the model to *"issue independent tool calls in one batch"* — the feature that most encourages the exact condition that breaks the counter.

## The fix

The tally moves into the index database as two rows in `meta`, incremented by a single atomic statement:

```sql
INSERT INTO meta (key, value) VALUES (?, ?)
ON CONFLICT(key) DO UPDATE SET value = CAST(CAST(value AS INTEGER) + ? AS TEXT)
```

The database is already open on this code path, so the change costs nothing and removes the file entirely.

```
200 increments across eight threads -> 200
```

## One contract narrows, deliberately

Without an index there is no counting. That is correct rather than a regression: `bump` is only reached after `_open_index` succeeds, and a tally without an index would be a number the guard never earned. Two tests state it — one that no index means no count, one that the index-backed counter holds under eight threads.

## How this was found

By asking what scale had never been varied. Fixture → real repositories found four defects; CLI → whole hook found the honest latency; small → large repository confirmed it holds. **Sequential → concurrent** was the one left, and it took one measurement.

## Verification

175 guard tests (2 new), all nine gates, `ruff` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)