### PR TITLE
fix(guard): import edges outlived the imports that created them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Short version: Drift installs as a Claude Code plugin and works inside the agent
 - stop build scripts counting as source, and measure the boundary
 - make the slash commands answer to the names the docs promise
 - the session tally lost 97 % of its increments under concurrency
+- import edges outlived the imports that created them
 
 ## [2.51.1] - 2026-05-04
 

--- a/src/drift/guard/build.py
+++ b/src/drift/guard/build.py
@@ -254,7 +254,7 @@ def build_full(repo_root: pathlib.Path) -> dict:
     known_dirs = {dir_of(rel) for rel, _ in collected}
 
     package_cache: dict[str, str] = {}
-    edge_counts: dict[tuple[str, str], int] = {}
+    edge_rows: set[tuple[str, str, str]] = set()
     symbol_rows: list[tuple] = []
     file_rows: list[tuple] = []
     now = time.time()
@@ -273,7 +273,7 @@ def build_full(repo_root: pathlib.Path) -> dict:
             dst_dir = import_to_dir(module, src_dir, known_dirs, path.suffix)
             if dst_dir is None or dst_dir == src_dir:
                 continue
-            edge_counts[(src_dir, dst_dir)] = edge_counts.get((src_dir, dst_dir), 0) + 1
+            edge_rows.add((rel, src_dir, dst_dir))
 
     conn.executemany(
         "INSERT INTO files (path, sha256, indexed_at, package_root) VALUES (?, ?, ?, ?)",
@@ -285,8 +285,8 @@ def build_full(repo_root: pathlib.Path) -> dict:
         symbol_rows,
     )
     conn.executemany(
-        "INSERT INTO import_edges (src_dir, dst_dir, count) VALUES (?, ?, ?)",
-        [(src, dst, count) for (src, dst), count in edge_counts.items()],
+        "INSERT INTO import_edges (path, src_dir, dst_dir) VALUES (?, ?, ?)",
+        sorted(edge_rows),
     )
     conn.execute("INSERT OR REPLACE INTO meta (key, value) VALUES ('built_at', ?)", (str(now),))
     conn.commit()
@@ -295,7 +295,7 @@ def build_full(repo_root: pathlib.Path) -> dict:
     return {
         "files": len(file_rows),
         "symbols": len(symbol_rows),
-        "edges": len(edge_counts),
+        "edges": len({(src, dst) for _, src, dst in edge_rows}),
         "elapsed_ms": round((time.perf_counter() - started) * 1000.0, 2),
     }
 
@@ -310,6 +310,11 @@ def update_file(repo_root: pathlib.Path, rel_path: str) -> None:
     path = repo_root / rel_path
     conn.execute("DELETE FROM symbols WHERE path = ?", (rel_path,))
     conn.execute("DELETE FROM files WHERE path = ?", (rel_path,))
+    # The file's edges go with it. As an aggregate these could only grow: five
+    # re-indexings of one unchanged file took a count from 2 to 12, and an
+    # import removed from the last file that declared it left the row behind,
+    # silencing that crossing for good.
+    conn.execute("DELETE FROM import_edges WHERE path = ?", (rel_path,))
 
     if path.exists():
         try:
@@ -336,9 +341,8 @@ def update_file(repo_root: pathlib.Path, rel_path: str) -> None:
             if dst_dir is None or dst_dir == src_dir:
                 continue
             conn.execute(
-                "INSERT INTO import_edges (src_dir, dst_dir, count) VALUES (?, ?, 1)"
-                " ON CONFLICT(src_dir, dst_dir) DO UPDATE SET count = count + 1",
-                (src_dir, dst_dir),
+                "INSERT OR IGNORE INTO import_edges (path, src_dir, dst_dir) VALUES (?, ?, ?)",
+                (rel_path, src_dir, dst_dir),
             )
 
     conn.commit()

--- a/src/drift/guard/schema.py
+++ b/src/drift/guard/schema.py
@@ -9,7 +9,11 @@ import sqlite3
 
 #: 2 added `files.package_root`. A symbol in one package of a workspace does
 #: not duplicate a symbol in another, and the guard could not tell before.
-SCHEMA_VERSION = 2
+#: 3 attributed import edges to the file that declares them. As an aggregate
+#: they could only ever grow: removing the last import that created an edge
+#: left the row behind, and the boundary signal went permanently silent for a
+#: crossing that had become novel again.
+SCHEMA_VERSION = 3
 
 _TABLES = """
 CREATE TABLE IF NOT EXISTS meta (
@@ -31,11 +35,12 @@ CREATE TABLE IF NOT EXISTS symbols (
     line      INTEGER NOT NULL
 );
 CREATE TABLE IF NOT EXISTS import_edges (
+    path    TEXT NOT NULL,
     src_dir TEXT NOT NULL,
     dst_dir TEXT NOT NULL,
-    count   INTEGER NOT NULL,
-    PRIMARY KEY (src_dir, dst_dir)
+    PRIMARY KEY (path, src_dir, dst_dir)
 );
+CREATE INDEX IF NOT EXISTS idx_edges_src ON import_edges(src_dir);
 CREATE INDEX IF NOT EXISTS idx_symbols_norm ON symbols(norm_name);
 CREATE INDEX IF NOT EXISTS idx_symbols_sig  ON symbols(sig_hash);
 CREATE INDEX IF NOT EXISTS idx_symbols_path ON symbols(path);

--- a/tests/guard/test_build.py
+++ b/tests/guard/test_build.py
@@ -135,3 +135,39 @@ def test_staleness_sample_spans_a_medium_sized_index(tmp_path):
     conn = schema.connect(tmp_path)
 
     assert build.is_stale(tmp_path, conn) is True
+
+
+def test_re_indexing_a_file_does_not_multiply_its_edges(sample_repo):
+    """Five re-indexings of one unchanged file took a count from 2 to 12."""
+    build.build_full(sample_repo)
+    conn = schema.connect(sample_repo)
+    before = conn.execute("SELECT COUNT(*) FROM import_edges").fetchone()[0]
+    conn.close()
+
+    for _ in range(5):
+        build.update_file(sample_repo, "src/api/routes.py")
+
+    conn = schema.connect(sample_repo)
+    assert conn.execute("SELECT COUNT(*) FROM import_edges").fetchone()[0] == before
+    conn.close()
+
+
+def test_removing_an_import_removes_its_edge(sample_repo):
+    """A crossing that stopped existing has to become novel again.
+
+    As an aggregate the row survived its last declaring import, so the guard
+    went permanently silent about a boundary it should announce.
+    """
+    from drift.guard import lookup
+
+    build.build_full(sample_repo)
+    (sample_repo / "src" / "api" / "routes.py").write_text(
+        "def register():\n    pass\n", encoding="utf-8"
+    )
+    build.update_file(sample_repo, "src/api/routes.py")
+
+    conn = schema.connect(sample_repo)
+    hits = lookup.find_novel_edges(conn, "src/api/routes.py", ["src.services.user_service"])
+    conn.close()
+
+    assert hits, "the edge outlived the import that created it"


### PR DESCRIPTION
Two defects from one cause. `import_edges` was an aggregate with no memory of which file contributed what, so it could only ever grow.

## The visible one

Re-indexing a single unchanged file five times:

```
count: 2 -> 12
```

Every PostToolUse added the same edges again. Harmless in itself — only existence is ever read — but it meant the column was fiction.

## The one that mattered

Removing the last import that created an edge **left the row behind**.

```
before removal:  src/api -> src/services
after removal:   src/api -> src/services   (still there)
announced as novel again?  NO
```

So re-introducing that crossing would never be announced again. A false negative that never heals, in a signal whose entire job is to notice a first-ever crossing — and silence is this guard's normal state, so nobody would ever have noticed it was broken.

## The fix

Edges are attributed to the file that declares them: one row per file per edge, deleted with the file exactly as symbols already were. The `count` column is gone; it was never read by anything.

```
after removal:  src/api -> src/services announced as novel again  ✓
after 5 re-indexings:  no duplicate rows  ✓
```

Schema goes to 3. SessionStart already treats an unreadable schema as stale ([#787](https://github.com/mick-gsk/drift/pull/787)), so an installed guard rebuilds itself on the next session without anyone doing anything.

## How this was found

By asking which scale had never been varied. **Time** was the last one — not a bigger repository or another language, but the same repository edited over and over, which is the only condition a real session actually produces.

| scale change | result |
|---|---|
| fixture → real repositories | four defects |
| CLI call → whole hook | honest latency |
| small → 2169 files | held |
| sequential → concurrent | 97 % of the tally lost |
| **one build → many edits** | **edges never died** |

## Verification

177 guard tests (2 new), all nine gates, flask 4.8 %, gin 2.0 %, ripgrep 7.3 % unchanged, `ruff` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)