### PR TITLE
feat(guard): let doctor say something true on the first run

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -37,8 +37,13 @@ if [ -f ".venv/Scripts/python.exe" ]; then
     PYTHON=".venv/Scripts/python.exe"
 elif [ -f ".venv/bin/python" ]; then
     PYTHON=".venv/bin/python"
-else
+elif command -v python >/dev/null 2>&1; then
     PYTHON="python"
+else
+    # macOS ships python3 and no `python`. Without this the hook warns on
+    # every commit made outside an activated venv, which is where a new
+    # contributor makes their first one.
+    PYTHON="python3"
 fi
 
 # Run the integration script.  A non-zero exit means a real error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ Short version: Drift installs as a Claude Code plugin and works inside the agent
 - guard Rust, and stop conflating packages in a workspace
 - guard Java and Kotlin
 - guard C#
+- let `drift-guard doctor` name what is already defined twice, so the first run says something true
 
 ### Fixed
 
+- Stop assuming a command named `python` exists; three tests and the post-commit hook failed on any machine without an activated venv
 - Spread stale-index samples across the full indexed path range
 - Hook output now reaches the model. The hooks printed findings to stdout and exited 0, which for `PreToolUse` and `PostToolUse` reaches the transcript only — the guard's findings would never have arrived. Output goes through `hookSpecificOutput.additionalContext`, with the session tally on `systemMessage`
 - `schema.connect()` no longer advertises `Connection | None` for writers that cannot fail; readers use `connect()`, writers use `create()`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,17 @@
 
 <sub>Not a mock-up — `bash demos/guard-in-30-seconds.sh` runs exactly this on your machine, in under a second.</sub>
 
-Restart Claude Code, then run `/drift:doctor`. Those two lines are the whole
+Restart Claude Code, then run `/drift:doctor` — it checks the install and, from
+the index it just built, names what is already defined twice in your repository:
+
+```text
+[x] index holds 1128 file(s)
+
+5 name(s) already defined in more than one place:
+  - _finding_key: scripts/ecosystem_check.py, scripts/triage_findings.py, src/drift/incremental.py
+```
+
+Those two lines are the whole
 install: the guard imports nothing but the standard library and runs from the
 plugin itself, so there is no `pip install`, no dependency to resolve and
 nothing to configure. It writes **nothing into your repositories** — the index

--- a/docs-site/claude-code-plugin.md
+++ b/docs-site/claude-code-plugin.md
@@ -103,7 +103,7 @@ it. Nothing is written into the repository being analysed.
 
 | Command | Purpose |
 |---|---|
-| `/drift:doctor` | Check that the guard is installed, indexed and answering |
+| `/drift:doctor` | Check the install, and name what is already defined twice |
 | `/drift:stats` | Show what the guard caught this session |
 
 Both are thin wrappers around `drift-guard doctor` and `drift-guard stats`,
@@ -114,10 +114,12 @@ which you can also run directly.
 **`/drift:doctor` shows `[ ]` for the index.** Run `drift-guard build` in the
 repository root. A full build of a 344-file repository takes about 6 seconds.
 
-**The guard never says anything.** That is the expected case for most edits.
-To confirm it is alive, create a Python file containing a function whose name
-already exists elsewhere in the repository — the report should appear right
-after the write.
+**The guard never says anything.** That is the expected case for most edits —
+measured at 0–5.6 % of files across five real repositories. Run `/drift:doctor`:
+it reads the same index and names what is already defined twice in your
+repository, so you can tell a quiet guard from a broken one without waiting.
+To see the live path fire, create a file containing a function whose name
+already exists elsewhere — the report appears right after the write.
 
 **Nothing loaded at all.** Confirm the hook scripts are executable
 (`chmod +x hooks/guard-*.sh`); Claude Code skips a hook whose script lacks the

--- a/src/drift/guard/__main__.py
+++ b/src/drift/guard/__main__.py
@@ -269,13 +269,32 @@ def _cmd_doctor(args) -> int:
     checks.append((usable, f"index schema version is {schema.SCHEMA_VERSION}"))
 
     file_count = 0
+    clusters: list[lookup.Cluster] = []
     if conn is not None and usable:
         file_count = conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
+        clusters = lookup.existing_duplicates(conn)
         conn.close()
     checks.append((file_count > 0, f"index holds {file_count} file(s)"))
 
     for ok, label in checks:
         print(f"[{'x' if ok else ' '}] {label}")
+
+    # Below the checks and deliberately outside the exit code: a repository
+    # that contains duplicates is a working guard, not a broken install.
+    #
+    # This is the one moment the guard can say something without waiting. It
+    # speaks on a few percent of edits by design, so a new user can work for
+    # days before hearing anything, and quiet-and-working is indistinguishable
+    # from broken. `doctor` is what the README tells them to run first.
+    if file_count > 0:
+        print()
+        if clusters:
+            print(f"{len(clusters)} name(s) already defined in more than one place:")
+            for cluster in clusters:
+                print(f"  - {cluster.display}: {', '.join(cluster.paths)}")
+        else:
+            print("no name is defined twice in this repository — nothing to reuse yet.")
+
     return 0 if all(ok for ok, _ in checks) else 1
 
 

--- a/src/drift/guard/lookup.py
+++ b/src/drift/guard/lookup.py
@@ -18,6 +18,13 @@ class Hit(NamedTuple):
     message: str
 
 
+class Cluster(NamedTuple):
+    """One name that is already defined in more than one place."""
+
+    display: str
+    paths: tuple[str, ...]
+
+
 #: Path segments whose contents repeat names on purpose. Measured against five
 #: real repositories: fastapi's `docs_src/` defines `Item` in over a hundred
 #: tutorial files, date-fns ships the same example under `cjs/`, `cts/`, `esm/`,
@@ -139,6 +146,55 @@ def find_duplicates(
             )
         )
     return hits
+
+
+def existing_duplicates(conn: sqlite3.Connection, limit: int = 5) -> list[Cluster]:
+    """Names already defined more than once in the tree as it stands today.
+
+    The guard is quiet by design, and measurably so: replayed over five real
+    repositories it speaks on 0–5.6 % of files. That is the correct behaviour
+    and it has a cost — someone who installs the plugin may work for days
+    before hearing anything, and a guard that is working and quiet looks
+    exactly like a guard that is broken. This reads what the index already
+    holds, so the first run can say something true about the reader's own code
+    instead of asking for patience.
+
+    Every rule the hot path applies is applied here too: stopwords, minimum
+    name length, dunder names, kind groups, package boundaries, directories
+    that repeat by design, and the ceiling above which a repeated name is a
+    convention rather than an accident. A report that flagged what the guard
+    ignores would promise findings the guard never delivers.
+    """
+    rows = conn.execute(
+        "SELECT s.norm_name, s.name, s.path, s.kind, COALESCE(f.package_root, '.')"
+        " FROM symbols s LEFT JOIN files f ON f.path = s.path"
+        " ORDER BY s.norm_name, s.path, s.line"
+    )
+
+    groups: dict[tuple[str, str, str], list[tuple[str, str]]] = {}
+    for norm_name, name, path, kind, package in rows:
+        if norm_name in extract.STOPWORDS:
+            continue
+        if len(norm_name) < MIN_DUPLICATE_NAME_LENGTH:
+            continue
+        if name.startswith("__") and name.endswith("__"):
+            continue
+        group = _KIND_GROUP.get(kind)
+        if group is None or repeats_by_design(path):
+            continue
+        groups.setdefault((norm_name, group, package), []).append((path, name))
+
+    clusters: list[Cluster] = []
+    for members in groups.values():
+        paths = sorted({path for path, _ in members})
+        if not 2 <= len(paths) <= MAX_DUPLICATE_OCCURRENCES:
+            continue
+        clusters.append(Cluster(display=members[0][1], paths=tuple(paths)))
+
+    # Widest spread first, then alphabetical, so an unchanged index always
+    # answers the same way — a report that reshuffles is a report nobody trusts.
+    clusters.sort(key=lambda c: (-len(c.paths), c.display))
+    return clusters[:limit]
 
 
 def _first_real_match(

--- a/tests/guard/test_cli.py
+++ b/tests/guard/test_cli.py
@@ -109,3 +109,53 @@ def test_doctor_fails_without_an_index(sample_repo):
 
     assert result.returncode == 1
     assert "[ ]" in result.stdout
+
+
+def test_doctor_reports_duplicates_that_already_exist(sample_repo):
+    """The first run must say something true about the reader's own code.
+
+    `/drift:doctor` is what README.md tells a new user to run right after
+    installing. Reporting only that the plumbing works leaves them waiting for
+    a guard that speaks on a few percent of files.
+    """
+    (sample_repo / "src" / "api" / "schemas.py").write_text(
+        "def validate_token(token, audience):\n    return True\n", encoding="utf-8"
+    )
+    build.build_full(sample_repo)
+
+    result = _run("doctor", "--repo", str(sample_repo))
+
+    assert "validate_token" in result.stdout
+    assert "src/auth/tokens.py" in result.stdout
+
+
+def test_doctor_stays_green_when_duplicates_exist(sample_repo):
+    """Findings are information, not a broken installation.
+
+    The exit code answers one question — is the guard working — and a
+    repository with duplicates in it is precisely a working guard.
+    """
+    (sample_repo / "src" / "api" / "schemas.py").write_text(
+        "def validate_token(token, audience):\n    return True\n", encoding="utf-8"
+    )
+    build.build_full(sample_repo)
+
+    assert _run("doctor", "--repo", str(sample_repo)).returncode == 0
+
+
+def test_doctor_says_so_when_it_found_nothing(sample_repo):
+    """Printing nothing would read as a step that did not run."""
+    build.build_full(sample_repo)
+
+    result = _run("doctor", "--repo", str(sample_repo))
+
+    assert "no name is defined twice" in result.stdout
+
+
+def test_doctor_without_an_index_reports_no_findings(sample_repo):
+    """Nothing to read from, so nothing may be claimed about the repository."""
+    result = _run("doctor", "--repo", str(sample_repo))
+
+    assert result.returncode == 1
+    assert "defined twice" not in result.stdout
+    assert "more than one place" not in result.stdout

--- a/tests/guard/test_demo.py
+++ b/tests/guard/test_demo.py
@@ -62,4 +62,4 @@ def test_demo_never_touches_the_real_index_cache():
     source = DEMO.read_text(encoding="utf-8")
 
     assert "export DRIFT_CACHE_HOME=" in source
-    assert 'trap ' in source and "rm -rf" in source, "the temporary tree is cleaned up"
+    assert "trap " in source and "rm -rf" in source, "the temporary tree is cleaned up"

--- a/tests/guard/test_lookup.py
+++ b/tests/guard/test_lookup.py
@@ -281,3 +281,87 @@ def test_build_scripts_are_configuration_not_source():
     assert lookup.repeats_by_design("android-test/build.gradle.kts")
     assert lookup.repeats_by_design("project/build.gradle")
     assert not lookup.repeats_by_design("src/main/kotlin/okhttp3/Request.kt")
+
+
+def test_existing_duplicates_finds_nothing_in_a_clean_tree(sample_repo):
+    conn = _conn(sample_repo)
+
+    assert lookup.existing_duplicates(conn) == []
+
+
+def test_existing_duplicates_reports_a_name_defined_in_two_files(sample_repo):
+    (sample_repo / "src" / "api" / "schemas.py").write_text(
+        "def validate_token(token, audience):\n    return True\n", encoding="utf-8"
+    )
+    conn = _conn(sample_repo)
+
+    clusters = lookup.existing_duplicates(conn)
+
+    assert len(clusters) == 1
+    assert clusters[0].display == "validate_token"
+    assert set(clusters[0].paths) == {"src/auth/tokens.py", "src/api/schemas.py"}
+
+
+def test_existing_duplicates_crosses_the_language_boundary(sample_repo):
+    """Same normalisation as the live guard: Go finds Python."""
+    (sample_repo / "src" / "api" / "handler.go").write_text(
+        "package api\n\nfunc ValidateToken(token string) bool {\n\treturn true\n}\n",
+        encoding="utf-8",
+    )
+    conn = _conn(sample_repo)
+
+    clusters = lookup.existing_duplicates(conn)
+
+    assert len(clusters) == 1
+    assert set(clusters[0].paths) == {"src/auth/tokens.py", "src/api/handler.go"}
+
+
+def test_existing_duplicates_obeys_the_rules_the_live_guard_obeys(sample_repo):
+    """A report that flags what the guard ignores promises findings it never delivers.
+
+    Test files restate names by design and stopwords are not duplication —
+    both are suppressed on the hot path, so both are suppressed here.
+    """
+    (sample_repo / "tests").mkdir(exist_ok=True)
+    (sample_repo / "tests" / "test_tokens.py").write_text(
+        "def validate_token(a, b):\n    return True\n", encoding="utf-8"
+    )
+    (sample_repo / "src" / "api" / "b.py").write_text(
+        "def run():\n    return 1\n", encoding="utf-8"
+    )
+    (sample_repo / "src" / "db" / "c.py").write_text("def run():\n    return 1\n", encoding="utf-8")
+    conn = _conn(sample_repo)
+
+    flagged = {c.display for c in lookup.existing_duplicates(conn)}
+
+    assert "validate_token" not in flagged, "a test file must not create a duplicate"
+    assert "run" not in flagged, "stopword names are never duplication"
+
+
+def test_existing_duplicates_stops_at_the_convention_ceiling(sample_repo):
+    """Above the ceiling a repeated name is the shape of the codebase.
+
+    The same rule the hot path applies, for the same reason: saying it is worse
+    than saying nothing.
+    """
+    for name in ("api", "db", "services", "auth"):
+        target = sample_repo / "src" / name / "widget.py"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("def widget_factory(a):\n    return a\n", encoding="utf-8")
+    conn = _conn(sample_repo)
+
+    assert "widget_factory" not in {c.display for c in lookup.existing_duplicates(conn)}
+
+
+def test_existing_duplicates_is_stable_and_bounded(sample_repo):
+    for i in range(4):
+        for where in ("api", "db"):
+            target = sample_repo / "src" / where / f"dup{i}.py"
+            target.write_text(f"def widget_factory_{i}(a):\n    return a\n", encoding="utf-8")
+    conn = _conn(sample_repo)
+
+    first = lookup.existing_duplicates(conn, limit=2)
+    second = lookup.existing_duplicates(conn, limit=2)
+
+    assert len(first) == 2
+    assert first == second, "an unchanged index must not reshuffle its answer"

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -13,6 +13,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -90,7 +91,7 @@ class TestRunCommand:
         from drift.integrations.runner import run_command
 
         result = run_command(
-            ["python", "-c", "print('hello')"],
+            [sys.executable, "-c", "print('hello')"],
             repo_path=tmp_path,
             timeout_seconds=10,
         )
@@ -102,7 +103,7 @@ class TestRunCommand:
         from drift.integrations.runner import run_command
 
         result = run_command(
-            ["python", "-c", "import sys; print(sys.argv[1])", "{repo_path}"],
+            [sys.executable, "-c", "import sys; print(sys.argv[1])", "{repo_path}"],
             repo_path=tmp_path,
             timeout_seconds=10,
         )
@@ -122,7 +123,7 @@ class TestRunCommand:
         from drift.integrations.runner import run_command
 
         result = run_command(
-            ["python", "-c", "import time; time.sleep(30)"],
+            [sys.executable, "-c", "import time; time.sleep(30)"],
             repo_path=tmp_path,
             timeout_seconds=1,
         )


### PR DESCRIPTION
## The problem this closes

The guard is quiet by design, and the README now measures how quiet: **0–5.6 % of files** across five real repositories. That is correct behaviour with a cost — a new user installs the plugin, works for a day, hears nothing, and cannot tell a working guard from a broken one.

Silence being indistinguishable from failure is the exact problem this project exists to attack. The plugin had it in its own onboarding.

## What changes

`/drift:doctor` is what README.md tells a new user to run first, and it reported only plumbing while sitting on an index that already knew something about their code:

```
[x] index present at ~/.cache/drift/drift-e7823d01e57356b2/index.db
[x] index schema version is 3
[x] index holds 1128 file(s)

5 name(s) already defined in more than one place:
  - _build_parser: scripts/brief_ab_study.py, scripts/mirror_ab_study.py, scripts/verify_gate_not_bypassed.py
  - _cohens_d: scripts/ab_harness.py, scripts/brief_ab_study.py, scripts/mirror_ab_study.py
  - _dispatch: scripts/make_launch_film.py, src/drift/retrieval/corpus_builder.py, src/drift/serve/a2a_router.py
  - _drift_analyze: scripts/ab_harness.py, scripts/generate_benchmark_baseline.py, scripts/repair_eval.py
  - _finding_key: scripts/ecosystem_check.py, scripts/triage_findings.py, src/drift/incremental.py
```

Real output from this repository, not a fixture. `_finding_key` living in two scripts *and* `src/drift/incremental.py` is worth someone's attention.

## Design

`existing_duplicates()` applies **every** rule the hot path applies — stopwords, minimum name length, dunder names, kind groups, package boundaries, directories that repeat by design, and the ceiling above which a repeated name is a convention. A report that flagged what the guard ignores would promise findings the guard never delivers, and the two halves would disagree about what "already exists" means. There is a test per rule.

It prints **below the checks and outside the exit code**. The exit code answers one question — is the guard working — and a repository with duplicates in it is precisely a working guard. Without an index it says nothing at all: nothing to read, therefore nothing that may be claimed.

Sorted widest-spread-first then alphabetical, because an unchanged index has to answer the same way twice.

No new command, no new dependency, no new hook. The surface stays where G4 put it.

## Also in here: two tests that could only pass on one machine

macOS ships `python3` and no `python`. Three tests in `test_integrations.py` invoked bare `python` through subprocess and failed with exit 127 on any machine without an activated venv — while the maintainer's shell resolved it and stayed green. A fresh clone is that machine, and it is where every new contributor starts. They now use `sys.executable`.

The post-commit hook made the same assumption in its fallback branch and warned on every commit outside an activated venv. It now falls back to `python3`.

This is the second instance of the same class this week — [#798](https://github.com/mick-gsk/drift/pull/798) fixed a test that passed only where a stray `.drift/` happened to sit beside the source.

## Verified

- **6978 passed, 6 skipped, 0 failed** (`-m "not slow"`) — first fully green run on a fresh checkout this week
- `tests/guard` — 194 passed
- `ruff check src tests` clean · `ruff format --check` clean · `mypy src` clean, 353 files
- Output above produced by running `doctor` against this repository

Developed in a separate git worktree; another session is editing the main checkout concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)