### PR TITLE
fix(guard): stop indexing nested checkouts and other people's build output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Short version: Drift installs as a Claude Code plugin and works inside the agent
 - make the slash commands answer to the names the docs promise
 - the session tally lost 97 % of its increments under concurrency
 - import edges outlived the imports that created them
+- stop indexing nested checkouts and other people's build output
 
 ## [2.51.1] - 2026-05-04
 

--- a/src/drift/guard/build.py
+++ b/src/drift/guard/build.py
@@ -25,6 +25,17 @@ SKIP_DIRS = {
     ".tox",
     ".mypy_cache",
     ".pytest_cache",
+    # The list stayed Python-and-npm while the guard grew into Go, Rust, the
+    # JVM and C#. Each of these holds code nobody in the repository wrote.
+    "vendor",
+    "target",
+    "obj",
+    ".gradle",
+    ".next",
+    "Pods",
+    # A Claude Code plugin has no business indexing Claude Code's own state,
+    # least of all the worktrees it parks there.
+    ".claude",
 }
 
 
@@ -127,16 +138,40 @@ def import_to_dir(
     return module_to_dir(specifier, known_dirs)
 
 
+def _nested_checkout_prefixes(repo_root: pathlib.Path) -> tuple[str, ...]:
+    """Paths below the root that are their own git checkout.
+
+    A worktree, a submodule and a vendored clone are all somebody else's source
+    tree. A nested `.git` is what the three have in common, so one rule covers
+    them instead of a list of directory names guessed in advance — worktrees
+    mark themselves with a `.git` file, clones and submodules with a directory.
+    """
+    prefixes: list[str] = []
+    for marker in repo_root.rglob(".git"):
+        parent = marker.parent
+        if parent == repo_root:
+            continue
+        rel = parent.relative_to(repo_root).as_posix()
+        # Anything already inside a known checkout needs no second entry.
+        if not any(rel == seen or rel.startswith(f"{seen}/") for seen in prefixes):
+            prefixes.append(rel)
+    return tuple(prefixes)
+
+
 def _iter_source_files(repo_root: pathlib.Path):
+    nested = _nested_checkout_prefixes(repo_root)
     for path in sorted(repo_root.rglob("*")):
         if path.suffix not in extract.GUARDED_SUFFIXES:
             continue
         rel = path.relative_to(repo_root)
         if any(part in SKIP_DIRS for part in rel.parts):
             continue
+        posix = rel.as_posix()
+        if any(posix.startswith(f"{prefix}/") for prefix in nested):
+            continue
         if not path.is_file():
             continue
-        yield rel.as_posix(), path
+        yield posix, path
 
 
 def _sha256(path: pathlib.Path) -> str:

--- a/tests/guard/test_build.py
+++ b/tests/guard/test_build.py
@@ -171,3 +171,88 @@ def test_removing_an_import_removes_its_edge(sample_repo):
     conn.close()
 
     assert hits, "the edge outlived the import that created it"
+
+
+def test_nested_repositories_are_not_this_repository(sample_repo):
+    """A worktree, submodule or vendored clone is somebody else's source.
+
+    Measured on drift itself: 1041 of 2169 indexed files — 48 % — were copies
+    of the repository under `.claude/worktrees/`, and the build took 5400 ms
+    instead of 4216 ms. Anything that enumerates the index rather than
+    answering one per-edit question then sees every finding twice. See #797.
+
+    A nested `.git` is what worktrees, submodules and vendored clones have in
+    common, so one rule covers all three instead of a list of names guessed in
+    advance. Worktrees mark themselves with a `.git` file, clones with a
+    directory; both count.
+    """
+    nested = sample_repo / "vendored" / "otherlib"
+    (nested / ".git").mkdir(parents=True)
+    (nested / "copy.py").write_text(
+        "def validate_token(token, audience):\n    return True\n", encoding="utf-8"
+    )
+    worktree = sample_repo / ".worktrees" / "wip"
+    worktree.mkdir(parents=True)
+    (worktree / ".git").write_text("gitdir: ../../.git/worktrees/wip\n", encoding="utf-8")
+    (worktree / "copy.py").write_text(
+        "def validate_token(token, audience):\n    return True\n", encoding="utf-8"
+    )
+
+    build.build_full(sample_repo)
+    conn = schema.connect(sample_repo)
+    paths = {row[0] for row in conn.execute("SELECT path FROM files")}
+
+    assert not [p for p in paths if p.startswith("vendored/")], sorted(paths)
+    assert not [p for p in paths if p.startswith(".worktrees/")], sorted(paths)
+    assert "src/auth/tokens.py" in paths, "the repository's own source still indexes"
+
+
+def test_language_specific_build_output_is_skipped(sample_repo):
+    """The skip list has to keep up with the languages the guard reads.
+
+    It covered Python and npm while the guard grew into Go, Rust, the JVM and
+    C#. Their build output is code nobody in this repository wrote or edits.
+    """
+    for directory in ("vendor", "target", "obj", ".claude"):
+        out = sample_repo / directory / "pkg"
+        out.mkdir(parents=True)
+        (out / "generated.py").write_text("def widget_maker():\n    pass\n", encoding="utf-8")
+
+    build.build_full(sample_repo)
+    conn = schema.connect(sample_repo)
+    paths = {row[0] for row in conn.execute("SELECT path FROM files")}
+
+    assert not [p for p in paths if "generated.py" in p], sorted(paths)
+
+
+def test_a_copied_tree_does_not_silence_the_guard(sample_repo):
+    """The consequence #797 is actually about, asserted end to end.
+
+    A copy that carries its own manifest is already harmless: `_first_real_match`
+    filters candidates by package root before it counts them, so such a copy was
+    never a candidate. A copy *without* one — a `cp -r`, a backup directory, a
+    worktree of a project whose root has no manifest — inherits the parent's
+    package root and does count. Three of those plus the original is four
+    definitions, one above the ceiling at which a repeated name stops being
+    reported, and the duplicate the guard exists to catch disappears.
+
+    Verified against pristine `origin/main` before this fix: 4 files indexed,
+    duplicate reported False. With the fix: 1 file indexed, reported True.
+    """
+    from drift.guard import extract, lookup
+
+    for i in range(3):
+        copy = sample_repo / ".worktrees" / f"wt{i}" / "src" / "auth"
+        copy.mkdir(parents=True)
+        (sample_repo / ".worktrees" / f"wt{i}" / ".git").write_text("gitdir: x\n", encoding="utf-8")
+        (copy / "tokens.py").write_text(
+            "def validate_token(token, audience):\n    return True\n", encoding="utf-8"
+        )
+
+    build.build_full(sample_repo)
+    conn = schema.connect(sample_repo)
+    symbols, _ = extract.extract("def validate_token(token, audience):\n    return True\n", ".py")
+
+    hits = lookup.find_duplicates(conn, "src/api/schemas.py", symbols)
+
+    assert hits, "the guard must still report the duplicate it was built to catch"

--- a/tests/guard/test_hooks.py
+++ b/tests/guard/test_hooks.py
@@ -230,25 +230,40 @@ def test_the_guard_imports_only_the_standard_library():
     assert result.stdout.strip() == "ok"
 
 
-def test_bin_wrapper_works_without_an_installed_package():
+def test_bin_wrapper_works_without_an_installed_package(sample_repo):
     """`/drift:doctor` calls `drift-guard` as a bare command; bin/ makes that real.
 
     Claude Code puts a plugin's bin/ on PATH. Without this wrapper the two slash
     commands only work for users who separately ran `pip install drift-analyzer`.
+
+    The wrapper builds the index and then reports on it, both in a bare
+    environment. It used to run `doctor` alone against the checkout itself,
+    which passes only where a stray `.drift/` happens to sit next to the
+    source: `_bare_env()` keeps `DRIFT_CACHE_HOME`, the fixture points it at an
+    empty per-test directory, and `doctor` exits 1 on a missing index. On a
+    fresh clone — the state every new contributor is in — that test failed.
     """
     wrapper = HOOKS.parent / "bin" / "drift-guard"
 
     assert wrapper.exists()
     assert os.access(wrapper, os.X_OK), "bin/drift-guard must be executable"
 
+    built = subprocess.run(
+        [str(wrapper), "--repo", str(sample_repo), "build"],
+        capture_output=True,
+        text=True,
+        env=_bare_env(),
+    )
+    assert built.returncode == 0, built.stderr
+
     result = subprocess.run(
-        [str(wrapper), "--repo", str(HOOKS.parent), "doctor"],
+        [str(wrapper), "--repo", str(sample_repo), "doctor"],
         capture_output=True,
         text=True,
         env=_bare_env(),
     )
 
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 0, result.stdout + result.stderr
     assert "index" in result.stdout
 
 


### PR DESCRIPTION
Closes #797.

## The measurement

Full build of this repository, same harness, pristine `main` against this branch:

| | files | symbols | edges | build |
|---|---|---|---|---|
| before | 2169 | 12851 | 94 | 5400 ms |
| after | **1128** | **6658** | 45 | **4216 ms** |

**1041 of 2169 indexed files — 48 % — were copies of this repository** under `.claude/worktrees/`. Names appearing in more than three distinct paths: 299 before, 49 after.

## The fix

Two rules:

1. **A directory below the root holding a `.git` entry is somebody else's source tree.** Worktrees mark themselves with a `.git` file, clones and submodules with a directory — one rule covers all three instead of a list of directory names guessed in advance.
2. **`SKIP_DIRS` catches up with the languages the guard grew into**: `vendor`, `target`, `obj`, `.gradle`, `.next`, `Pods`, and `.claude` — a Claude Code plugin has no business indexing Claude Code's own state.

## What the consequence actually is

I first claimed in #797 that the ceiling in `MAX_DUPLICATE_OCCURRENCES` would be crossed by every symbol, so the guard would go quiet on any repository carrying a worktree. That was derived from reading the code rather than running it, and it is wrong — [corrected here](https://github.com/mick-gsk/drift/issues/797#issuecomment-5128317972). `_first_real_match` filters candidates by package root *before* it counts them, so a copy carrying its own manifest was never a candidate.

The real edge is narrower and verified end to end. A copy **without** a manifest — a `cp -r`, a backup directory, a worktree of a project whose root has none — inherits the parent's package root and does count:

```
pristine main:  4 files indexed  ->  guard reports the duplicate: False
this branch:    1 file  indexed  ->  guard reports the duplicate: True
```

Three copies plus the original is four definitions, one above the ceiling. The duplicate the guard exists to catch disappears, and silence is indistinguishable from a guard that found nothing.

## Also in here: a test that could not pass on a fresh clone

`test_bin_wrapper_works_without_an_installed_package` ran `doctor` against the checkout and asserted exit 0. `_bare_env()` keeps `DRIFT_CACHE_HOME`, the autouse fixture points it at an empty per-test directory, and `doctor` exits 1 on a missing index — so it passed only where a stray `.drift/` happened to sit next to the source. On a fresh clone, which is the state every new contributor starts in, it failed.

It now builds through the wrapper before reporting through it: more of the wrapper covered, nothing ambient depended on.

## Verified

- 3186 passed, 4 skipped on this branch (`-m "not slow"`)
- `ruff check src tests` clean · `mypy src` clean, 353 files
- `tests/guard` — 184 passed on a checkout with no `.drift/` present
- One unrelated failure, `test_integrations.py::TestRunCommand::test_successful_command`, is environmental: it invokes bare `python`, which does not exist on the PATH of the isolated worktree this was verified in (exit 127, `command not found`)

Developed in a separate git worktree because another session was editing the main checkout concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)