### PR TITLE
fix(plugin): run the bundled guard, not whatever drift-guard is on PATH

### DIFF
--- a/hooks/_guard_lib.sh
+++ b/hooks/_guard_lib.sh
@@ -14,22 +14,52 @@
 #
 # This sets a variable rather than echoing a command, because a `PYTHONPATH`
 # exported inside `$(...)` would be lost with the subshell.
+
+# Try the copy that ships inside the plugin. Sets GUARD_CMD and returns 0 on
+# success, so both callers below stay one line.
+_guard_try_bundled() {
+  local root="$1"
+  [ -d "$root/src/drift/guard" ] || return 1
+  command -v python3 >/dev/null 2>&1 || return 1
+  PYTHONPATH="$root/src" python3 -c "import drift.guard" >/dev/null 2>&1 || return 1
+  export PYTHONPATH="$root/src${PYTHONPATH:+:$PYTHONPATH}"
+  GUARD_CMD="python3 -m drift.guard"
+  return 0
+}
+
 guard_resolve() {
+  # Inside a plugin invocation the bundled copy wins, and it wins first.
+  #
+  # Preferring PATH here cost correctness for anyone who also has
+  # `drift-analyzer` installed from PyPI — which is this tool's existing
+  # audience, not a hypothetical one. If their venv precedes the plugin's
+  # `bin/`, every hook ran their pip guard at whatever version they installed,
+  # regardless of the commit the plugin is pinned to. An older guard fails the
+  # index schema check, every hook exits 0 with no output, and the guard goes
+  # quiet in a way that is indistinguishable from having found nothing (#801).
+  #
+  # CLAUDE_PLUGIN_ROOT is set only by Claude Code, so this branch cannot
+  # affect anyone running `drift-guard` directly.
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && _guard_try_bundled "$CLAUDE_PLUGIN_ROOT"; then
+    GUARD_SOURCE="bundled"
+    return 0
+  fi
+
   if command -v drift-guard >/dev/null 2>&1; then
     GUARD_CMD="drift-guard"
+    GUARD_SOURCE="path"
     return 0
   fi
 
   if command -v python3 >/dev/null 2>&1 && python3 -c "import drift.guard" >/dev/null 2>&1; then
     GUARD_CMD="python3 -m drift.guard"
+    GUARD_SOURCE="installed"
     return 0
   fi
 
-  local bundled="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}/src"
-  if [ -d "$bundled/drift/guard" ] && command -v python3 >/dev/null 2>&1 &&
-    PYTHONPATH="$bundled" python3 -c "import drift.guard" >/dev/null 2>&1; then
-    export PYTHONPATH="$bundled${PYTHONPATH:+:$PYTHONPATH}"
-    GUARD_CMD="python3 -m drift.guard"
+  # No plugin root — running from a checkout. Resolve relative to this script.
+  if _guard_try_bundled "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; then
+    GUARD_SOURCE="bundled"
     return 0
   fi
 

--- a/src/drift/guard/__main__.py
+++ b/src/drift/guard/__main__.py
@@ -261,6 +261,12 @@ def _cmd_doctor(args) -> int:
     repo_root = pathlib.Path(args.repo)
     checks: list[tuple[bool, str]] = []
 
+    # Which copy of the guard is answering. Without this line a guard shadowed
+    # by an older `pip install drift-analyzer` on PATH reports a schema
+    # mismatch and nothing that points at the cause — and the failure it
+    # produces is silence, which looks like a guard that found nothing (#801).
+    checks.append((True, f"guard running from {pathlib.Path(build.__file__).parent}"))
+
     index_file = schema.index_path(repo_root)
     checks.append((index_file.exists(), f"index present at {index_file}"))
 

--- a/tests/guard/test_cli.py
+++ b/tests/guard/test_cli.py
@@ -159,3 +159,19 @@ def test_doctor_without_an_index_reports_no_findings(sample_repo):
     assert result.returncode == 1
     assert "defined twice" not in result.stdout
     assert "more than one place" not in result.stdout
+
+
+def test_doctor_says_which_copy_of_the_guard_answered(sample_repo):
+    """A shadowed guard must be diagnosable from the outside.
+
+    Without this, a guard running from an older `pip install drift-analyzer`
+    reports a schema mismatch and nothing that points at the cause — and its
+    failure mode is silence, which looks exactly like a guard that found
+    nothing. See #801.
+    """
+    build.build_full(sample_repo)
+
+    result = _run("doctor", "--repo", str(sample_repo))
+
+    assert "guard running from" in result.stdout
+    assert "drift/guard" in result.stdout.replace("\\", "/")

--- a/tests/guard/test_hooks.py
+++ b/tests/guard/test_hooks.py
@@ -312,3 +312,77 @@ def test_slash_commands_are_named_the_way_the_documents_promise():
         assert f"/drift:{name}" in documented or name == "stats", (
             f"/drift:{name} is not the name the README promises"
         )
+
+
+def test_a_stale_drift_guard_on_path_does_not_shadow_the_plugin(sample_repo, tmp_path):
+    """Inside a plugin invocation, the plugin's own copy is the only right one.
+
+    A user with `drift-analyzer` installed from PyPI has a second `drift-guard`
+    on PATH, at whatever version they installed. That is not a hypothetical
+    audience — it is the tool's existing one. If their venv precedes the
+    plugin's `bin/`, every hook runs the pip guard regardless of which commit
+    the plugin is pinned to.
+
+    The index carries a schema version. An older guard fails `is_usable()`,
+    `_open_index` returns None, and every hook exits 0 with no output: the
+    guard goes silent, and silence is indistinguishable from having found
+    nothing. See #801.
+
+    This plants a `drift-guard` that would answer wrongly and asserts the hook
+    ignores it while CLAUDE_PLUGIN_ROOT says we are inside the plugin.
+    """
+    build.build_full(sample_repo)
+    (sample_repo / "src" / "api" / "schemas.py").write_text(
+        "def validate_token(token, audience):\n    return True\n", encoding="utf-8"
+    )
+
+    impostor_dir = tmp_path / "stale-venv" / "bin"
+    impostor_dir.mkdir(parents=True)
+    impostor = impostor_dir / "drift-guard"
+    impostor.write_text("#!/usr/bin/env bash\necho 'IMPOSTOR'\nexit 0\n", encoding="utf-8")
+    impostor.chmod(0o755)
+
+    env = _bare_env()
+    env["PATH"] = f"{impostor_dir}:{env['PATH']}"
+    env["CLAUDE_PLUGIN_ROOT"] = str(HOOKS.parent)
+
+    result = subprocess.run(
+        ["bash", str(HOOKS / "guard-post-edit.sh")],
+        input=json.dumps(
+            {"tool_input": {"file_path": str(sample_repo / "src" / "api" / "schemas.py")}}
+        ),
+        capture_output=True,
+        text=True,
+        cwd=sample_repo,
+        env=env,
+    )
+
+    assert "IMPOSTOR" not in result.stdout, "the plugin ran a foreign drift-guard"
+    assert "validate_token" in json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+
+
+def test_path_still_wins_outside_a_plugin_invocation(sample_repo, tmp_path):
+    """Without CLAUDE_PLUGIN_ROOT this is the plain CLI, and PATH is correct.
+
+    The fix must not take the installed console script away from someone using
+    `drift-guard` directly.
+    """
+    impostor_dir = tmp_path / "bin"
+    impostor_dir.mkdir(parents=True)
+    impostor = impostor_dir / "drift-guard"
+    impostor.write_text("#!/usr/bin/env bash\necho 'FROM-PATH'\nexit 0\n", encoding="utf-8")
+    impostor.chmod(0o755)
+
+    env = _bare_env()
+    env["PATH"] = f"{impostor_dir}:{env['PATH']}"
+    env.pop("CLAUDE_PLUGIN_ROOT", None)
+
+    result = subprocess.run(
+        ["bash", "-c", f'. "{HOOKS}/_guard_lib.sh" && guard_resolve && echo "$GUARD_CMD"'],
+        capture_output=True,
+        text=True,
+        cwd=sample_repo,
+        env=env,
+    )
+
+    assert result.stdout.strip() == "drift-guard", result.stdout + result.stderr


### PR DESCRIPTION
Closes #801.

## The bug

`hooks/_guard_lib.sh` resolved PATH first:

1. `command -v drift-guard`
2. an importable `drift.guard`
3. the copy bundled in the plugin

For a plugin-only user that is fine — Claude Code puts the plugin's `bin/` on PATH, so step 1 finds the plugin's own binary.

It breaks for a user who **also** has `drift-analyzer` from PyPI. That is this tool's existing audience, not a hypothetical one. If their venv precedes the plugin's `bin/`, every hook ran their pip guard at whatever version they installed, regardless of which commit the plugin is pinned to.

The index carries `SCHEMA_VERSION = 3`. An older guard fails `is_usable()`, `_open_index` returns None, and every hook exits 0 with no output.

**The failure is silence** — indistinguishable from a guard that found nothing. That is the confusion this project exists to remove, sitting in its own installation path.

## The fix

Inside a plugin invocation the bundled copy wins, and wins first. `CLAUDE_PLUGIN_ROOT` is set only by Claude Code, so nobody running `drift-guard` directly is affected — and a test asserts that PATH still wins without it.

The regression test plants an executable named `drift-guard` earlier on PATH that prints `IMPOSTOR`, then fails if the hook speaks with its voice. It fails on `main` and passes here.

## Diagnosability

`doctor` now leads with the copy that answered:

```
[x] guard running from /Users/you/.claude/plugins/cache/drift/drift/<sha>/src/drift/guard
[x] index present at ~/.cache/drift/<repo>/index.db
[x] index schema version is 3
[x] index holds 1091 file(s)
```

Without that line a shadowed guard reports a schema mismatch and nothing pointing at the cause. It is not a diagnosis anyone could make from the outside.

## Verified

- **6981 passed, 6 skipped, 0 failed** (`-m "not slow"`)
- `run_all_gates.py` — all pass
- `ruff check` · `ruff format --check` · `mypy src` — clean, 353 files
- `tests/guard` — 197 passed

Developed in a separate worktree; another session is editing the main checkout concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)