### PR TITLE
test: measure amphetamin's throughput instructions instead of asserting them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ benchmark_results/*
 !benchmark_results/drift_self.json
 !benchmark_results/pr_throughput_baseline.json
 !benchmark_results/guard_baseline.json
+# Every number in docs/amphetamin-instructions-pilot.md comes out of this file.
+# Untracked, that document is an assertion.
+!benchmark_results/amphetamin_instructions_pilot.json
 # Precision/recall baselines are cited as evidence from README.md and
 # docs/STUDY.md — they must stay tracked or those claims lose their artifact.
 !benchmark_results/*_precision_recall_baseline.json

--- a/benchmark_results/amphetamin_instructions_pilot.json
+++ b/benchmark_results/amphetamin_instructions_pilot.json
@@ -1,0 +1,292 @@
+{
+  "runs": 3,
+  "repo": "/private/tmp/claude-501/-Users-moritzbecker-mick-self-opt/393b17ec-62ff-4b5d-b5f4-b7411bb9598d/scratchpad/wt-amph",
+  "tasks": {
+    "map-modules": {
+      "without": {
+        "n": 2,
+        "rate_limited": 2,
+        "turns": {
+          "median": 12.0,
+          "min": 12,
+          "max": 12,
+          "samples": [
+            12,
+            12
+          ]
+        },
+        "tool_calls": {
+          "median": 9.0,
+          "min": 9,
+          "max": 9,
+          "samples": [
+            9,
+            9
+          ]
+        },
+        "repeat_reads": {
+          "median": 0.0,
+          "min": 0,
+          "max": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "ranged_reads": {
+          "median": 4.0,
+          "min": 4,
+          "max": 4,
+          "samples": [
+            4,
+            4
+          ]
+        },
+        "output_tokens": {
+          "median": 1540.5,
+          "min": 1481,
+          "max": 1600,
+          "samples": [
+            1600,
+            1481
+          ]
+        },
+        "api_ms": {
+          "median": 30181.5,
+          "min": 28952,
+          "max": 31411,
+          "samples": [
+            28952,
+            31411
+          ]
+        },
+        "cost_usd": {
+          "median": 0.47169725,
+          "min": 0.4649559999999999,
+          "max": 0.4784385000000001,
+          "samples": [
+            0.4784385000000001,
+            0.4649559999999999
+          ]
+        }
+      },
+      "with": {
+        "n": 2,
+        "rate_limited": 2,
+        "turns": {
+          "median": 12.0,
+          "min": 12,
+          "max": 12,
+          "samples": [
+            12,
+            12
+          ]
+        },
+        "tool_calls": {
+          "median": 9.0,
+          "min": 9,
+          "max": 9,
+          "samples": [
+            9,
+            9
+          ]
+        },
+        "repeat_reads": {
+          "median": 0.0,
+          "min": 0,
+          "max": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "ranged_reads": {
+          "median": 0.0,
+          "min": 0,
+          "max": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "output_tokens": {
+          "median": 1426.0,
+          "min": 1328,
+          "max": 1524,
+          "samples": [
+            1328,
+            1524
+          ]
+        },
+        "api_ms": {
+          "median": 114817.0,
+          "min": 26694,
+          "max": 202940,
+          "samples": [
+            202940,
+            26694
+          ]
+        },
+        "cost_usd": {
+          "median": 0.6016982500000001,
+          "min": 0.599527,
+          "max": 0.6038695000000001,
+          "samples": [
+            0.599527,
+            0.6038695000000001
+          ]
+        }
+      }
+    },
+    "find-symbol": {
+      "without": {
+        "n": 3,
+        "rate_limited": 3,
+        "turns": {
+          "median": 7,
+          "min": 6,
+          "max": 8,
+          "samples": [
+            8,
+            7,
+            6
+          ]
+        },
+        "tool_calls": {
+          "median": 4,
+          "min": 3,
+          "max": 4,
+          "samples": [
+            4,
+            4,
+            3
+          ]
+        },
+        "repeat_reads": {
+          "median": 0,
+          "min": 0,
+          "max": 0,
+          "samples": [
+            0,
+            0,
+            0
+          ]
+        },
+        "ranged_reads": {
+          "median": 0,
+          "min": 0,
+          "max": 0,
+          "samples": [
+            0,
+            0,
+            0
+          ]
+        },
+        "output_tokens": {
+          "median": 1166,
+          "min": 1062,
+          "max": 1696,
+          "samples": [
+            1166,
+            1696,
+            1062
+          ]
+        },
+        "api_ms": {
+          "median": 18989,
+          "min": 13623,
+          "max": 32702,
+          "samples": [
+            18989,
+            32702,
+            13623
+          ]
+        },
+        "cost_usd": {
+          "median": 0.270544,
+          "min": 0.269637,
+          "max": 0.302582,
+          "samples": [
+            0.270544,
+            0.302582,
+            0.269637
+          ]
+        }
+      },
+      "with": {
+        "n": 3,
+        "rate_limited": 3,
+        "turns": {
+          "median": 8,
+          "min": 6,
+          "max": 8,
+          "samples": [
+            8,
+            8,
+            6
+          ]
+        },
+        "tool_calls": {
+          "median": 4,
+          "min": 3,
+          "max": 5,
+          "samples": [
+            4,
+            5,
+            3
+          ]
+        },
+        "repeat_reads": {
+          "median": 0,
+          "min": 0,
+          "max": 0,
+          "samples": [
+            0,
+            0,
+            0
+          ]
+        },
+        "ranged_reads": {
+          "median": 0,
+          "min": 0,
+          "max": 0,
+          "samples": [
+            0,
+            0,
+            0
+          ]
+        },
+        "output_tokens": {
+          "median": 1413,
+          "min": 1067,
+          "max": 1422,
+          "samples": [
+            1422,
+            1413,
+            1067
+          ]
+        },
+        "api_ms": {
+          "median": 17589,
+          "min": 16396,
+          "max": 19689,
+          "samples": [
+            17589,
+            19689,
+            16396
+          ]
+        },
+        "cost_usd": {
+          "median": 0.285609,
+          "min": 0.274974,
+          "max": 0.2859515,
+          "samples": [
+            0.285609,
+            0.2859515,
+            0.274974
+          ]
+        }
+      }
+    }
+  }
+}

--- a/docs/amphetamin-instructions-pilot.md
+++ b/docs/amphetamin-instructions-pilot.md
@@ -1,0 +1,99 @@
+# Amphetamin's throughput instructions: what a pilot measurement found
+
+**Date:** 2026-07-30 · **Harness:** `scripts/gates/measure_amphetamin.py`
+**Raw data:** 10 sessions, 5 per arm across two tasks · Claude Code headless, `stream-json` transcripts
+
+Amphetamin ships two unlike things. The held stop is a mechanism with tests on
+both branches. The four throughput instructions are advice injected at session
+start, and README.md has said from the beginning that no speedup was measured.
+This is the measurement.
+
+## Method
+
+Same task, same corpus, run with and without the four instructions appended to
+the system prompt. Read-only work in a throwaway copy of this repository, so
+runs cannot diverge after the first edit. The instruction text is read out of
+`drift/guard/__main__.py` rather than restated, because measuring a copy would
+prove nothing about the mode.
+
+Counted from each transcript: assistant turns, tool calls, files read more than
+once, ranged reads, output tokens, cost. Tool calls sit beside turns so a drop
+in turns cannot be mistaken for the model doing less work.
+
+## Results
+
+### Task `map-modules` — "what is each module under src/drift/guard/ for?"
+
+| metric | without | with |
+|---|---|---|
+| turns | 12, 12 | 12, 12 |
+| tool calls | 9, 9 | 9, 9 |
+| repeat reads | 0, 0 | 0, 0 |
+| **ranged reads** | **4, 4** | **0, 0** |
+| output tokens | 1600, 1481 | 1328, 1524 |
+| cost (USD) | 0.478, 0.465 | 0.600, 0.604 |
+
+### Task `find-symbol` — "where is anything named *duplicate* defined?"
+
+| metric | without | with |
+|---|---|---|
+| turns | 8, 7, 6 | 8, 8, 6 |
+| tool calls | 4, 4, 3 | 4, 5, 3 |
+| repeat reads | 0, 0, 0 | 0, 0, 0 |
+| ranged reads | 0, 0, 0 | 0, 0, 0 |
+| output tokens | 1166, 1696, 1062 | 1422, 1413, 1067 |
+| cost (USD) | 0.271, 0.303, 0.270 | 0.286, 0.286, 0.275 |
+
+## What this shows
+
+**No effect on turns or tool calls.** Identical in the first task, fully
+overlapping ranges in the second. If the batching instruction changes anything,
+the change is smaller than the run-to-run spread at this sample size.
+
+**One instruction targets a behaviour that never happened.** "Do not re-read a
+file you already read this session" — repeat reads were **0 in all ten
+sessions, both arms**. There was nothing to prevent. That instruction cannot
+improve anything here because the baseline was already perfect.
+
+**One instruction moved the wrong way.** "Read the part you need" — the arm
+*with* the instruction did **fewer** ranged reads, 4 → 0. Two runs per arm is
+too little to call it harm, but it is not support either.
+
+**The instructions cost money.** Higher in both tasks: +26 % on `map-modules`,
++3 % on `find-symbol`. They are ~640 characters on every request, and the
+transcript shows that being paid for.
+
+## What this does not show
+
+It does not show the instructions have no effect. Five sessions per arm against
+a stochastic model cannot establish that, and this document should not be cited
+as if it could.
+
+It does not judge answer quality. Grading was left out deliberately: without a
+rubric, a mode that traded correctness for turns would score as an improvement.
+
+Every session was rate-limited, so wall-clock time is not reported.
+
+## What proving an effect would cost
+
+`find-symbol` turns ranged 6–8 across three runs. Detecting a 10 % change —
+roughly 0.7 turns — against that spread needs on the order of 30 sessions per
+arm. At the observed \$0.27–0.60 per session that is **\$40–70 per task**, plus
+hours of rate-limited waiting, for one metric on one corpus.
+
+## Recommendation
+
+Delete the four instructions and keep the mechanism.
+
+The cheap measurement found no benefit and a measurable cost. The expensive
+measurement that could still find a small benefit costs more than the benefit
+could plausibly be worth, and one of the four instructions is already known to
+address a non-problem. Amphetamin then describes exactly what it does: it holds
+one stop per session when the index recorded work left behind. That claim has
+tests. This one does not.
+
+Reproduce with:
+
+```bash
+python scripts/gates/measure_amphetamin.py --runs 3 --out results.json
+```

--- a/scripts/gates/measure_amphetamin.py
+++ b/scripts/gates/measure_amphetamin.py
@@ -1,0 +1,253 @@
+"""Does amphetamin's throughput advice actually change how a session runs?
+
+The mode ships two very different things. The held stop is a mechanism: it
+fires or it does not, and `tests/guard/test_amphetamin.py` covers both. The
+four throughput instructions are advice — nothing enforces them, and until now
+nothing measured them either. README.md said so plainly, which is honest and
+also an open question sitting in a shipped feature.
+
+This answers it the only way that counts: run the same task with and without
+the instructions, many times, and count what came out.
+
+    python scripts/gates/measure_amphetamin.py --runs 3 --out results.json
+
+What it measures, per session, from the `stream-json` transcript:
+
+* **turns** — assistant messages. The instruction "issue independent tool calls
+  in one batch" predicts fewer.
+* **tool_calls** — total tool uses. Batching does not reduce these; it packs
+  them into fewer turns. Reported so a drop in turns cannot be mistaken for
+  the model simply doing less.
+* **repeat_reads** — files read more than once. Directly targeted by "do not
+  re-read a file you already read".
+* **ranged_reads** — Read calls carrying offset/limit, targeted by "read the
+  part you need".
+* **output_tokens**, **duration_s** — what the user actually pays.
+
+Two things this deliberately does not do. It does not judge whether the answer
+was good; that would need a rubric and a grader, and a mode that trades
+correctness for turns would look like an improvement here. And it does not
+report a single number: with a handful of runs against a stochastic model the
+spread is the finding, so every metric comes back with its full sample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+
+#: Kept in sync with the constant the guard injects, by reading it rather than
+#: restating it — a measurement of a copy would prove nothing about the mode.
+GUARD_MAIN = pathlib.Path(__file__).resolve().parents[2] / "src" / "drift" / "guard" / "__main__.py"
+
+#: Read-only work. Anything that edits would make runs diverge after the first
+#: tool call, and then the arms are no longer comparable.
+TASKS = {
+    "map-modules": (
+        "In one sentence each, say what every module directly inside "
+        "src/drift/guard/ is responsible for. No preamble."
+    ),
+    "find-symbol": (
+        "List every place a function or class whose name mentions 'duplicate' "
+        "is defined under src/. Give file and line, nothing else."
+    ),
+}
+
+
+def instruction_text() -> str:
+    """The four instructions, lifted from the guard rather than retyped."""
+    source = GUARD_MAIN.read_text(encoding="utf-8")
+    match = re.search(r"AMPHETAMIN_TEXT = \((.*?)\n\)", source, re.DOTALL)
+    if match is None:  # pragma: no cover - the constant is covered by its own tests
+        raise SystemExit("AMPHETAMIN_TEXT not found in the guard; the harness is stale.")
+    return (
+        "".join(re.findall(r'"((?:[^"\\]|\\.)*)"', match.group(1)))
+        .encode()
+        .decode("unicode_escape")
+    )
+
+
+def _metrics(events: list[dict]) -> dict | None:
+    """Metrics for one session, or None when the session did not really run.
+
+    The first pilot recorded a rate-limited session as `turns=1, tool_calls=0,
+    output_tokens=0` and put it in the table beside real numbers, where it read
+    as a dramatic improvement. A harness that reports a failed run as a
+    measurement is worse than no harness, so a session counts only if it
+    finished successfully, and a session that waited on a rate limit has a
+    meaningless wall clock and says so.
+    """
+    turns = tool_calls = ranged_reads = 0
+    read_targets: list[str] = []
+    result: dict | None = None
+    rate_limited = False
+
+    for event in events:
+        if event.get("type") == "assistant":
+            turns += 1
+            for block in event.get("message", {}).get("content", []):
+                if block.get("type") != "tool_use":
+                    continue
+                tool_calls += 1
+                if block.get("name") == "Read":
+                    args = block.get("input", {})
+                    read_targets.append(str(args.get("file_path", "")))
+                    if args.get("offset") is not None or args.get("limit") is not None:
+                        ranged_reads += 1
+        elif event.get("type") == "rate_limit_event":
+            rate_limited = True
+        elif event.get("type") == "result":
+            result = event
+
+    if result is None or result.get("is_error") or result.get("subtype") != "success":
+        return None
+
+    usage = result.get("usage") or {}
+    return {
+        "turns": turns,
+        "tool_calls": tool_calls,
+        "repeat_reads": len(read_targets) - len(set(read_targets)),
+        "ranged_reads": ranged_reads,
+        "output_tokens": int(usage.get("output_tokens", 0)),
+        "cost_usd": float(result.get("total_cost_usd") or 0.0),
+        "api_ms": int(result.get("duration_api_ms") or 0),
+        "rate_limited": rate_limited,
+    }
+
+
+def run_once(task: str, repo: pathlib.Path, extra_prompt: str | None) -> dict | None:
+    """One headless session in a throwaway copy of the corpus."""
+    workdir = pathlib.Path(tempfile.mkdtemp())
+    try:
+        target = workdir / "repo"
+        shutil.copytree(repo, target, ignore=shutil.ignore_patterns(".git", ".venv", "__pycache__"))
+        argv = [
+            "claude",
+            "-p",
+            task,
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            # Read-only by tool policy rather than by plan mode: plan mode ends
+            # in an approval step, which would land in the turn count as an
+            # artefact of the harness instead of the behaviour being measured.
+            "--permission-mode",
+            "acceptEdits",
+            "--disallowedTools",
+            "Write,Edit,NotebookEdit,Bash",
+        ]
+        if extra_prompt:
+            argv += ["--append-system-prompt", extra_prompt]
+
+        started = time.monotonic()
+        proc = subprocess.run(
+            argv, cwd=target, capture_output=True, text=True, timeout=600, check=False
+        )
+        elapsed = time.monotonic() - started
+
+        events = []
+        for line in proc.stdout.splitlines():
+            try:
+                events.append(json.loads(line))
+            except ValueError:
+                continue
+        if not events:
+            print(f"    no transcript: {proc.stderr.strip()[:160]}", file=sys.stderr)
+            return None
+
+        result = _metrics(events)
+        if result is None:
+            print("    session did not complete; discarded", file=sys.stderr)
+            return None
+        # Wall clock is only comparable when nothing waited on a rate limit.
+        result["duration_s"] = None if result["rate_limited"] else round(elapsed, 1)
+        return result
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+def _summary(samples: list[dict], key: str) -> dict:
+    values = [s[key] for s in samples if s.get(key) is not None]
+    return {
+        "median": statistics.median(values) if values else None,
+        "min": min(values) if values else None,
+        "max": max(values) if values else None,
+        "samples": values,
+    }
+
+
+METRICS = (
+    "turns",
+    "tool_calls",
+    "repeat_reads",
+    "ranged_reads",
+    "output_tokens",
+    "api_ms",
+    "cost_usd",
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runs", type=int, default=3, help="Sessions per arm per task.")
+    parser.add_argument("--repo", default=".", help="Corpus to run against.")
+    parser.add_argument("--out", default=None, help="Write the raw result JSON here.")
+    args = parser.parse_args()
+
+    repo = pathlib.Path(args.repo).resolve()
+    instructions = instruction_text()
+    arms = {"without": None, "with": instructions}
+    results: dict = {"runs": args.runs, "repo": str(repo), "tasks": {}}
+
+    for task_name, task in TASKS.items():
+        print(f"\n=== {task_name} ===")
+        results["tasks"][task_name] = {}
+        for arm_name, extra in arms.items():
+            samples = []
+            for i in range(args.runs):
+                print(f"  {arm_name} {i + 1}/{args.runs} ...", flush=True)
+                sample = run_once(task, repo, extra)
+                if sample is not None:
+                    samples.append(sample)
+            results["tasks"][task_name][arm_name] = {
+                "n": len(samples),
+                "rate_limited": sum(1 for s in samples if s["rate_limited"]),
+                **{metric: _summary(samples, metric) for metric in METRICS},
+            }
+
+    print("\n" + "=" * 72)
+    for task_name, arms_result in results["tasks"].items():
+        print(f"\n{task_name}")
+        print(f"  {'metric':<15}{'without':>22}{'with':>22}")
+        for metric in METRICS:
+            a, b = arms_result["without"], arms_result["with"]
+            left = f"{a[metric]['median']} ({a[metric]['min']}–{a[metric]['max']})"
+            right = f"{b[metric]['median']} ({b[metric]['min']}–{b[metric]['max']})"
+            print(f"  {metric:<15}{left:>22}{right:>22}")
+        a, b = arms_result["without"], arms_result["with"]
+        print(
+            f"  n = {a['n']} / {b['n']} sessions completed"
+            f" (rate-limited: {a['rate_limited']} / {b['rate_limited']})"
+        )
+
+    print(
+        "\nRanges are min–max over the samples. Where they overlap, this run"
+        "\nfound no effect — it did not find that there is none."
+    )
+
+    if args.out:
+        pathlib.Path(args.out).write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+        print(f"\nRaw results: {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
README.md has said since the feature landed that no speedup was measured for amphetamin's four throughput instructions. This measures them.

## Harness

`scripts/gates/measure_amphetamin.py` runs the same task with and without the instructions appended to the system prompt, in a throwaway copy of the corpus, read-only so runs cannot diverge after the first edit. The instruction text is read out of `drift/guard/__main__.py` rather than restated — measuring a copy would prove nothing about the mode.

Tool calls are reported beside turns so a drop in turns cannot be mistaken for the model doing less work.

## Results — 10 sessions, 5 per arm

**`map-modules`** — what is each module under `src/drift/guard/` for?

| metric | without | with |
|---|---|---|
| turns | 12, 12 | 12, 12 |
| tool calls | 9, 9 | 9, 9 |
| repeat reads | 0, 0 | 0, 0 |
| **ranged reads** | **4, 4** | **0, 0** |
| cost (USD) | 0.478, 0.465 | 0.600, 0.604 |

**`find-symbol`** — where is anything named *duplicate* defined?

| metric | without | with |
|---|---|---|
| turns | 8, 7, 6 | 8, 8, 6 |
| tool calls | 4, 4, 3 | 4, 5, 3 |
| repeat reads | 0, 0, 0 | 0, 0, 0 |
| cost (USD) | 0.271, 0.303, 0.270 | 0.286, 0.286, 0.275 |

## What it found

- **No effect on turns or tool calls.** Identical on the first task, fully overlapping on the second.
- **One instruction targets a non-problem.** "Do not re-read a file you already read" — repeat reads were **0 in all ten sessions, both arms**. Nothing to prevent.
- **One instruction moved the wrong way.** "Read the part you need" — the arm carrying it did *fewer* ranged reads, 4 → 0. Two runs is too few to call it harm; it is not support either.
- **The instructions cost.** +26 % and +3 %. Roughly 640 characters on every request.

## What it cannot say

Five sessions per arm cannot establish that there is no effect, and the document says so rather than letting the tables imply it. Quality was not graded — without a rubric, a mode trading correctness for turns would score as an improvement. Every session was rate-limited, so wall clock is not reported.

Proving a 10 % turn difference against the observed 6–8 spread needs ~30 sessions per arm: **\$40–70 per task**, hours of waiting, one metric, one corpus.

## The harness measured itself first

The first pilot recorded a rate-limited session as `turns=1, tool_calls=0, output_tokens=0` and printed it beside real numbers, where it read as a dramatic win. A session now counts only if it reported success, and one that waited on a rate limit has no comparable wall clock and says so. A harness that reports a failed run as a measurement is worse than no harness.

## Recommendation

Delete the four instructions, keep the mechanism. Amphetamin then describes exactly what it does — hold one stop per session when the index recorded work left behind — and that claim has tests.

Not done in this PR: it is the maintainer's call, and this is the evidence it was asked to rest on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)